### PR TITLE
Whole slab insulation

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -785,6 +785,9 @@
 												name="UnderSlabInsulationWidth"
 												type="LengthMeasurement"/>
 												<xs:element minOccurs="0"
+												name="UnderSlabInsulationSpansEntireSlab"
+												type="xs:boolean"/>
+												<xs:element minOccurs="0"
 												name="OnGradeExposedPerimeter"
 												type="LengthMeasurement">
 												<xs:annotation>


### PR DESCRIPTION
Adds an `UnderSlabInsulationSpansEntireSlab` boolean element for the `Slab` to specify that there's whole slab insulation.

![image](https://user-images.githubusercontent.com/5861765/57385356-8cdb4680-716f-11e9-8ffc-2b95a075eadb.png)
