### PR TITLE
Adds desuperheater flexibility

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -1404,10 +1404,10 @@
 											<xs:documentation>[deg F]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HasGeothermalDesuperheater"
+									<xs:element minOccurs="0" name="HasDesuperheater"
 										type="xs:boolean">
 										<xs:annotation>
-											<xs:documentation>Indicates whether this water heater has a geothermal desuperheater. The attached heat pump can be referenced in the RelatedHeatingSystem element.</xs:documentation>
+											<xs:documentation>Indicates whether this water heater has a desuperheater. The attached heat pump or air conditioner can be referenced in the RelatedHVACSystem element.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="HasSharedCombustionVentilation"
@@ -1421,8 +1421,12 @@
 									<xs:element minOccurs="0" name="PilotLight" type="xs:boolean"/>
 									<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
 										type="xs:boolean"/>
-									<xs:element name="RelatedHeatingSystem" type="LocalReference"
-										minOccurs="0"/>
+									<xs:element name="RelatedHVACSystem" type="LocalReference"
+										minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Reference a HeatingSystem, HeatPump, or CoolingSystem.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
 									<xs:element minOccurs="0" name="Installation">
 										<xs:complexType>
 											<xs:sequence>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -1404,10 +1404,10 @@
 											<xs:documentation>[deg F]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HasDesuperheater"
+									<xs:element minOccurs="0" name="UsesDesuperheater"
 										type="xs:boolean">
 										<xs:annotation>
-											<xs:documentation>Indicates whether this water heater has a desuperheater. The attached heat pump or air conditioner can be referenced in the RelatedHVACSystem element.</xs:documentation>
+											<xs:documentation>Indicates whether this water heater uses a desuperheater. The attached heat pump or air conditioner can be referenced in the RelatedHVACSystem element.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="HasSharedCombustionVentilation"


### PR DESCRIPTION
`WaterHeatingSystem` elements already support describing a desuperheater, however:
- It's assumed to be attached to a geothermal heat pump
- The `RelatedHeatingSystem` is confusingly named since you would point to a `HeatPump` and not a `HeatingSystem`

This PR adds the flexibility of attaching a desuperheater to an air source heat pump or an air conditioner. While less common, these residential systems exist. The PR allows this by:
- Renaming `HasGeothermalDesuperheater` to `UsesDesuperheater`. Description: "Indicates whether this water heater uses a desuperheater. The attached heat pump or air conditioner can be referenced in the RelatedHVACSystem element."
- Renaming `RelatedHeatingSystem` to `RelatedHVACSystem`. Description: "Reference a HeatingSystem, HeatPump, or CoolingSystem."

These changes should still work for other uses of the `RelatedHVACSystem`, like a combination boiler.

cc @yzhou601
