### PR TITLE
Adds SpecificLeakageArea elements for vented attics/crawls

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -4208,11 +4208,7 @@ master meter with sub-metering = tenant sub-metered by building owner</xs:docume
 						<xs:element minOccurs="0" name="Vented" type="xs:boolean"/>
 						<xs:element minOccurs="0" name="Conditioned" type="xs:boolean"/>
 						<xs:element minOccurs="0" name="SpecificLeakageArea"
-							type="SpecificLeakageAreaType">
-							<xs:annotation>
-								<xs:documentation/>
-							</xs:annotation>
-						</xs:element>
+							type="SpecificLeakageAreaType"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -4714,11 +4710,7 @@ https://hpxml.nrel.gov/wiki/WallTypes</xs:documentation>
 						<xs:element minOccurs="0" name="Conditioned" type="xs:boolean"/>
 						<xs:element minOccurs="0" name="CapeCod" type="xs:boolean"/>
 						<xs:element minOccurs="0" name="SpecificLeakageArea"
-							type="SpecificLeakageAreaType">
-							<xs:annotation>
-								<xs:documentation/>
-							</xs:annotation>
-						</xs:element>
+							type="SpecificLeakageAreaType"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -527,6 +527,12 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element name="AtticType" type="AtticType" minOccurs="0"/>
+									<xs:element minOccurs="0" name="AtticSpecificLeakageArea"
+										type="Fraction">
+										<xs:annotation>
+											<xs:documentation>The Specific Leakage Area (SLA) for a vented attic is defined as the Effective Leakage Area (ELA) divided by the floor area.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
 									<xs:element minOccurs="0" name="Roofs">
 										<xs:complexType>
 											<xs:sequence>
@@ -682,6 +688,12 @@
 									<xs:element name="FoundationType" type="FoundationType"/>
 									<xs:element minOccurs="0" name="ThermalBoundary"
 										type="FoundationThermalBoundary"/>
+									<xs:element minOccurs="0" name="FoundationSpecificLeakageArea"
+										type="Fraction">
+										<xs:annotation>
+											<xs:documentation>The Specific Leakage Area (SLA) for a vented foundation is defined as the Effective Leakage Area (ELA) divided by the floor area.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
 									<xs:element name="FrameFloor" maxOccurs="unbounded"
 										minOccurs="0">
 										<xs:complexType>


### PR DESCRIPTION
This allows specifying the SLA for, e.g., vented attics and vented crawlspaces. Note that this branches off the `attics_refactor` branch since it operates on the `Attic` element.