### PR TITLE
Adds extension element for CeilingFan

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -1835,6 +1835,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" name="ThirdPartyCertification"
 							type="ApplianceThirdPartyCertifications" maxOccurs="unbounded"/>
+						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>


### PR DESCRIPTION
It was missing and I want to use it.

![BaseElements_CeilingFan](https://user-images.githubusercontent.com/5861765/56765149-b35ab400-6763-11e9-8fb0-3681938e79f1.png)
