### PR TITLE
adding year and month element to when the duct system was sealed

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -4230,6 +4230,11 @@ https://hpxml.nrel.gov/wiki/WallTypes</xs:documentation>
 	<xs:complexType name="HVACDistributionImprovementInfo">
 		<xs:sequence>
 			<xs:element name="DuctSystemSealed" type="xs:boolean" minOccurs="0"/>
+			<xs:element minOccurs="0" name="DuctSystemSealedYearMonth" type="xs:gYearMonth">
+				<xs:annotation>
+					<xs:documentation>The year and month the duct system was sealed.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element name="DuctOutsideEnvelopeInsulatedaspartofRetrofit" type="xs:boolean"
 				minOccurs="0"/>
 			<xs:element name="DuctSystemReplaced" type="xs:boolean" minOccurs="0"/>


### PR DESCRIPTION
Adding this element

![baseelements_hvacdistributionimprovementinfo](https://cloud.githubusercontent.com/assets/5325034/12722473/53d4ab0a-c8c2-11e5-815c-248b1c9c8c9f.png)

It requires a valid in the form `YYYY-MM` (i.e. `2016-02`). Is that too granular @RebHudson?

fixes #45