### PR TITLE
Multiple IECC climate zones

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -3334,7 +3334,8 @@ Volume inside the building envelope of the conditioned spaces. This metric can b
 				<xs:complexType>
 					<xs:sequence minOccurs="0">
 						<xs:element name="ClimateZoneDOE" type="ClimateZoneDOE" minOccurs="0"/>
-						<xs:element name="ClimateZoneIECC" minOccurs="0" type="IECCClimateZoneType"/>
+						<xs:element name="ClimateZoneIECC" minOccurs="0" type="IECCClimateZoneType"
+							maxOccurs="unbounded"/>
 						<xs:element name="RadonZone" type="RadonZone" minOccurs="0"/>
 						<xs:element name="TermiteZone" type="TermiteZone" minOccurs="0"/>
 						<xs:element name="HurricaneZone" type="xs:boolean" minOccurs="0"/>


### PR DESCRIPTION
Currently only a single IECC climate zone can be specified in HPXML. This change allows multiple IECC climate zones (for different years) to be specified. 

The ERI calculation requires use of the 2006 IECC climate zone (per 301-2014) and 2012 IECC climate zone (per Addendum E-2018 House Size Index Adjustment Factors).

![image](https://user-images.githubusercontent.com/5861765/51558547-f5aae700-1e3c-11e9-803e-ba7b7cef2400.png)

