### PR TITLE
Adds Refrigerator Type choice

### DIFF
--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1517,6 +1517,7 @@
 			<xs:enumeration value="top freezer"/>
 			<xs:enumeration value="bottom freezer"/>
 			<xs:enumeration value="single door"/>
+			<xs:enumeration value="single door with freezer"/>
 			<xs:enumeration value="full-size one door"/>
 			<xs:enumeration value="full-size two doors"/>
 			<xs:enumeration value="half or quarter size"/>


### PR DESCRIPTION
Adds "single door with freezer" as a Refrigerator/Type choice. Available choice in the Weatherization program's software interface. All other types already map into HPXML.

For example:

![image](https://user-images.githubusercontent.com/5861765/55193437-92a33c80-516c-11e9-89f5-eacc37eb74dd.png)

cc @mpathak24

![image](https://user-images.githubusercontent.com/5861765/56766440-a5f2f900-6766-11e9-87fb-2b824729f71c.png)
