### PR TITLE
Foundation wall insulation height

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -571,9 +571,9 @@
 												<xs:element minOccurs="0" name="RoofColor"
 												type="WallAndRoofColor"/>
 												<xs:element minOccurs="0" name="SolarAbsorptance"
-													type="SolarAbsorptance"/>
+												type="SolarAbsorptance"/>
 												<xs:element minOccurs="0" name="Emittance"
-													type="Emittance"/>
+												type="Emittance"/>
 												<xs:element minOccurs="0" name="RoofType"
 												type="RoofType"/>
 												<xs:element minOccurs="0" name="DeckType"
@@ -740,6 +740,12 @@
 												type="AdjacentTo"/>
 												<xs:element minOccurs="0" name="InteriorStuds"
 												type="StudProperties"/>
+												<xs:element minOccurs="0" name="InsulationHeight"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft] Height of the insulation, spanning from the top of the foundation wall downward.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
 												<xs:element maxOccurs="1" minOccurs="0"
 												name="Insulation" type="InsulationInfo"/>
 												<xs:element minOccurs="0" ref="extension"/>


### PR DESCRIPTION
Adds an `InsulationHeight` element for the height of the `FoundationWall/Insulation`. Allows for describing, e.g., 4ft high insulation in an 8ft basement. 

This was implemented similarly to the `PerimeterInsulationDepth` and `UnderSlabInsulationWidth` elements in the `Slab`.

![image](https://user-images.githubusercontent.com/5861765/57454206-83acb100-7225-11e9-83d1-49199b2da615.png)
