### PR TITLE
Allow insulation location to be layer-specific

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -177,7 +177,6 @@
 			<xs:group ref="SystemInfo"/>
 			<xs:element minOccurs="0" name="InsulationGrade" type="InsulationGrade"/>
 			<xs:element minOccurs="0" name="InsulationCondition" type="InsulationCondition"/>
-			<xs:element minOccurs="0" name="InsulationLocation" type="InsulationLocation"/>
 			<xs:element minOccurs="0" name="AssemblyEffectiveRValue" type="RValue">
 				<xs:annotation>
 					<xs:documentation>This should indicate the effective R-value of the complete assembly including any air films or other treatments.</xs:documentation>
@@ -190,6 +189,8 @@
 						<xs:element name="InstallationType" type="InstallationType" minOccurs="0"/>
 						<xs:element name="InsulationMaterial" type="InsulationMaterial"
 							minOccurs="0"/>
+						<xs:element minOccurs="0" name="InsulationLocation"
+							type="InsulationLocation"/>
 						<xs:element name="NominalRValue" type="RValue" minOccurs="0"/>
 						<xs:element name="Thickness" type="LengthMeasurement" minOccurs="0">
 							<xs:annotation>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -189,8 +189,6 @@
 						<xs:element name="InstallationType" type="InstallationType" minOccurs="0"/>
 						<xs:element name="InsulationMaterial" type="InsulationMaterial"
 							minOccurs="0"/>
-						<xs:element minOccurs="0" name="InsulationLocation"
-							type="InsulationLocation"/>
 						<xs:element name="NominalRValue" type="RValue" minOccurs="0"/>
 						<xs:element name="Thickness" type="LengthMeasurement" minOccurs="0">
 							<xs:annotation>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -669,6 +669,8 @@
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="cavity"/>
 			<xs:enumeration value="continuous"/>
+			<xs:enumeration value="continuous - interior"/>
+			<xs:enumeration value="continuous - exterior"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="InsulationBattType">


### PR DESCRIPTION
Addresses #125. Adds "continuous - interior" and "continuous - exterior" to `InstallationType` element, which can be defined for each insulation `Layer`. Removes `InsulationLocation` element. 

This new approach makes it clear that the interior vs exterior insulation location is meant to only apply to continuous insulation layers. The "continuous" option is still allowed if the insulation location is unknown.