### PR TITLE
WaterType Enum typo fix

### DIFF
--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1326,7 +1326,8 @@
 	<xs:simpleType name="WaterType">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="indoor and outdoor water"/>
-			<xs:enumeration value="indoor water "/>
+			<xs:enumeration value="indoor water "/><!-- deprecated -->
+			<xs:enumeration value="indoor water"/>
 			<xs:enumeration value="outdoor water"/>
 			<xs:enumeration value="wastewater/sewer"/>
 		</xs:restriction>


### PR DESCRIPTION
Adding an enumeration for "indoor water" without a trailing space as part of #74.