### PR TITLE
Adding customer comments element

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -4902,13 +4902,13 @@ https://hpxml.nrel.gov/wiki/WallTypes</xs:documentation>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="HomeownerConcerns">
+			<xs:element minOccurs="0" name="Comments">
 				<xs:annotation>
-					<xs:documentation>A list of homeowner concerns to address in priority order. Examples could include: bad smells, cold or hot rooms, noise, humidity/mold, ice damming.</xs:documentation>
+					<xs:documentation>A list of comments in priority order. </xs:documentation>
 				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="HomeownerConcern" type="xs:string"/>
+						<xs:element maxOccurs="unbounded" name="Comment" type="xs:string"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -4902,6 +4902,16 @@ https://hpxml.nrel.gov/wiki/WallTypes</xs:documentation>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
+			<xs:element minOccurs="0" name="HomeownerConcerns">
+				<xs:annotation>
+					<xs:documentation>A list of homeowner concerns to address in priority order. Examples could include: bad smells, cold or hot rooms, noise, humidity/mold, ice damming.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element maxOccurs="unbounded" name="HomeownerConcern" type="xs:string"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="OtherContact">
 				<xs:complexType>
 					<xs:sequence>


### PR DESCRIPTION
Fixes #170 

Adds a list of homeowner concerns as `/HPXML/Customer/HomeownerConcerns`

![BaseElements_Comments](https://user-images.githubusercontent.com/5325034/65531702-b47d4200-deb7-11e9-9759-b78ced8b3ca9.png)

This would look something like

```xml
<Customer>
    <CustomerDetails>
        <Person>
            <SystemIdentifier id="homeowner"/>
            <Name>Joe Homeowner</Name>
        </Person>
    </CustomerDetails>
    <Comments>
        <Comment>ice damming</Comment>
        <Comment>neighbor's dog poops on my lawn</Comment>
        <Comment>thermal comfort</Comment>
        <Comment>keeping up with Jonses</Comment>
        <!-- can have as many as you need -->
    </Comments>
</Customer>
```

~~I'm not 100% sure this is the best way to do this, so I'd like to have some discussion about it. Maybe this should be called `CustomerConcerns`?~~

Changed to `Comments/Comment` to make more general.

@Tedkidd