### PR TITLE
Clarifies UnderSlabInsulationWidth description

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -571,9 +571,9 @@
 												<xs:element minOccurs="0" name="RoofColor"
 												type="WallAndRoofColor"/>
 												<xs:element minOccurs="0" name="SolarAbsorptance"
-													type="SolarAbsorptance"/>
+												type="SolarAbsorptance"/>
 												<xs:element minOccurs="0" name="Emittance"
-													type="Emittance"/>
+												type="Emittance"/>
 												<xs:element minOccurs="0" name="RoofType"
 												type="RoofType"/>
 												<xs:element minOccurs="0" name="DeckType"
@@ -783,7 +783,11 @@
 												</xs:element>
 												<xs:element minOccurs="0"
 												name="UnderSlabInsulationWidth"
-												type="LengthMeasurement"/>
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft] Width from slab edge inward of horizontal under-slab insulation.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
 												<xs:element minOccurs="0"
 												name="OnGradeExposedPerimeter"
 												type="LengthMeasurement">


### PR DESCRIPTION
Describes the UnderSlabInsulationWidth element and clarifies its units as ft.

![BaseElements_UnderSlabInsulationWidth](https://user-images.githubusercontent.com/5861765/56765259-e0a76200-6763-11e9-8375-f006ff913c0b.png)
