### PR TITLE
Add 2x3 stud size enumeration

### DIFF
--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -603,6 +603,7 @@
 	<xs:simpleType name="StudSize">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="2x2"/>
+			<xs:enumeration value="2x3"/>
 			<xs:enumeration value="2x4"/>
 			<xs:enumeration value="2x6"/>
 			<xs:enumeration value="2x8"/>


### PR DESCRIPTION
Fixes #119 

This adds "2x3" to the list of stud size enumerations. It is used in [Attic/Rafters](https://hpxml.nrel.gov/datadictionary/2.2.1/Building/BuildingDetails/Enclosure/AtticAndRoof/Attics/Attic/Rafters/Size), [FrameFloor/FloorJoists](https://hpxml.nrel.gov/datadictionary/2.2.1/Building/BuildingDetails/Enclosure/Foundations/Foundation/FrameFloor/FloorJoists/Size), [FrameFloor/FloorTrusses](https://hpxml.nrel.gov/datadictionary/2.2.1/Building/BuildingDetails/Enclosure/Foundations/Foundation/FrameFloor/FloorTrusses/Size), [FoundationWall/InteriorStuds](https://hpxml.nrel.gov/datadictionary/2.2.1/Building/BuildingDetails/Enclosure/Foundations/Foundation/FoundationWall/InteriorStuds/Size), [RimJoist/FloorJoists](https://hpxml.nrel.gov/datadictionary/2.2.1/Building/BuildingDetails/Enclosure/RimJoists/RimJoist/FloorJoists/Size), and [Wall/Studs](https://hpxml.nrel.gov/datadictionary/2.2.1/Building/BuildingDetails/Enclosure/Walls/Wall/Studs/Size).