### PR TITLE
Adding date (year, month) of last HVAC tune up.

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -4240,6 +4240,11 @@ https://hpxml.nrel.gov/wiki/WallTypes</xs:documentation>
 	<xs:complexType name="HVACMaintenance">
 		<xs:sequence>
 			<xs:element minOccurs="0" name="TuneAndRepair" type="xs:boolean"/>
+			<xs:element minOccurs="0" name="TuneAndRepairYearMonth" type="xs:gYearMonth">
+				<xs:annotation>
+					<xs:documentation>Year and month of the last tune and repair for this HVAC equipment.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element minOccurs="0" name="NumberofCoilsReplaced"
 				type="IntegerGreaterThanOrEqualToZero"/>
 			<xs:element minOccurs="0" name="NumberofAirHandlersReplaced"


### PR DESCRIPTION
Adding this element:

![baseelements_hvacmaintenance](https://cloud.githubusercontent.com/assets/5325034/12722694/4a1b370e-c8c3-11e5-8711-0422a4efaf96.png)

Requires a year and month of last HVAC tune up `YYYY-MM`.

fixes #48