### PR TITLE
Adds "other" enumeration for Occupancy

### DIFF
--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -375,6 +375,7 @@
 			<xs:enumeration value="owner-occupied"/>
 			<xs:enumeration value="renter-occupied"/>
 			<xs:enumeration value="owner-and-renter-occupied"/>
+			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="OccupantIncomeRangeUnits">


### PR DESCRIPTION
The Weatherization program's choices for "Dwelling Ownership" are "owned", "rented", and "other". This allows "other" to be mapped.

![image](https://user-images.githubusercontent.com/5861765/56768748-629b8900-676c-11e9-9493-1c44c28ed5b2.png)
