### PR TITLE
Adds Garages element

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -976,8 +976,8 @@
 												<xs:sequence>
 												<xs:group ref="SystemInfo"/>
 												<xs:element minOccurs="0" ref="AttachedToSpace"/>
-												<xs:element name="ExteriorAdjacentTo"
-												type="AdjacentTo" minOccurs="0"> </xs:element>
+												<xs:element name="AdjacentTo" type="AdjacentTo"
+												minOccurs="0"> </xs:element>
 												<xs:element name="WallType" type="WallType"
 												minOccurs="0"> </xs:element>
 												<xs:element minOccurs="0" name="Thickness"

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -1080,12 +1080,6 @@
 												<xs:documentation>[ft] Perimeter of slab measuerd in feet that is on-grade (2 ft. below grade or less) and exposed to ambient conditions.</xs:documentation>
 												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="DepthBelowGrade"
-												type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>[ft] Depth from the top of the slab surface to grade</xs:documentation>
-												</xs:annotation>
-												</xs:element>
 												<xs:element minOccurs="0" name="FloorCovering"
 												type="FloorCovering"/>
 												<xs:element maxOccurs="1" minOccurs="0"

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -914,6 +914,206 @@
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
+			<xs:element minOccurs="0" name="Garages">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element maxOccurs="unbounded" name="Garage">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="SystemInfo"/>
+									<xs:element minOccurs="0" ref="AttachedToSpace">
+										<xs:annotation>
+											<xs:documentation/>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="GarageType">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element minOccurs="0" name="AttachedtoHouse"
+												type="xs:boolean"/>
+												<xs:element minOccurs="0" name="Vented"
+												type="xs:boolean"/>
+												<xs:element minOccurs="0" name="Conditioned"
+												type="xs:boolean"/>
+												<xs:element minOccurs="0" ref="extension"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element minOccurs="0" name="Ceilings">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="Ceiling" maxOccurs="unbounded"
+												minOccurs="1">
+												<xs:complexType>
+												<xs:sequence>
+												<xs:group ref="SystemInfo"/>
+												<xs:element name="AdjacentTo" type="AdjacentTo"
+												minOccurs="0"> </xs:element>
+												<xs:element minOccurs="0" name="CeilingJoists"
+												type="StudProperties"/>
+												<xs:element minOccurs="0" name="CeilingTrusses"
+												type="StudProperties"/>
+												<xs:element minOccurs="0" name="Area"
+												type="SurfaceArea">
+												<xs:annotation>
+												<xs:documentation>[sq.ft.]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" maxOccurs="1"
+												name="Insulation" type="InsulationInfo"> </xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												</xs:complexType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="Walls" minOccurs="0">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="Wall" maxOccurs="unbounded">
+												<xs:complexType>
+												<xs:sequence>
+												<xs:group ref="SystemInfo"/>
+												<xs:element minOccurs="0" ref="AttachedToSpace"/>
+												<xs:element name="ExteriorAdjacentTo"
+												type="AdjacentTo" minOccurs="0"> </xs:element>
+												<xs:element name="WallType" type="WallType"
+												minOccurs="0"> </xs:element>
+												<xs:element minOccurs="0" name="Thickness"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[in] Thickness of the wall assembly</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="Area"
+												type="SurfaceArea">
+												<xs:annotation>
+												<xs:documentation>[sq.ft.] Gross wall area</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="Orientation"
+												type="OrientationType"/>
+												<xs:element name="Azimuth" type="AzimuthType"
+												minOccurs="0">
+												<xs:annotation>
+												<xs:documentation>[deg]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="Studs"
+												type="StudProperties"/>
+												<xs:element minOccurs="0" name="Siding"
+												type="Siding"/>
+												<xs:element minOccurs="0" name="Color"
+												type="WallAndRoofColor"/>
+												<xs:element minOccurs="0" name="SolarAbsorptance"
+												type="SolarAbsorptance"/>
+												<xs:element minOccurs="0" name="Emittance"
+												type="Emittance"/>
+												<xs:element minOccurs="0" maxOccurs="1"
+												name="Insulation" type="InsulationInfo"/>
+												<xs:element name="AnnualEnergyUse" minOccurs="0">
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
+												</xs:sequence>
+												</xs:complexType>
+												</xs:element>
+												<xs:element ref="extension" minOccurs="0"/>
+												</xs:sequence>
+												</xs:complexType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element minOccurs="0" name="Slabs">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="Slab" maxOccurs="unbounded"
+												minOccurs="1">
+												<xs:complexType>
+												<xs:sequence>
+												<xs:group ref="SystemInfo"/>
+												<xs:element minOccurs="0" name="Area"
+												type="SurfaceArea">
+												<xs:annotation>
+												<xs:documentation>[sq.ft.] Area of the slab</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="Thickness"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[in] Thickness of foundation slab.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="Perimeter"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft] Length of slab perimeter.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="ExposedPerimeter"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft] Perimeter of the slab exposed to ambient conditions</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0"
+												name="PerimeterInsulationDepth"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft] Depth from grade to bottom of vertical slab perimeter insulation</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0"
+												name="UnderSlabInsulationWidth"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft] Width from slab edge inward of horizontal under-slab insulation.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0"
+												name="OnGradeExposedPerimeter"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft] Perimeter of slab measuerd in feet that is on-grade (2 ft. below grade or less) and exposed to ambient conditions.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="DepthBelowGrade"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft] Depth from the top of the slab surface to grade</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="FloorCovering"
+												type="FloorCovering"/>
+												<xs:element maxOccurs="1" minOccurs="0"
+												name="PerimeterInsulation" type="InsulationInfo"/>
+												<xs:element minOccurs="0"
+												name="UnderSlabInsulation" type="InsulationInfo"/>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												</xs:complexType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="AnnualEnergyUse" minOccurs="0">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element ref="extension" minOccurs="0"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
 			<xs:element minOccurs="0" name="RimJoists">
 				<xs:complexType>
 					<xs:sequence>


### PR DESCRIPTION
Adds a `Garages` element similar to `Attics` and `Foundations`. Allows fully specifying all garage surfaces -- for example, the floor surface below a bonus room and above a garage. It also provides more detail for describing the garage (e.g., attached/detached, conditioned/unconditioned, etc.).

**Note**: This is branched off the `v3` branch in order to capture other proposed changes in other PRs. I will re-base it to be off the `master` branch once the following PRs are merged:
- [ ] [Add Solar Absorptance & Emittance #113](https://github.com/hpxmlwg/hpxml/pull/113)
- [ ] [Addresses Inconsistencies #124](https://github.com/hpxmlwg/hpxml/pull/124)
- [ ] [Clarifies UnderSlabInsulationWidth description #153](https://github.com/hpxmlwg/hpxml/pull/153)

![image](https://user-images.githubusercontent.com/5861765/57085933-6d00da00-6cba-11e9-9721-a3d47eff8236.png)
