### PR TITLE
Energy Score Changes

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -3274,6 +3274,12 @@ The Home Energy Rating System (HERS) index is a measure of a home's energy effic
 					</xs:restriction>
 				</xs:simpleType>
 			</xs:element>
+			<xs:element minOccurs="0" name="OtherScoreType">
+				<xs:annotation>
+					<xs:documentation>Name of the score type if "other" is selected in ScoreType.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="ScoreDate" type="xs:date"/>
 			<xs:element name="Score" type="xs:integer"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>


### PR DESCRIPTION
Adding `OtherScoreType` and `ScoreDate`. Does this work for everyone?

![baseelements_energyscoretype](https://cloud.githubusercontent.com/assets/5325034/11487522/11fc8a98-977d-11e5-9143-f52b1bdd7ca9.png)

@brandongallagher @kmwoley @GamalielL @juliecaracino @RebHudson @gmdickey

Fixes #39 
Fixes #40