### PR TITLE
Adds generic "coal" fuel type

### DIFF
--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -512,6 +512,7 @@
 			<xs:enumeration value="propane"/>
 			<xs:enumeration value="kerosene"/>
 			<xs:enumeration value="diesel"/>
+			<xs:enumeration value="coal"/>
 			<xs:enumeration value="anthracite coal"/>
 			<xs:enumeration value="bituminous coal"/>
 			<xs:enumeration value="coke"/>


### PR DESCRIPTION
There's already a generic fuel oil option; now there's a generic coal option for situations where you don't know if it's "anthracite coal" or "bituminous coal".

![image](https://user-images.githubusercontent.com/5861765/56765486-64f9e500-6764-11e9-9406-4ba2ff1253a5.png)
