### PR TITLE
Presence of Insulation

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -168,7 +168,6 @@
 					<xs:documentation>Describe</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="None"/>
 			<xs:element name="Unknown"/>
 		</xs:choice>
 	</xs:complexType>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -168,13 +168,21 @@
 					<xs:documentation>Describe</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Unknown"/>
+			<xs:element name="None">
+				<xs:annotation>
+					<xs:documentation>Indicates insulation not present.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Unknown">
+				<xs:annotation>
+					<xs:documentation>Indicates insulation present but material type unknown.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 		</xs:choice>
 	</xs:complexType>
 	<xs:complexType name="InsulationInfo">
 		<xs:sequence>
 			<xs:group ref="SystemInfo"/>
-			<xs:element minOccurs="0" name="InsulationPresent" type="xs:boolean"/>
 			<xs:element minOccurs="0" name="InsulationGrade" type="InsulationGrade"/>
 			<xs:element minOccurs="0" name="InsulationCondition" type="InsulationCondition"/>
 			<xs:element minOccurs="0" name="InsulationLocation" type="InsulationLocation"/>
@@ -3053,7 +3061,8 @@ http://www.epa.gov/compliance/monitoring/programs/caa/woodheaters.html</xs:docum
 					<xs:sequence>
 						<xs:element name="DuctType" type="DuctType" minOccurs="0"/>
 						<xs:element name="DuctMaterial" type="DuctMaterial" minOccurs="0"/>
-						<xs:element minOccurs="0" name="DuctInsulationPresent" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="DuctInsulationMaterial"
+							type="InsulationMaterial"/>
 						<xs:element name="DuctInsulationRValue" type="RValue" minOccurs="0"/>
 						<xs:element minOccurs="0" name="DuctInsulationThickness"
 							type="LengthMeasurement">

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -175,6 +175,7 @@
 	<xs:complexType name="InsulationInfo">
 		<xs:sequence>
 			<xs:group ref="SystemInfo"/>
+			<xs:element minOccurs="0" name="InsulationPresent" type="xs:boolean"/>
 			<xs:element minOccurs="0" name="InsulationGrade" type="InsulationGrade"/>
 			<xs:element minOccurs="0" name="InsulationCondition" type="InsulationCondition"/>
 			<xs:element minOccurs="0" name="InsulationLocation" type="InsulationLocation"/>
@@ -3053,6 +3054,7 @@ http://www.epa.gov/compliance/monitoring/programs/caa/woodheaters.html</xs:docum
 					<xs:sequence>
 						<xs:element name="DuctType" type="DuctType" minOccurs="0"/>
 						<xs:element name="DuctMaterial" type="DuctMaterial" minOccurs="0"/>
+						<xs:element minOccurs="0" name="DuctInsulationPresent" type="xs:boolean"/>
 						<xs:element name="DuctInsulationRValue" type="RValue" minOccurs="0"/>
 						<xs:element minOccurs="0" name="DuctInsulationThickness"
 							type="LengthMeasurement">


### PR DESCRIPTION
Documents that `InsulationMaterial/None` implies insulation not present and `InsulationMaterial/Unknown` implies insulation present (but material type unknown).

Also adds a `DuctInsulationMaterial` to allow similar characterization for ducts.
