### PR TITLE
Adding preconstruction event type

### DIFF
--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -529,6 +529,7 @@
 			<xs:enumeration value="construction-period testing/daily test out"/>
 			<xs:enumeration value="job completion testing/final inspection"/>
 			<xs:enumeration value="quality assurance/monitoring"/>
+			<xs:enumeration value="preconstruction"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<!--Air Sealing Below-->


### PR DESCRIPTION
From David Heslam:

>It would be great if you ask the working group about adding another enumeration for the HES Assessment Type in HPXML called "preconstruction" with a description of "An assessment based on plans for a house under construction".