### PR TITLE
Restricting HousePressure to only allow positive values

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -4082,7 +4082,7 @@ master meter with sub-metering = tenant sub-metered by building owner</xs:docume
 			<xs:element name="TypeOfInfiltrationMeasurement" type="TypeofInfiltrationMeasurement"
 				minOccurs="0"/>
 			<xs:element name="TypeOfBlowerDoorTest" type="TypeofBlowerDoorTest" minOccurs="0"/>
-			<xs:element name="HousePressure" type="xs:double" minOccurs="0">
+			<xs:element name="HousePressure" type="HousePressure" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[Pa] with respect to outside</xs:documentation>
 				</xs:annotation>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -154,6 +154,11 @@
 			<xs:enumeration value="depressurization"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:simpleType name="HousePressure">
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
 	<xs:simpleType name="TypeofInfiltrationMeasurement">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="blower door"/>


### PR DESCRIPTION
Fixes #37 
@brandongallagher 

As discussed in #37, this is technically a breaking change, but provides needed clarification on `AirInfiltrationMeasurement/HousePressure`.

Speak now or forever hold your peace.