### PR TITLE
Adds VentilationFan/AttachedToHVACDistributionSystem

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -571,9 +571,9 @@
 												<xs:element minOccurs="0" name="RoofColor"
 												type="WallAndRoofColor"/>
 												<xs:element minOccurs="0" name="SolarAbsorptance"
-													type="SolarAbsorptance"/>
+												type="SolarAbsorptance"/>
 												<xs:element minOccurs="0" name="Emittance"
-													type="Emittance"/>
+												type="Emittance"/>
 												<xs:element minOccurs="0" name="RoofType"
 												type="RoofType"/>
 												<xs:element minOccurs="0" name="DeckType"
@@ -1224,6 +1224,12 @@
 												<xs:element maxOccurs="unbounded" minOccurs="0"
 												name="ThirdPartyCertification"
 												type="VentilationFanThirdPartyCertification"/>
+												<xs:element name="AttachedToHVACDistributionSystem"
+												type="LocalReference" minOccurs="0" maxOccurs="1">
+												<xs:annotation>
+												<xs:documentation>For central fan integrated supply mechanical ventilation, specifies the HVAC distribution system it is attached to.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
 										</xs:complexType>


### PR DESCRIPTION
Allows specifying the HVAC distribution system a CFIS mechanical ventilation system is attached to. Particularly useful if there is more than one distribution system.

![BaseElements_AttachedToHVACDistributionSystem](https://user-images.githubusercontent.com/5861765/56765373-1f3d1c80-6764-11e9-9b5a-16cb882ecc36.png)
