### PR TITLE
New DuctLocation choices

### DIFF
--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1063,6 +1063,7 @@
 			<xs:enumeration value="crawlspace - unconditioned"/>
 			<xs:enumeration value="crawlspace - unvented"/>
 			<xs:enumeration value="crawlspace - vented"/>
+			<xs:enumeration value="exterior wall"/>
 			<xs:enumeration value="garage"/>
 			<xs:enumeration value="garage - conditioned"/>
 			<xs:enumeration value="garage - unconditioned"/>
@@ -1071,6 +1072,7 @@
 			<xs:enumeration value="outside"/>
 			<xs:enumeration value="roof deck"/>
 			<xs:enumeration value="unconditioned space"/>
+			<xs:enumeration value="under slab"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="DuctLeakageTestMethod">


### PR DESCRIPTION
Adds "under slab" and 'exterior wall" as choices for `DuctLocation`. These duct locations are found in ASHRAE 152 and many residential software tools.

("roof deck" was added in https://github.com/hpxmlwg/hpxml/pull/156 for similar reasons.)

@GamalielL 