### PR TITLE
Addresses inconsistencies

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -4606,7 +4606,7 @@ https://hpxml.nrel.gov/wiki/WallTypes</xs:documentation>
 	</xs:complexType>
 	<xs:complexType name="WeatherStation">
 		<xs:sequence>
-			<xs:element ref="SystemIdentifiersInfo"/>
+      <xs:group ref="SystemInfo"/>
 			<xs:element name="Name" type="xs:string"/>
 			<xs:element minOccurs="0" name="City" nillable="true" type="xs:string"/>
 			<xs:element minOccurs="0" name="State" type="StateCode"/>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -2877,7 +2877,8 @@ http://www.epa.gov/compliance/monitoring/programs/caa/woodheaters.html</xs:docum
 					<xs:element minOccurs="0" name="CoolingSensibleHeatFraction" type="Fraction"/>
 					<xs:element name="GeothermalLoop" type="GeothermalLoop" minOccurs="0"/>
 					<xs:element name="BackupSystemFuel" type="FuelType" minOccurs="0"/>
-					<xs:element minOccurs="0" name="BackupAFUE" type="AFUE"/>
+					<xs:element name="BackupAnnualHeatingEfficiency" minOccurs="0"
+						type="HeatingEfficiencyType" maxOccurs="unbounded"> </xs:element>
 					<xs:element minOccurs="0" name="BackupHeatingCapacity" type="Capacity">
 						<xs:annotation>
 							<xs:documentation>[Btuh]</xs:documentation>
@@ -4606,7 +4607,7 @@ https://hpxml.nrel.gov/wiki/WallTypes</xs:documentation>
 	</xs:complexType>
 	<xs:complexType name="WeatherStation">
 		<xs:sequence>
-      <xs:group ref="SystemInfo"/>
+			<xs:group ref="SystemInfo"/>
 			<xs:element name="Name" type="xs:string"/>
 			<xs:element minOccurs="0" name="City" nillable="true" type="xs:string"/>
 			<xs:element minOccurs="0" name="State" type="StateCode"/>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -677,7 +677,7 @@
 												<xs:documentation>[in] Thickness of foundation wall excluding interior framing.</xs:documentation>
 												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="BelowGradeDepth"
+												<xs:element minOccurs="0" name="DepthBelowGrade"
 												type="LengthMeasurement">
 												<xs:annotation>
 												<xs:documentation>[ft] Depth below grade of foundation wall</xs:documentation>
@@ -2896,9 +2896,9 @@ http://www.epa.gov/compliance/monitoring/programs/caa/woodheaters.html</xs:docum
 							<xs:documentation>[sq.ft.]</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="AnnualCoolEfficiency" type="CoolingEfficiencyType"
+					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType"
 						minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="AnnualHeatEfficiency" minOccurs="0"
+					<xs:element name="AnnualHeatingEfficiency" minOccurs="0"
 						type="HeatingEfficiencyType" maxOccurs="unbounded"> </xs:element>
 					<xs:element minOccurs="0" ref="extension"/>
 				</xs:sequence>
@@ -3550,8 +3550,14 @@ The Home Energy Rating System (HERS) index is a measure of a home's energy effic
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="InstalledComponent" type="RemoteReference"
-				maxOccurs="unbounded"/>
+			<xs:element minOccurs="0" name="InstalledComponents">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="1" name="InstalledComponent" type="RemoteReference"
+							maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -910,7 +910,7 @@
 	<!--Cooling System Information Below-->
 	<xs:simpleType name="CoolingSystemType">
 		<xs:restriction base="xs:string">
-			<xs:enumeration value="central air conditioning"/>
+			<xs:enumeration value="central air conditioner"/>
 			<xs:enumeration value="mini-split"/>
 			<xs:enumeration value="room air conditioner"/>
 			<xs:enumeration value="evaporative cooler"/>


### PR DESCRIPTION
Addresses several inconsistencies as documented in #111. Also fixes #29.

- Renames `HeatPump/AnnualHeatEfficiency` to `HeatPump/AnnualHeatingEfficiency` (now consistent with `HeatingSystem/AnnualHeatingEfficiency`)
- Renames `HeatPump/AnnualCoolEfficiency` to `HeatPump/AnnualCoolingEfficiency` (now consistent with `CoolingSystem/AnnualCoolingEfficiency`)
- Replaces `Measure/InstalledComponent` with `Measure/InstalledComponents/InstalledComponent` (now consistent with `Measure/ReplacedComponents/ReplacedComponent`)
- Renames `FoundationWall/BelowGradeDepth` to `FoundationWall/DepthBelowGrade` (now consistent with `Slab/DepthBelowGrade`)
- Replaces `WeatherStation/SystemIdentifiersInfo` with `WeatherStation/SystemIdentifier` (now consistent with all other elements)
- Renames "central air conditioning" to "central air conditioner" for CoolingSystemType (now consistent with "room air conditioner")
- Renames `HeatPump/BackupAFUE` to `BackupAnnualHeatingEfficiency`, accepts 0-1 instead of 1-100 (now consistent with AnnualEfficiency elements)