### PR TITLE
Adding air filter to HVACMaintenance

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -4262,6 +4262,7 @@ https://hpxml.nrel.gov/wiki/WallTypes</xs:documentation>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" name="DateLastReplaced" type="xs:date"/>
+						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -4237,6 +4237,7 @@ https://hpxml.nrel.gov/wiki/WallTypes</xs:documentation>
 			<xs:element minOccurs="0" name="AirFilter">
 				<xs:complexType>
 					<xs:sequence>
+						<xs:group ref="SystemInfo"/>
 						<xs:element minOccurs="0" name="Size">
 							<xs:annotation>
 								<xs:documentation>Width x Length x Thickness</xs:documentation>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -4234,6 +4234,37 @@ https://hpxml.nrel.gov/wiki/WallTypes</xs:documentation>
 				type="IntegerGreaterThanOrEqualToZero"/>
 			<xs:element minOccurs="0" name="NumberofAirHandlersReplaced"
 				type="IntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="AirFilter">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="Size">
+							<xs:annotation>
+								<xs:documentation>Width x Length x Thickness</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="Width">
+										<xs:annotation>
+											<xs:documentation>[in]</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="Length">
+										<xs:annotation>
+											<xs:documentation>[in]</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="Thickness">
+										<xs:annotation>
+											<xs:documentation>[in]</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element minOccurs="0" name="DateLastReplaced" type="xs:date"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 	</xs:complexType>


### PR DESCRIPTION
This adds a new complex element `HVACSystemInfoType/HVACMaintenance/AirFilter`. This will show up in `HeatingSystem`, `CoolingSystem`, and `HeatPump`.

![baseelements_hvacmaintenance](https://cloud.githubusercontent.com/assets/5325034/11508074/1e553d48-9814-11e5-8cd8-a5463b252f3c.png)


Fixes #49
Fixes #50