### PR TITLE
Add 'medium dark' to WallAndRoofColor

### DIFF
--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1689,6 +1689,7 @@
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="light"/>
 			<xs:enumeration value="medium"/>
+			<xs:enumeration value="medium dark"/>
 			<xs:enumeration value="dark"/>
 			<xs:enumeration value="reflective"/>
 		</xs:restriction>


### PR DESCRIPTION
This adds the enumeration "medium dark" to [Wall/Color](https://hpxml.nrel.gov/datadictionary/2.2.1/Building/BuildingDetails/Enclosure/Walls/Wall/Color) and [Roof/RoofColor](https://hpxml.nrel.gov/datadictionary/2.2.1/Building/BuildingDetails/Enclosure/AtticAndRoof/Roofs/Roof/RoofColor). It is needed for Home Energy Score. 

Fixes #126 