### PR TITLE
Add 'conditioned attic' to AtticType

### DIFF
--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1658,6 +1658,7 @@
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="cape cod"/>
 			<xs:enumeration value="cathedral ceiling"/>
+			<xs:enumeration value="conditioned attic"/>
 			<xs:enumeration value="flat roof"/>
 			<xs:enumeration value="unvented attic"/>
 			<xs:enumeration value="vented attic"/>


### PR DESCRIPTION
Fixes #127 

> HPXML does not have the ability to specify a conditioned attic directly in [AtticType](https://hpxml.nrel.gov/datadictionary/2.2.1/Building/BuildingDetails/Enclosure/AtticAndRoof/Attics/Attic/AtticType). Conditioned attics are available in Home Energy Score, but cannot be directly communicated in HPXML. The closest thing is "cape cod", which is sort of ambiguous and not general (and I'd argue should eventually be removed in v3.0 with the addition of conditioned attic).