### PR TITLE
Adds solar absorptance and emittance for non-foundation walls/roofs

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -527,6 +527,10 @@
 												<xs:element minOccurs="0" ref="AttachedToSpace"/>
 												<xs:element minOccurs="0" name="RoofColor"
 												type="WallAndRoofColor"/>
+												<xs:element minOccurs="0" name="SolarAbsorptance"
+													type="SolarAbsorptance"/>
+												<xs:element minOccurs="0" name="Emittance"
+													type="Emittance"/>
 												<xs:element minOccurs="0" name="RoofType"
 												type="RoofType"/>
 												<xs:element minOccurs="0" name="DeckType"
@@ -839,6 +843,9 @@
 									<xs:element minOccurs="0" name="Studs" type="StudProperties"/>
 									<xs:element minOccurs="0" name="Siding" type="Siding"/>
 									<xs:element minOccurs="0" name="Color" type="WallAndRoofColor"/>
+									<xs:element minOccurs="0" name="SolarAbsorptance"
+										type="SolarAbsorptance"/>
+									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
 									<xs:element minOccurs="0" maxOccurs="1" name="Insulation"
 										type="InsulationInfo"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -2090,4 +2090,16 @@
 			<xs:maxInclusive value="20"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:simpleType name="SolarAbsorptance">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+			<xs:maxInclusive value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Emittance">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+			<xs:maxInclusive value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
This adds a `SolarAbsorptance` and `Emittance` element to [Roof](https://hpxml.nrel.gov/datadictionary/2.2.1/Building/BuildingDetails/Enclosure/AtticAndRoof/Roofs/Roof) and [Wall](https://hpxml.nrel.gov/datadictionary/2.2.1/Building/BuildingDetails/Enclosure/Walls/Wall). This is needed for both Home Energy Score and Energy Rating Index.

There is a similar pull request that applies this to the attics refactor branch #113. This applies it to v2.3 so we can have it sooner.