### PR TITLE
Rearranging Attics

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -517,42 +517,6 @@
 			<xs:element name="AtticAndRoof" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="Roofs">
-							<xs:complexType>
-								<xs:sequence>
-									<xs:element name="Roof" maxOccurs="unbounded">
-										<xs:complexType>
-											<xs:sequence>
-												<xs:group ref="SystemInfo"/>
-												<xs:element minOccurs="0" ref="AttachedToSpace"/>
-												<xs:element minOccurs="0" name="RoofColor"
-												type="WallAndRoofColor"/>
-												<xs:element minOccurs="0" name="RoofType"
-												type="RoofType"/>
-												<xs:element minOccurs="0" name="DeckType"
-												type="DeckType"/>
-												<xs:element minOccurs="0" name="Pitch" type="Pitch">
-												<xs:annotation>
-												<xs:documentation>Pitch of roof ?/12</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" name="RoofArea"
-												type="SurfaceArea">
-												<xs:annotation>
-												<xs:documentation>[sq.ft.] Surface area of the roof itself</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element name="RadiantBarrier" type="xs:boolean"
-												minOccurs="0"/>
-												<xs:element name="RadiantBarrierLocation"
-												type="RadiantBarrierLocation" minOccurs="0"/>
-												<xs:element ref="extension" minOccurs="0"/>
-											</xs:sequence>
-										</xs:complexType>
-									</xs:element>
-								</xs:sequence>
-							</xs:complexType>
-						</xs:element>
 						<xs:element minOccurs="0" name="Attics">
 							<xs:complexType>
 								<xs:sequence>
@@ -565,32 +529,126 @@
 												<xs:documentation>The space over which this attic is</xs:documentation>
 												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="AttachedToRoof"
-												type="LocalReference"/>
-												<xs:element name="ExteriorAdjacentTo"
-												type="AdjacentTo" minOccurs="0"> </xs:element>
-												<xs:element minOccurs="0" name="InteriorAdjacentTo"
-												type="AdjacentTo"/>
-												<xs:element maxOccurs="unbounded" minOccurs="0"
-												name="AtticKneeWall" type="LocalReference"> </xs:element>
 												<xs:element name="AtticType" type="AtticType"
 												minOccurs="0"/>
-												<xs:element minOccurs="0"
-												name="AtticFloorInsulation" type="InsulationInfo">
+												<xs:element minOccurs="0" name="Roofs">
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element name="Roof" maxOccurs="unbounded">
+												<xs:complexType>
+												<xs:sequence>
+												<xs:group ref="SystemInfo"/>
+												<xs:element minOccurs="0" name="Area"
+												type="SurfaceArea">
+												<xs:annotation>
+												<xs:documentation>[sq.ft.] Surface area of the roof itself</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="RoofType"
+												type="RoofType"/>
+												<xs:element minOccurs="0" name="RoofColor"
+												type="WallAndRoofColor"/>
+												<xs:element minOccurs="0" name="Rafters"
+												type="StudProperties"/>
+												<xs:element minOccurs="0" name="DeckType"
+												type="DeckType"/>
+												<xs:element minOccurs="0" name="Pitch"
+												type="Pitch">
+												<xs:annotation>
+												<xs:documentation>Pitch of roof ?/12</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element name="RadiantBarrier"
+												type="xs:boolean" minOccurs="0"/>
+												<xs:element name="RadiantBarrierLocation"
+												type="RadiantBarrierLocation" minOccurs="0"/>
+												<xs:element minOccurs="0" name="Insulation"
+												type="InsulationInfo"/>
+												<xs:element ref="extension" minOccurs="0"/>
+												</xs:sequence>
+												</xs:complexType>
+												</xs:element>
+												</xs:sequence>
+												</xs:complexType>
+												</xs:element>
+												<xs:element minOccurs="0" name="Floors">
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element maxOccurs="unbounded" name="Floor">
+												<xs:complexType>
+												<xs:sequence>
+												<xs:group ref="SystemInfo"/>
+												<xs:element minOccurs="0" name="Area"
+												type="SurfaceArea">
+												<xs:annotation>
+												<xs:documentation>[sq.ft.] Area of the floor</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="Joists"
+												type="StudProperties"/>
+												<xs:element minOccurs="0" name="Insulation"
+												type="InsulationInfo">
 												<xs:annotation>
 												<xs:documentation>For attic floor insulation that covers the rafters, two layers should be defined: 1.) a cavity later with thickness equal to the rafter height, and 2.) a continuous layer above that.</xs:documentation>
 												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="AtticRoofInsulation"
-												type="InsulationInfo"/>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												</xs:complexType>
+												</xs:element>
+												</xs:sequence>
+												</xs:complexType>
+												</xs:element>
+												<xs:element minOccurs="0" name="Walls">
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element maxOccurs="unbounded" name="Wall">
+												<xs:complexType>
+												<xs:sequence>
+												<xs:group ref="SystemInfo"/>
+												<xs:element name="AtticWallType"
+												type="AtticWallType"/>
+												<xs:element minOccurs="0" name="Thickness"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[in] Thickness of the wall assembly</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="Area"
+												type="SurfaceArea">
+												<xs:annotation>
+												<xs:documentation>[sq.ft.] Gross wall area</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="Orientation"
+												type="OrientationType"/>
+												<xs:element name="Azimuth" type="AzimuthType"
+												minOccurs="0">
+												<xs:annotation>
+												<xs:documentation>[deg]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="Studs"
+												type="StudProperties"/>
+												<xs:element minOccurs="0" name="Siding"
+												type="Siding"/>
+												<xs:element minOccurs="0" name="Color"
+												type="WallAndRoofColor"/>
+												<xs:element minOccurs="0" maxOccurs="1"
+												name="Insulation" type="InsulationInfo"/>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												</xs:complexType>
+												</xs:element>
+												</xs:sequence>
+												</xs:complexType>
+												</xs:element>
 												<xs:element name="Area" type="SurfaceArea"
 												minOccurs="0">
 												<xs:annotation>
-												<xs:documentation>[sq.ft.] Area of the floor of the attic.</xs:documentation>
+												<xs:documentation>[sq.ft.] Area of the floor of the attic. DO WE STILL NEED THIS?</xs:documentation>
 												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="Rafters"
-												type="StudProperties"/>
 												<xs:element ref="extension" minOccurs="0"/>
 											</xs:sequence>
 										</xs:complexType>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -653,11 +653,6 @@
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
-									<xs:element name="Area" type="SurfaceArea" minOccurs="0">
-										<xs:annotation>
-											<xs:documentation>[sq.ft.] Area of the floor of the attic. DO WE STILL NEED THIS?</xs:documentation>
-										</xs:annotation>
-									</xs:element>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -608,6 +608,8 @@
 												<xs:group ref="SystemInfo"/>
 												<xs:element name="AtticWallType"
 												type="AtticWallType" minOccurs="0"/>
+												<xs:element name="WallType" type="WallType"
+												minOccurs="0"> </xs:element>
 												<xs:element minOccurs="0" name="Thickness"
 												type="LengthMeasurement">
 												<xs:annotation>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -526,7 +526,7 @@
 											<xs:documentation>The space over which this attic is</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="AtticType" type="AtticType" minOccurs="0"/>
+									<xs:element name="AtticType" type="AtticType" minOccurs="1"/>
 									<xs:element minOccurs="0" name="Roofs">
 										<xs:complexType>
 											<xs:sequence>
@@ -4698,5 +4698,40 @@ https://hpxml.nrel.gov/wiki/WallTypes</xs:documentation>
 			<xs:element minOccurs="0" name="StaticPressureSource" type="StaticPressureSource"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AtticType">
+		<xs:choice>
+			<xs:element name="Attic">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="Vented" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="Conditioned" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="CapeCod" type="xs:boolean"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="CathedralCeiling">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="FlatRoof">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Other">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:choice>
 	</xs:complexType>
 </xs:schema>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -514,26 +514,22 @@
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="AtticAndRoof" minOccurs="0">
+			<xs:element minOccurs="0" name="Attics">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="Attics">
+						<xs:element maxOccurs="unbounded" name="Attic">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element maxOccurs="unbounded" name="Attic">
+									<xs:group ref="SystemInfo"/>
+									<xs:element minOccurs="0" ref="AttachedToSpace">
+										<xs:annotation>
+											<xs:documentation>The space over which this attic is</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="AtticType" type="AtticType" minOccurs="0"/>
+									<xs:element minOccurs="0" name="Roofs">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:group ref="SystemInfo"/>
-												<xs:element minOccurs="0" ref="AttachedToSpace">
-												<xs:annotation>
-												<xs:documentation>The space over which this attic is</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element name="AtticType" type="AtticType"
-												minOccurs="0"/>
-												<xs:element minOccurs="0" name="Roofs">
-												<xs:complexType>
-												<xs:sequence>
 												<xs:element name="Roof" maxOccurs="unbounded">
 												<xs:complexType>
 												<xs:sequence>
@@ -576,12 +572,12 @@
 												</xs:sequence>
 												</xs:complexType>
 												</xs:element>
-												</xs:sequence>
-												</xs:complexType>
-												</xs:element>
-												<xs:element minOccurs="0" name="Floors">
-												<xs:complexType>
-												<xs:sequence>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element minOccurs="0" name="Floors">
+										<xs:complexType>
+											<xs:sequence>
 												<xs:element maxOccurs="unbounded" name="Floor">
 												<xs:complexType>
 												<xs:sequence>
@@ -606,12 +602,12 @@
 												</xs:sequence>
 												</xs:complexType>
 												</xs:element>
-												</xs:sequence>
-												</xs:complexType>
-												</xs:element>
-												<xs:element minOccurs="0" name="Walls">
-												<xs:complexType>
-												<xs:sequence>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element minOccurs="0" name="Walls">
+										<xs:complexType>
+											<xs:sequence>
 												<xs:element maxOccurs="unbounded" name="Wall">
 												<xs:complexType>
 												<xs:sequence>
@@ -654,30 +650,26 @@
 												</xs:sequence>
 												</xs:complexType>
 												</xs:element>
-												</xs:sequence>
-												</xs:complexType>
-												</xs:element>
-												<xs:element name="Area" type="SurfaceArea"
-												minOccurs="0">
-												<xs:annotation>
-												<xs:documentation>[sq.ft.] Area of the floor of the attic. DO WE STILL NEED THIS?</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element ref="extension" minOccurs="0"/>
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
+									<xs:element name="Area" type="SurfaceArea" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>[sq.ft.] Area of the floor of the attic. DO WE STILL NEED THIS?</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="AnnualEnergyUse" minOccurs="0">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
-						<xs:element name="AnnualEnergyUse" minOccurs="0">
-							<xs:complexType>
-								<xs:sequence>
-									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
-								</xs:sequence>
-							</xs:complexType>
-						</xs:element>
-						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -586,6 +586,8 @@
 												<xs:complexType>
 												<xs:sequence>
 												<xs:group ref="SystemInfo"/>
+												<xs:element minOccurs="0" name="AdjacentTo"
+												type="AdjacentTo"/>
 												<xs:element minOccurs="0" name="Area"
 												type="SurfaceArea">
 												<xs:annotation>
@@ -614,6 +616,8 @@
 												<xs:complexType>
 												<xs:sequence>
 												<xs:group ref="SystemInfo"/>
+												<xs:element minOccurs="0" name="AdjacentTo"
+												type="AdjacentTo"/>
 												<xs:element name="AtticWallType"
 												type="AtticWallType" minOccurs="0"/>
 												<xs:element name="WallType" type="WallType"

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -607,7 +607,7 @@
 												<xs:sequence>
 												<xs:group ref="SystemInfo"/>
 												<xs:element name="AtticWallType"
-												type="AtticWallType"/>
+												type="AtticWallType" minOccurs="0"/>
 												<xs:element minOccurs="0" name="Thickness"
 												type="LengthMeasurement">
 												<xs:annotation>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -544,6 +544,14 @@
 												<xs:documentation>[sq.ft.] Surface area of the roof itself</xs:documentation>
 												</xs:annotation>
 												</xs:element>
+												<xs:element minOccurs="0" name="Orientation"
+												type="OrientationType"/>
+												<xs:element name="Azimuth" type="AzimuthType"
+												minOccurs="0">
+												<xs:annotation>
+												<xs:documentation>[deg]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
 												<xs:element minOccurs="0" name="RoofType"
 												type="RoofType"/>
 												<xs:element minOccurs="0" name="RoofColor"

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -584,7 +584,7 @@
 												<xs:documentation>[sq.ft.] Area of the floor</xs:documentation>
 												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="Joists"
+												<xs:element minOccurs="0" name="FloorJoists"
 												type="StudProperties"/>
 												<xs:element minOccurs="0" name="Insulation"
 												type="InsulationInfo">

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1332,7 +1332,8 @@
 	<xs:simpleType name="WaterType">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="indoor and outdoor water"/>
-			<xs:enumeration value="indoor water "/><!-- deprecated -->
+			<xs:enumeration value="indoor water "/>
+			<!-- deprecated -->
 			<xs:enumeration value="indoor water"/>
 			<xs:enumeration value="outdoor water"/>
 			<xs:enumeration value="wastewater/sewer"/>
@@ -1660,6 +1661,13 @@
 			<xs:enumeration value="unvented attic"/>
 			<xs:enumeration value="vented attic"/>
 			<xs:enumeration value="venting unknown attic"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AtticWallType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="gable"/>
+			<xs:enumeration value="knee wall"/>
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1653,17 +1653,6 @@
 			<xs:minInclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="AtticType">
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="cape cod"/>
-			<xs:enumeration value="cathedral ceiling"/>
-			<xs:enumeration value="flat roof"/>
-			<xs:enumeration value="unvented attic"/>
-			<xs:enumeration value="vented attic"/>
-			<xs:enumeration value="venting unknown attic"/>
-			<xs:enumeration value="other"/>
-		</xs:restriction>
-	</xs:simpleType>
 	<xs:simpleType name="AtticWallType">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="gable"/>


### PR DESCRIPTION
I went ahead and threw together a straw man for rearranging attics based on feedback I've received. This definitely breaks current implementations and would go in the next *major* release. It treats attics more as a space with attached surfaces. 

(click on the image to see it larger)

![image](https://user-images.githubusercontent.com/5861765/51558291-4ec64b00-1e3c-11e9-81dc-3782ac14630b.png)

Closes #28 and #102.

It also replaces the optional `AtticType` enumeration with a required `AtticType` element w/ sub-elements, consistent with `FoundationType`.

![image](https://user-images.githubusercontent.com/5861765/52495116-01acdd80-2b8d-11e9-8bc0-1deb3ce61310.png)

All old attic type enumerations can be mapped to the new approach:
- "cape cod" => `<Attic><CapeCod>true</CapeCod></Attic>`
- "cathedral ceiling" => `<CathedralCeiling/>`
- "flat roof" => `<FlatRoof/>`
- "unvented attic" => `<Attic><Vented>false</Vented></Attic>`
- "vented attic" => `<Attic><Vented>true</Vented></Attic>`
- "venting unknown attic" => `<Attic/>`
- "other" => `<Other/>`