### PR TITLE
Add Solar Absorptance & Emittance

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -854,6 +854,9 @@
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
+									<xs:element minOccurs="0" name="SolarAbsorptance"
+										type="SolarAbsorptance"/>
+									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
 									<xs:element minOccurs="0" name="Insulation"
 										type="InsulationInfo"/>
 									<xs:element minOccurs="0" name="FloorJoists"

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -548,6 +548,10 @@
 												type="RoofType"/>
 												<xs:element minOccurs="0" name="RoofColor"
 												type="WallAndRoofColor"/>
+												<xs:element minOccurs="0" name="SolarAbsorptance"
+												type="SolarAbsorptance"/>
+												<xs:element minOccurs="0" name="Emittance"
+												type="Emittance"/>
 												<xs:element minOccurs="0" name="Rafters"
 												type="StudProperties"/>
 												<xs:element minOccurs="0" name="DeckType"
@@ -636,6 +640,10 @@
 												type="Siding"/>
 												<xs:element minOccurs="0" name="Color"
 												type="WallAndRoofColor"/>
+												<xs:element minOccurs="0" name="SolarAbsorptance"
+												type="SolarAbsorptance"/>
+												<xs:element minOccurs="0" name="Emittance"
+												type="Emittance"/>
 												<xs:element minOccurs="0" maxOccurs="1"
 												name="Insulation" type="InsulationInfo"/>
 												<xs:element minOccurs="0" ref="extension"/>
@@ -899,6 +907,9 @@
 									<xs:element minOccurs="0" name="Studs" type="StudProperties"/>
 									<xs:element minOccurs="0" name="Siding" type="Siding"/>
 									<xs:element minOccurs="0" name="Color" type="WallAndRoofColor"/>
+									<xs:element minOccurs="0" name="SolarAbsorptance"
+										type="SolarAbsorptance"/>
+									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
 									<xs:element minOccurs="0" maxOccurs="1" name="Insulation"
 										type="InsulationInfo"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -2096,4 +2096,16 @@
 			<xs:maxInclusive value="20"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:simpleType name="SolarAbsorptance">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+			<xs:maxInclusive value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Emittance">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+			<xs:maxInclusive value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
Adds solar absorptance and emittance elements for non-foundation walls/roofs and rim joists. Needed for an ERI calculation. Note that this branch is based off of the `attics_refactor` branch.