### PR TITLE
Adding dataSource attribute

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.0">
 	<xs:include schemaLocation="HPXMLDataTypes.xsd"/>
-	<xs:attribute name="dataSource" type="DataSource"/>
 	<xs:element name="XMLTransactionHeaderInformation">
 		<xs:annotation>
 			<xs:documentation>These are a series of elements that indicate the type of XML and basic descriptive data about the XML.</xs:documentation>
@@ -14,7 +13,7 @@
 				<xs:element name="Transaction" type="TransactionType"/>
 				<xs:element minOccurs="0" ref="extension"/>
 			</xs:sequence>
-			<xs:attribute ref="dataSource"/>
+			<xs:attribute name="dataSource" type="DataSource"/>
 		</xs:complexType>
 	</xs:element>
 	<xs:complexType name="AddressInformation">
@@ -31,7 +30,7 @@
 			<xs:element name="USPSBarCode" type="USPSBarCode" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="SystemIdentifiersInfoType">
 		<xs:annotation>
@@ -54,11 +53,11 @@
 				<xs:documentation>Use to reference the id of the same object on the base building where the object has not been replaced.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="LocalReference">
 		<xs:attribute name="idref" type="xs:IDREF"/>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="RemoteReference">
 		<xs:annotation>
@@ -76,7 +75,7 @@
 				<xs:documentation>Id reference in the current document. Optional. If the element isn't available in the current document, don't use this.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:element name="ContractorSystemIdentifiers">
 		<xs:annotation>
@@ -86,14 +85,14 @@
 			<xs:sequence>
 				<xs:element maxOccurs="unbounded" ref="SystemIdentifiersInfo"/>
 			</xs:sequence>
-			<xs:attribute ref="dataSource"/>
+			<xs:attribute name="dataSource" type="DataSource"/>
 		</xs:complexType>
 	</xs:element>
 	<xs:complexType name="extensionType">
 		<xs:sequence>
 			<xs:any maxOccurs="unbounded" minOccurs="0" namespace="##any" processContents="skip"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:element name="extension" type="extensionType"> </xs:element>
 	<xs:element name="ProjectStatus">
@@ -108,7 +107,7 @@
 				<xs:element minOccurs="0" name="Date" type="HPXMLDate"/>
 				<xs:element minOccurs="0" ref="extension"/>
 			</xs:sequence>
-			<xs:attribute ref="dataSource"/>
+			<xs:attribute name="dataSource" type="DataSource"/>
 		</xs:complexType>
 	</xs:element>
 	<xs:complexType name="IndividualInfo">
@@ -124,7 +123,7 @@
 						<xs:element name="SuffixName" type="SuffixName" minOccurs="0"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="IndividualType" type="IndividualType"/>
@@ -132,7 +131,7 @@
 			<xs:element minOccurs="0" maxOccurs="unbounded" name="Email" type="EmailInfoType"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:element name="UtilityFuelProvider">
 		<xs:annotation>
@@ -150,7 +149,7 @@
 				<xs:element maxOccurs="unbounded" minOccurs="0" name="BusinessContactInfo" type="BusinessContactInfoType"/>
 				<xs:element ref="extension" minOccurs="0"/>
 			</xs:sequence>
-			<xs:attribute ref="dataSource"/>
+			<xs:attribute name="dataSource" type="DataSource"/>
 		</xs:complexType>
 	</xs:element>
 	<xs:complexType name="IECCClimateZoneType">
@@ -159,7 +158,7 @@
 			<xs:element name="ClimateZone" type="ClimateZoneIECC"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="InsulationMaterial">
 		<xs:choice>
@@ -183,7 +182,7 @@
 				</xs:annotation>
 			</xs:element>
 		</xs:choice>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="InsulationInfo">
 		<xs:sequence>
@@ -209,12 +208,12 @@
 						</xs:element>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:element name="CoolingSystemInfo" type="CoolingSystemInfoType"/>
 	<xs:element name="HeatPumpInfo" type="HeatPumpInfoType"/>
@@ -232,7 +231,7 @@
 			<xs:element name="ModelYear" type="Year" minOccurs="0"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="ApplianceThirdPartyCertifications"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="ClothesDryerInfoType">
 		<xs:complexContent>
@@ -445,7 +444,7 @@
 				<xs:element name="SoftwareProgramVersion" type="SoftwareProgramVersion" minOccurs="0"/>
 				<xs:element ref="extension" minOccurs="0"/>
 			</xs:sequence>
-			<xs:attribute ref="dataSource"/>
+			<xs:attribute name="dataSource" type="DataSource"/>
 		</xs:complexType>
 	</xs:element>
 	<xs:complexType name="BusinessContactType">
@@ -455,7 +454,7 @@
 					<xs:sequence>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Auditor">
@@ -466,7 +465,7 @@
 						<xs:element minOccurs="0" name="YearsExperience" type="IntegerGreaterThanOrEqualToZero"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Implementer">
@@ -476,7 +475,7 @@
 						<xs:element minOccurs="0" name="StateWhereQualificationHeld" type="StateCode"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Other">
@@ -485,11 +484,11 @@
 						<xs:element minOccurs="0" name="Description" type="HPXMLString"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:choice>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="ContractorType">
 		<xs:sequence>
@@ -498,7 +497,7 @@
 			<xs:element name="SubContractor" type="ContractorType" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:element name="AttachedToSpace" type="LocalReference"/>
 	<xs:element name="AttachedToZone" type="LocalReference"/>
@@ -527,11 +526,11 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="Zones">
 		<xs:sequence>
@@ -544,11 +543,11 @@
 						<xs:element name="Spaces" type="Spaces" minOccurs="0"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="Enclosure">
 		<xs:sequence>
@@ -568,11 +567,11 @@
 												<xs:element maxOccurs="unbounded" minOccurs="0" name="BasementCrawlspace" type="BasementCrawlspaceComponentsAirSealed"/>
 												<xs:element maxOccurs="unbounded" minOccurs="0" name="LivingSpace" type="LivingSpaceComponentsAirSealed"/>
 											</xs:sequence>
-											<xs:attribute ref="dataSource"/>
+											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element name="AnnualEnergyUse" minOccurs="0">
@@ -580,12 +579,12 @@
 								<xs:sequence>
 									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Attics">
@@ -613,16 +612,16 @@
 											<xs:sequence>
 												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
-											<xs:attribute ref="dataSource"/>
+											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Foundations" minOccurs="0">
@@ -649,16 +648,16 @@
 											<xs:sequence>
 												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
-											<xs:attribute ref="dataSource"/>
+											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Garages">
@@ -684,7 +683,7 @@
 												<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
-											<xs:attribute ref="dataSource"/>
+											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element minOccurs="0" name="AttachedToRoof" type="LocalReference" maxOccurs="unbounded"/>
@@ -697,16 +696,16 @@
 											<xs:sequence>
 												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
-											<xs:attribute ref="dataSource"/>
+											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Roofs">
@@ -748,11 +747,11 @@
 									<xs:element minOccurs="0" name="Insulation" type="InsulationInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="RimJoists">
@@ -790,16 +789,16 @@
 											<xs:sequence>
 												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
-											<xs:attribute ref="dataSource"/>
+											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Walls" minOccurs="0">
@@ -841,16 +840,16 @@
 											<xs:sequence>
 												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
-											<xs:attribute ref="dataSource"/>
+											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="FoundationWalls">
@@ -914,11 +913,11 @@
 									<xs:element maxOccurs="1" minOccurs="0" name="Insulation" type="InsulationInfo"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="FrameFloors">
@@ -946,11 +945,11 @@
 									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"> </xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Slabs">
@@ -1011,11 +1010,11 @@
 									<xs:element minOccurs="0" name="UnderSlabInsulation" type="InsulationInfo"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Windows" minOccurs="0">
@@ -1036,16 +1035,16 @@
 											<xs:sequence>
 												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
-											<xs:attribute ref="dataSource"/>
+											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Skylights">
@@ -1071,16 +1070,16 @@
 											<xs:sequence>
 												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
-											<xs:attribute ref="dataSource"/>
+											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Doors" minOccurs="0">
@@ -1115,21 +1114,21 @@
 											<xs:sequence>
 												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
-											<xs:attribute ref="dataSource"/>
+											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="Systems">
 		<xs:sequence>
@@ -1148,7 +1147,7 @@
 												<xs:element minOccurs="0" name="PrimaryHeatingSystem" type="LocalReference"/>
 												<xs:element minOccurs="0" name="PrimaryCoolingSystem" type="LocalReference"/>
 											</xs:sequence>
-											<xs:attribute ref="dataSource"/>
+											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element minOccurs="0" maxOccurs="unbounded" name="HeatingSystem" type="HeatingSystemInfoType"/>
@@ -1156,7 +1155,7 @@
 									<xs:element minOccurs="0" maxOccurs="unbounded" name="HeatPump" type="HeatPumpInfoType"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element maxOccurs="unbounded" minOccurs="0" name="HVACControl" type="HVACControlType"> </xs:element>
@@ -1176,7 +1175,7 @@
 													</xs:annotation>
 												</xs:element>
 											</xs:choice>
-											<xs:attribute ref="dataSource"/>
+											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element minOccurs="0" name="ConditionedFloorAreaServed" type="SurfaceArea">
@@ -1201,7 +1200,7 @@
 									<xs:element minOccurs="0" name="HVACDistributionImprovement" type="HVACDistributionImprovementInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" name="Maintenance">
@@ -1211,7 +1210,7 @@
 									<xs:element minOccurs="0" name="ACReplacedinLastTenYears" type="HPXMLBoolean"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element name="AnnualEnergyUse" minOccurs="0">
@@ -1219,12 +1218,12 @@
 								<xs:sequence>
 									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType" maxOccurs="unbounded"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="MechanicalVentilation">
@@ -1330,16 +1329,16 @@
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
-											<xs:attribute ref="dataSource"/>
+											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="CombustionVentilation">
@@ -1353,11 +1352,11 @@
 									<xs:element minOccurs="0" ref="AttachedToZone"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="WaterHeating" minOccurs="0">
@@ -1439,7 +1438,7 @@
 															</xs:element>
 															<xs:element minOccurs="0" ref="extension"/>
 														</xs:sequence>
-														<xs:attribute ref="dataSource"/>
+														<xs:attribute name="dataSource" type="DataSource"/>
 													</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="TankWall">
@@ -1458,11 +1457,11 @@
 															</xs:element>
 															<xs:element minOccurs="0" ref="extension"/>
 														</xs:sequence>
-														<xs:attribute ref="dataSource"/>
+														<xs:attribute name="dataSource" type="DataSource"/>
 													</xs:complexType>
 												</xs:element>
 											</xs:sequence>
-											<xs:attribute ref="dataSource"/>
+											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element name="MeetsACCA5QIHVACSpecification" type="HPXMLBoolean" minOccurs="0"/>
@@ -1495,13 +1494,13 @@
 												<xs:element minOccurs="0" name="Standard" type="HVACInstallationStandard"/>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
-											<xs:attribute ref="dataSource"/>
+											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element minOccurs="0" name="WaterHeaterImprovement" type="WaterHeaterImprovementInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element maxOccurs="unbounded" minOccurs="0" name="WaterHeatingControl">
@@ -1516,7 +1515,7 @@
 									<xs:element minOccurs="0" name="TemperatureControl" type="DHWTemperatureControl"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element maxOccurs="unbounded" minOccurs="0" name="HotWaterDistribution">
@@ -1543,7 +1542,7 @@
 															</xs:element>
 															<xs:element minOccurs="0" ref="extension"/>
 														</xs:sequence>
-														<xs:attribute ref="dataSource"/>
+														<xs:attribute name="dataSource" type="DataSource"/>
 													</xs:complexType>
 												</xs:element>
 												<xs:element name="Recirculation">
@@ -1570,11 +1569,11 @@
 															</xs:element>
 															<xs:element minOccurs="0" ref="extension"/>
 														</xs:sequence>
-														<xs:attribute ref="dataSource"/>
+														<xs:attribute name="dataSource" type="DataSource"/>
 													</xs:complexType>
 												</xs:element>
 											</xs:choice>
-											<xs:attribute ref="dataSource"/>
+											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element minOccurs="0" name="PipeInsulation" type="PipeInsulationType"/>
@@ -1590,12 +1589,12 @@
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
-											<xs:attribute ref="dataSource"/>
+											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element maxOccurs="unbounded" minOccurs="0" name="WaterFixture">
@@ -1644,7 +1643,7 @@
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element name="AnnualEnergyUse" minOccurs="0">
@@ -1652,11 +1651,11 @@
 								<xs:sequence>
 									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="SolarThermal">
@@ -1719,11 +1718,11 @@
 									</xs:element>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Photovoltaics">
@@ -1784,11 +1783,11 @@
 									</xs:element>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Batteries">
@@ -1845,11 +1844,11 @@
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="ElectricVehicleChargers">
@@ -1889,11 +1888,11 @@
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Wind">
@@ -1948,16 +1947,16 @@
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="Appliances">
 		<xs:sequence>
@@ -1971,7 +1970,7 @@
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="Oven" type="OvenInfoType"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="Lighting">
 		<xs:sequence>
@@ -2028,7 +2027,7 @@
 						</xs:element>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="LightingFixture">
@@ -2039,7 +2038,7 @@
 						<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="LightingFixtureThirdPartyCertification"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="LightingControl" minOccurs="0" maxOccurs="unbounded">
@@ -2053,7 +2052,7 @@
 						<xs:element name="Location" type="LightingLocation" minOccurs="0"> </xs:element>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="CeilingFan">
@@ -2081,7 +2080,7 @@
 										</xs:annotation>
 									</xs:element>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" name="ThirdPartyCertification" type="ApplianceThirdPartyCertifications" maxOccurs="unbounded"/>
@@ -2092,12 +2091,12 @@
 						</xs:element>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="LightingType">
 		<xs:choice>
@@ -2107,7 +2106,7 @@
 						<xs:element minOccurs="0" name="Halogen" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="FluorescentTube">
@@ -2117,7 +2116,7 @@
 						<xs:element minOccurs="0" name="BallastType" type="FluorescentBallastType"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="CompactFluorescent">
@@ -2125,7 +2124,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="LightEmittingDiode">
@@ -2133,7 +2132,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="HighIntensityDischarge">
@@ -2149,17 +2148,17 @@
 												<xs:element minOccurs="0" name="Pressure" type="SodiumLight_Pressure"> </xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
-											<xs:attribute ref="dataSource"/>
+											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element name="MetalHalide"/>
 								</xs:choice>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Other">
@@ -2168,11 +2167,11 @@
 						<xs:element minOccurs="0" name="Description" type="HPXMLString"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:choice>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="Pools">
 		<xs:sequence>
@@ -2305,16 +2304,16 @@
 															</xs:element>
 															<xs:element minOccurs="0" ref="extension"/>
 														</xs:sequence>
-														<xs:attribute ref="dataSource"/>
+														<xs:attribute name="dataSource" type="DataSource"/>
 													</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
-											<xs:attribute ref="dataSource"/>
+											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" name="Cleaner">
@@ -2334,7 +2333,7 @@
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" name="Heater">
@@ -2354,16 +2353,16 @@
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="MiscLoads">
 		<xs:sequence>
@@ -2378,7 +2377,7 @@
 						<xs:element name="PlugLoadControlType" minOccurs="0" type="PlugLoadControlType"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="PlugLoad" minOccurs="0" maxOccurs="unbounded">
@@ -2396,17 +2395,17 @@
 									<xs:element name="Units" type="PlugLoadUnits"/>
 									<xs:element name="Value" type="HPXMLDouble"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="HealthAndSafety">
 		<xs:sequence>
@@ -2416,7 +2415,7 @@
 						<xs:element minOccurs="0" name="TestsCompleted" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="TestsPassed" type="HPXMLBoolean"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Ventilation" minOccurs="0">
@@ -2428,7 +2427,7 @@
 						<xs:element minOccurs="0" name="VentilationImprovement" type="VentilationImprovementInfo"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="MoistureControl" minOccurs="0">
@@ -2438,7 +2437,7 @@
 						<xs:element minOccurs="0" name="MoistureControlImprovement" type="MoistureControlImprovementInfo"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="CombustionAppliances">
@@ -2561,22 +2560,22 @@
 															<xs:element minOccurs="0" name="Notes" type="HPXMLString"/>
 															<xs:element minOccurs="0" ref="extension"/>
 														</xs:sequence>
-														<xs:attribute ref="dataSource"/>
+														<xs:attribute name="dataSource" type="DataSource"/>
 													</xs:complexType>
 												</xs:element>
 												<xs:element ref="extension" minOccurs="0"/>
 											</xs:sequence>
-											<xs:attribute ref="dataSource"/>
+											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element minOccurs="0" name="Notes" type="HPXMLString"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="StoveTest">
@@ -2591,7 +2590,7 @@
 						<xs:element name="ActionsTaken" type="HPXMLString" minOccurs="0"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="LeadPaint">
@@ -2619,7 +2618,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Radon">
@@ -2641,7 +2640,7 @@
 									<xs:element minOccurs="0" name="RadonTestMethod" type="RadonTestTypes"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" name="EducationMaterialProvided" type="HPXMLBoolean">
@@ -2665,7 +2664,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="SourcePollutants">
@@ -2703,7 +2702,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Pests">
@@ -2728,7 +2727,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Asbestos">
@@ -2754,7 +2753,7 @@
 						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecifications" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="SprayFoam">
@@ -2768,12 +2767,12 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="CAZApplianceReading">
 		<xs:sequence>
@@ -2786,7 +2785,7 @@
 			</xs:element>
 			<xs:element minOccurs="0" name="TestResult" type="TestResultType"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="CAZTestConfiguration">
 		<xs:sequence>
@@ -2799,7 +2798,7 @@
 						<xs:element minOccurs="0" name="CentralVacuum" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="AirHandler" type="HPXMLBoolean"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="DoorsOpenClosed">
@@ -2808,7 +2807,7 @@
 						<xs:element minOccurs="0" name="BasementDoors" type="OpenClosed"/>
 						<xs:element minOccurs="0" name="OtherDoors" type="OpenClosed"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Pressure" type="HPXMLDouble">
@@ -2818,7 +2817,7 @@
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="YesNoRecommendInstall">
 		<xs:choice>
@@ -2832,7 +2831,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="No">
@@ -2845,7 +2844,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="NA">
@@ -2853,11 +2852,11 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:choice>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="WholeBldgVentDesignInfo">
 		<xs:sequence>
@@ -2886,7 +2885,7 @@
 			<xs:element minOccurs="0" name="VentilationImprovementRecommendation" type="Recommendation"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="SpotVentDesignInfo">
 		<xs:sequence>
@@ -2926,7 +2925,7 @@
 			<xs:element minOccurs="0" name="AirflowRateUnits" type="SpotVentilationUnits"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="OtherVentIssues">
 		<xs:sequence>
@@ -2952,12 +2951,12 @@
 						<xs:element name="Description" type="HPXMLString"/>
 						<xs:element name="Answer" type="YesNoRecommendInstall"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="StatusMessage">
 		<xs:sequence>
@@ -2966,7 +2965,7 @@
 			<xs:element name="Message" type="HPXMLString"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="FuelSavingsType">
 		<xs:sequence>
@@ -2982,7 +2981,7 @@
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="EndUseSavings" type="EndUseInfoType"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="EndUseInfoType">
 		<xs:sequence>
@@ -2994,7 +2993,7 @@
 			</xs:element>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:group name="SystemInfo">
 		<xs:sequence>
@@ -3031,7 +3030,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="AnnualEnergyUse">
@@ -3039,12 +3038,12 @@
 					<xs:sequence>
 						<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="HVACMaintenance" type="HVACMaintenance"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="HeatingSystemInfoType">
 		<xs:complexContent>
@@ -3090,7 +3089,7 @@
 						<xs:element minOccurs="0" name="RetentionHead" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="WallFurnace" type="WallAndFloorFurnace"> </xs:element>
@@ -3110,7 +3109,7 @@
 						<xs:element minOccurs="0" name="RetentionHead" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="ElectricResistance">
@@ -3119,7 +3118,7 @@
 						<xs:element name="ElectricDistribution" type="ElectricDistributionType" minOccurs="0"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Fireplace">
@@ -3135,7 +3134,7 @@
 						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Stove">
@@ -3151,7 +3150,7 @@
 						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="PortableHeater">
@@ -3159,7 +3158,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="SolarThermal">
@@ -3168,7 +3167,7 @@
 						<xs:element minOccurs="0" name="SolarThermalSystem" type="LocalReference"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="DistrictSteam">
@@ -3177,7 +3176,7 @@
 						<xs:element minOccurs="0" name="DistrictSteamType" type="DistrictSteamType"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Other">
@@ -3186,11 +3185,11 @@
 						<xs:element minOccurs="0" name="Description" type="HPXMLString"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:choice>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="HeatPumpInfoType">
 		<xs:complexContent>
@@ -3281,7 +3280,7 @@
 			<xs:element name="Units" type="CoolingEfficiencyUnits"/>
 			<xs:element name="Value" type="Efficiency"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="HeatingEfficiencyType">
 		<xs:sequence>
@@ -3292,7 +3291,7 @@
 			</xs:element>
 			<xs:element name="Value" type="Efficiency"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="HydronicDistributionInfo">
 		<xs:sequence>
@@ -3331,12 +3330,12 @@
 						<xs:element minOccurs="0" name="ThermostaticRadiatorValves" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="VariableSpeedPump" type="HPXMLBoolean"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="AirDistributionInfo">
 		<xs:sequence>
@@ -3371,7 +3370,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="NumberofReturnRegisters" type="IntegerGreaterThanOrEqualToZero"/>
@@ -3381,12 +3380,12 @@
 						<xs:element minOccurs="0" name="Supply" type="TotalExternalStaticPressureMeasurement"/>
 						<xs:element minOccurs="0" name="Return" type="TotalExternalStaticPressureMeasurement"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:element name="BuildingSystemIdentifiers">
 		<xs:annotation>
@@ -3397,7 +3396,7 @@
 			<xs:sequence>
 				<xs:element ref="SystemIdentifiersInfo"/>
 			</xs:sequence>
-			<xs:attribute ref="dataSource"/>
+			<xs:attribute name="dataSource" type="DataSource"/>
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="Associations" type="AssociationsType"> </xs:element>
@@ -3415,7 +3414,7 @@
 			<xs:element name="IncentiveAmount" type="IncentiveAmount" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="BuildingDetailsType">
 		<xs:sequence>
@@ -3461,7 +3460,7 @@
 													</xs:annotation>
 												</xs:element>
 											</xs:sequence>
-											<xs:attribute ref="dataSource"/>
+											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element minOccurs="0" name="WalkingScore" type="IntegerGreaterThanOrEqualToZero"/>
@@ -3474,12 +3473,12 @@
 											<xs:sequence>
 												<xs:element maxOccurs="unbounded" name="Fuel" type="FuelType"/>
 											</xs:sequence>
-											<xs:attribute ref="dataSource"/>
+											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" name="BuildingOccupancy">
@@ -3519,7 +3518,7 @@
 									<xs:element minOccurs="0" name="HighestLevelofOccupantEducation" type="EducationLevels"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" name="BuildingConstruction">
@@ -3670,7 +3669,7 @@
 									<xs:element minOccurs="0" name="SpaceAboveGarage" type="SpaceAboveGarage"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element name="AnnualEnergyUse" minOccurs="0">
@@ -3678,12 +3677,12 @@
 								<xs:sequence>
 									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType" maxOccurs="unbounded"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="ClimateandRiskZones" minOccurs="0">
@@ -3703,7 +3702,7 @@
 						</xs:element>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="GreenBuildingVerifications">
@@ -3785,11 +3784,11 @@
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Zones" type="Zones"/>
@@ -3802,7 +3801,7 @@
 			<xs:element minOccurs="0" name="HealthAndSafety" type="HealthAndSafety"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="ProjectDetailsType">
 		<xs:sequence>
@@ -3849,7 +3848,7 @@
 					<xs:sequence>
 						<xs:element maxOccurs="unbounded" name="Incentive" type="IncentiveDetailsType"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType" maxOccurs="2"/>
@@ -3859,19 +3858,19 @@
 					<xs:sequence>
 						<xs:element maxOccurs="unbounded" name="Measure" type="MeasureDetailsType"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="TotalCostType">
 		<xs:sequence>
 			<xs:element name="TotalCostHealthSafetyMeasures" type="TotalCostHealthSafetyMeasures" minOccurs="1"/>
 			<xs:element name="TotalCostQualEnergyMeasures" type="TotalCostQualEnergyMeasures" minOccurs="1"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="MeasureDetailsType">
 		<xs:sequence>
@@ -3883,7 +3882,7 @@
 					<xs:sequence>
 						<xs:element maxOccurs="unbounded" ref="SystemIdentifiersInfo"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element maxOccurs="unbounded" minOccurs="0" ref="ExternalResource"/>
@@ -3895,7 +3894,7 @@
 						<xs:element name="Units" type="HPXMLString"/>
 						<xs:element name="Value" type="Quantity"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Location" type="UnitLocation" minOccurs="0"/>
@@ -3908,7 +3907,7 @@
 					<xs:sequence>
 						<xs:element maxOccurs="unbounded" name="Incentive" type="IncentiveDetailsType"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="ResourceSavingsInfo">
@@ -3928,11 +3927,11 @@
 									<xs:element name="AnnualAmount" type="AnnualAmount" minOccurs="0"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType" maxOccurs="2"/>
@@ -3953,7 +3952,7 @@
 						<xs:element name="QAComments" type="Notes"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="ReplacedComponents">
@@ -3964,7 +3963,7 @@
 					<xs:sequence>
 						<xs:element maxOccurs="unbounded" name="ReplacedComponent" type="RemoteReference"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="InstalledComponents">
@@ -3972,12 +3971,12 @@
 					<xs:sequence>
 						<xs:element minOccurs="1" name="InstalledComponent" type="RemoteReference" maxOccurs="unbounded"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="EnergySavingsType">
 		<xs:sequence>
@@ -4000,7 +3999,7 @@
 			</xs:element>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="WaterSavingsType">
 		<xs:sequence>
@@ -4017,7 +4016,7 @@
 			<xs:element minOccurs="0" name="ReclaimedWaterSystem" type="HPXMLBoolean"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="DuctLeakageMeasurementType">
 		<xs:sequence>
@@ -4035,7 +4034,7 @@
 						<xs:element name="Value" type="MeasuredDuctLeakage" minOccurs="0"/>
 						<xs:element minOccurs="0" name="TotalOrToOutside" type="DuctLeakageTotalOrToOutside"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="EffectiveLeakageArea" type="SurfaceArea">
@@ -4046,7 +4045,7 @@
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="ConsumptionInfoType">
 		<xs:sequence>
@@ -4078,7 +4077,7 @@
 						<xs:element name="ConsumptionCost" type="HPXMLDouble" minOccurs="0"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="MarginalRate" type="HPXMLDouble" minOccurs="0"/>
@@ -4095,7 +4094,7 @@
 			</xs:element>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="BPI2400Inputs">
 		<xs:sequence>
@@ -4183,7 +4182,7 @@
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="EnergyAndWaterUseTypeDescription">
 		<xs:choice>
@@ -4212,11 +4211,11 @@
 												<xs:element name="EmissionUnits" type="EmissionUnits"/>
 												<xs:element name="Emissions" type="HPXMLDouble"/>
 											</xs:sequence>
-											<xs:attribute ref="dataSource"/>
+											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" name="FuelInterruptibility" type="FuelInterruptibility"/>
@@ -4241,7 +4240,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Water">
@@ -4260,16 +4259,16 @@
 									<xs:element name="Units" type="WaterUseIntensityUnits"/>
 									<xs:element name="Value" type="HPXMLDouble"/>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:choice>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="ModeledUsageType">
 		<xs:sequence>
@@ -4291,7 +4290,7 @@
 			<xs:element minOccurs="0" name="ElectricityDemandKW" type="HPXMLDouble"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="StudProperties">
 		<xs:sequence>
@@ -4309,7 +4308,7 @@
 			<xs:element minOccurs="0" name="Material" type="StudMaterial"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="TelephoneInfoType">
 		<xs:sequence>
@@ -4319,7 +4318,7 @@
 			<xs:element name="TelephoneExtension" type="TelephoneExtension" minOccurs="0"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="EmailInfoType">
 		<xs:sequence>
@@ -4328,7 +4327,7 @@
 			<xs:element minOccurs="0" name="PreferredContactMethod" type="HPXMLBoolean"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="BusinessInfoType">
 		<xs:sequence>
@@ -4342,7 +4341,7 @@
 			<xs:element minOccurs="0" maxOccurs="unbounded" name="EmailInfo" type="EmailInfoType"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="BusinessContactInfoType">
 		<xs:sequence>
@@ -4350,7 +4349,7 @@
 			<xs:element minOccurs="0" name="Person" type="IndividualInfo"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:group name="WindowInfo">
 		<xs:sequence>
@@ -4392,7 +4391,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="ExteriorShading">
@@ -4414,7 +4413,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="InteriorShading">
@@ -4439,7 +4438,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="StormWindow">
@@ -4452,7 +4451,7 @@
 						<xs:element minOccurs="0" name="Condition" type="WindowCondition"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="MoveableInsulation">
@@ -4465,7 +4464,7 @@
 						<xs:element minOccurs="0" name="RValue" type="RValue"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Overhangs">
@@ -4487,7 +4486,7 @@
 							</xs:annotation>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="WeatherStripping" type="HPXMLBoolean"/>
@@ -4503,7 +4502,7 @@
 						<xs:element minOccurs="0" name="ThermalBreak" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Composite">
@@ -4511,7 +4510,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Fiberglass">
@@ -4519,7 +4518,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Metal">
@@ -4528,7 +4527,7 @@
 						<xs:element minOccurs="0" name="ThermalBreak" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Vinyl">
@@ -4536,7 +4535,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Wood">
@@ -4544,7 +4543,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Other">
@@ -4553,11 +4552,11 @@
 						<xs:element minOccurs="0" name="Description"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:choice>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="AssociationsType">
 		<xs:all minOccurs="0">
@@ -4570,17 +4569,17 @@
 									<xs:element name="Measure" minOccurs="0" maxOccurs="unbounded">
 										<xs:complexType>
 											<xs:attribute name="ID" type="xs:int" use="required"/>
-											<xs:attribute ref="dataSource"/>
+											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element name="JobRole" type="JobRole" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="ID" type="xs:int" use="required"/>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Locations" minOccurs="0">
@@ -4589,21 +4588,21 @@
 						<xs:element name="Location" minOccurs="0" maxOccurs="unbounded">
 							<xs:complexType>
 								<xs:attribute name="ID" type="xs:int" use="required"/>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Contractor" minOccurs="0">
 				<xs:complexType>
 					<xs:attribute name="ID" type="xs:int"/>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:all>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="AirInfiltrationMeasurementType">
 		<xs:sequence>
@@ -4637,7 +4636,7 @@
 						<xs:element name="UnitofMeasure" type="BuildingAirLeakageUnit" minOccurs="0"/>
 						<xs:element name="AirLeakage" type="BuildingAirLeakage" minOccurs="0"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="EffectiveLeakageArea" type="HPXMLDouble">
@@ -4654,7 +4653,7 @@
 			</xs:element>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="MoistureControlInfoType">
 		<xs:sequence>
@@ -4663,7 +4662,7 @@
 			<xs:element name="InteriorLocationsofWaterLeaksorDamage" type="InteriorLocationsofWaterLeaksorDamage" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="FoundationType">
 		<xs:choice>
@@ -4674,7 +4673,7 @@
 						<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Crawlspace">
@@ -4684,7 +4683,7 @@
 						<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="SlabOnGrade">
@@ -4692,7 +4691,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Garage">
@@ -4701,7 +4700,7 @@
 						<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="AboveApartment">
@@ -4712,7 +4711,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Combination">
@@ -4720,7 +4719,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Ambient">
@@ -4731,7 +4730,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="RubbleStone">
@@ -4739,7 +4738,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Other">
@@ -4747,11 +4746,11 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:choice>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="WallType">
 		<xs:annotation>
@@ -4773,7 +4772,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="DoubleWoodStud">
@@ -4782,7 +4781,7 @@
 						<xs:element minOccurs="0" name="Staggered" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="ConcreteMasonryUnit">
@@ -4793,7 +4792,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="StructurallyInsulatedPanel">
@@ -4804,7 +4803,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="InsulatedConcreteForms">
@@ -4815,7 +4814,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="SteelFrame">
@@ -4823,7 +4822,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="SolidConcrete">
@@ -4831,7 +4830,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="StructuralBrick">
@@ -4839,7 +4838,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="StrawBale">
@@ -4847,7 +4846,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Stone">
@@ -4855,7 +4854,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="LogWall">
@@ -4863,7 +4862,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Other">
@@ -4871,11 +4870,11 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:choice>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="HVACControlType">
 		<xs:sequence>
@@ -4929,7 +4928,7 @@
 			<xs:element name="HVACSystemsServed" type="LocalReference" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="HVACControlTypeAdjustments">
 		<xs:sequence>
@@ -4937,7 +4936,7 @@
 			<xs:element minOccurs="0" name="Night" type="HPXMLBoolean"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="MoistureControlImprovementInfo">
 		<xs:sequence>
@@ -4948,7 +4947,7 @@
 			<xs:element name="OtherMeasuresImplementedDescription" type="HPXMLString" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="HVACDistributionImprovementInfo">
 		<xs:sequence>
@@ -4963,7 +4962,7 @@
 			<xs:element name="SystemPumpandZoneValveCorrectionsMade" type="HPXMLBoolean" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="HVACMaintenance">
 		<xs:sequence>
@@ -5001,7 +5000,7 @@
 										</xs:annotation>
 									</xs:element>
 								</xs:sequence>
-								<xs:attribute ref="dataSource"/>
+								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" name="MERVRating" type="MERV">
@@ -5017,12 +5016,12 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="WaterHeaterImprovementInfo">
 		<xs:sequence>
@@ -5039,7 +5038,7 @@
 			<xs:element name="SystemReplaced" type="HPXMLBoolean" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="VentilationImprovementInfo">
 		<xs:sequence>
@@ -5047,7 +5046,7 @@
 			<xs:element name="MechanicalVentilationInstalled" type="HPXMLBoolean" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="Building">
 		<xs:sequence>
@@ -5064,7 +5063,7 @@
 						<xs:element minOccurs="0" name="eGridRegion" type="eGridRegions"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="ContractorID" type="RemoteReference"/>
@@ -5085,12 +5084,12 @@
 						</xs:element>
 						<xs:element maxOccurs="unbounded" name="ModeledUsage" type="ModeledUsageType"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="Project">
 		<xs:sequence>
@@ -5100,14 +5099,14 @@
 			<xs:element name="ProjectDetails" type="ProjectDetailsType"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="Contractor">
 		<xs:sequence>
 			<xs:element name="ContractorDetails" type="ContractorType"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="Customer">
 		<xs:sequence>
@@ -5122,7 +5121,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Comments">
@@ -5133,7 +5132,7 @@
 					<xs:sequence>
 						<xs:element maxOccurs="unbounded" name="Comment" type="HPXMLString"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="OtherContact">
@@ -5143,12 +5142,12 @@
 						<xs:element name="Address" type="AddressInformation"> </xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="Utility">
 		<xs:sequence>
@@ -5160,12 +5159,12 @@
 					<xs:sequence>
 						<xs:element maxOccurs="unbounded" ref="UtilityFuelProvider"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="Consumption">
 		<xs:sequence>
@@ -5176,12 +5175,12 @@
 					<xs:sequence>
 						<xs:element maxOccurs="unbounded" name="ConsumptionInfo" type="ConsumptionInfoType"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="WeatherStation">
 		<xs:sequence>
@@ -5195,7 +5194,7 @@
 			<xs:element minOccurs="0" name="Use" nillable="true" type="WeatherStationUse"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="PipeInsulationType">
 		<xs:sequence>
@@ -5213,7 +5212,7 @@
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="TotalExternalStaticPressureMeasurement">
 		<xs:sequence>
@@ -5227,7 +5226,7 @@
 			<xs:element minOccurs="0" name="StaticPressureSource" type="StaticPressureSource"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="WallAndFloorFurnace">
 		<xs:sequence>
@@ -5240,7 +5239,7 @@
 			<xs:element minOccurs="0" name="RetentionHead" type="HPXMLBoolean"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="AtticType">
 		<xs:choice>
@@ -5252,7 +5251,7 @@
 						<xs:element minOccurs="0" name="CapeCod" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="CathedralCeiling">
@@ -5260,7 +5259,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="FlatRoof">
@@ -5268,7 +5267,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Other">
@@ -5276,18 +5275,18 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:choice>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="VentilationType">
 		<xs:sequence>
 			<xs:element name="UnitofMeasure" type="VentilationUnit" minOccurs="0"/>
 			<xs:element name="Value" type="BuildingAirLeakage" minOccurs="0"/>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="PipeDiameterType">
 		<xs:sequence>
@@ -5301,11 +5300,11 @@
 							</xs:annotation>
 						</xs:element>
 					</xs:sequence>
-					<xs:attribute ref="dataSource"/>
+					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:sequence>
-		<xs:attribute ref="dataSource"/>
+		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:element name="ExternalResource">
 		<xs:complexType>
@@ -5316,7 +5315,7 @@
 				<xs:element minOccurs="0" ref="extension"/>
 			</xs:sequence>
 			<xs:attribute name="id" use="required"/>
-			<xs:attribute ref="dataSource"/>
+			<xs:attribute name="dataSource" type="DataSource"/>
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="ConnectedDevice">
@@ -5330,7 +5329,7 @@
 				<xs:element minOccurs="0" name="OccupancySensor" type="HPXMLBoolean"/>
 				<xs:element minOccurs="0" ref="extension"/>
 			</xs:sequence>
-			<xs:attribute ref="dataSource"/>
+			<xs:attribute name="dataSource" type="DataSource"/>
 		</xs:complexType>
 	</xs:element>
 </xs:schema>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -258,7 +258,7 @@
 								drying cycle energy as well as energy consumed during Stand-by and Off modes.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element maxOccurs="unbounded" minOccurs="0" name="ControlType" type="ClothesDryerControlType_simple"> </xs:element>
+					<xs:element maxOccurs="unbounded" minOccurs="0" name="ControlType" type="ClothesDryerControlType"> </xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -1685,13 +1685,13 @@
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorRatedOpticalEfficiency" type="CollectorRatedOpticalEfficiency_simple">
+									<xs:element minOccurs="0" name="CollectorRatedOpticalEfficiency" type="CollectorRatedOpticalEfficiency">
 										<xs:annotation>
 											<xs:documentation>Often referred to as Fr-tau-alpha (FRta), this describes the optical efficiency portion of the overall collector efficiency. In the OG-100
 												SRCC Certified Solar Thermal Collector Directory, this is the y-intercept of the efficiency curve.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorRatedThermalLosses" type="CollectorRatedThermalLosses_simple">
+									<xs:element minOccurs="0" name="CollectorRatedThermalLosses" type="CollectorRatedThermalLosses">
 										<xs:annotation>
 											<xs:documentation>Often referred to as Fr-Ul (FRUl), this describes the collector thermal losses portion of the overall collector efficiency. In the OG-100
 												SRCC Certified Solar Thermal Collector Directory, this is the slope of the efficiency curve.</xs:documentation>
@@ -1703,14 +1703,14 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="ConnectedTo" type="LocalReference"/>
-									<xs:element minOccurs="0" name="SolarFraction" type="SolarFraction_simple">
+									<xs:element minOccurs="0" name="SolarFraction" type="SolarFraction">
 										<xs:annotation>
 											<xs:documentation>The Solar Fraction is the portion of the total conventional hot water heating load (delivered energy and tank standby losses). The higher
 												the solar fraction, the greater the solar contribution to water heating, which reduces the energy required by the backup water heater. This value can be
 												found in the OG-300 SRCC Certified Solar Water Heating System Directory.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="SolarEnergyFactor" type="SolarThermalSystemEnergyFactor_simple">
+									<xs:element minOccurs="0" name="SolarEnergyFactor" type="SolarThermalSystemEnergyFactor">
 										<xs:annotation>
 											<xs:documentation>The Solar Energy Factor is defined as the energy delivered by the system divided by the electrical or gas energy put into the system. The
 												higher the number, the more energy efficient. This value can be found in the OG-300 SRCC Certified Solar Water Heating System
@@ -1736,8 +1736,8 @@
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
 									<xs:element minOccurs="0" name="Location" type="PVSystemLocation"/>
 									<xs:element minOccurs="0" name="Ownership" type="PVSystemOwnership"/>
-									<xs:element minOccurs="0" name="ModuleType" type="PVModuleType_simple"> </xs:element>
-									<xs:element maxOccurs="1" minOccurs="0" name="Tracking" type="PVTracking_simple"> </xs:element>
+									<xs:element minOccurs="0" name="ModuleType" type="PVModuleType"> </xs:element>
+									<xs:element maxOccurs="1" minOccurs="0" name="Tracking" type="PVTracking"> </xs:element>
 									<xs:element minOccurs="0" name="ArrayOrientation" type="OrientationType"/>
 									<xs:element minOccurs="0" name="ArrayAzimuth" type="AzimuthType">
 										<xs:annotation>
@@ -2067,7 +2067,7 @@
 							</xs:annotation>
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element minOccurs="0" name="FanSpeed" type="FanSpeed_simple"> </xs:element>
+									<xs:element minOccurs="0" name="FanSpeed" type="FanSpeed"> </xs:element>
 									<xs:element minOccurs="0" name="Airflow" type="HPXMLDouble">
 										<xs:annotation>
 											<xs:documentation>[CFM]</xs:documentation>
@@ -2146,7 +2146,7 @@
 									<xs:element name="Sodium">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="Pressure" type="SodiumLight_Pressure_simple"> </xs:element>
+												<xs:element minOccurs="0" name="Pressure" type="SodiumLight_Pressure"> </xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
 											<xs:attribute ref="dataSource"/>
@@ -3215,7 +3215,7 @@
 					</xs:element>
 					<xs:element minOccurs="0" name="CoolingSensibleHeatFraction" type="Fraction"/>
 					<xs:element name="GeothermalLoop" type="GeothermalLoop" minOccurs="0"/>
-					<xs:element minOccurs="0" name="BackupType" type="HeatPumpBackupType_simple">
+					<xs:element minOccurs="0" name="BackupType" type="HeatPumpBackupType">
 						<xs:annotation>
 							<xs:documentation>Whether the heat pump backup is integrated into the unit (describe in BackupSystemFuel, BackupAnnualHeatingEfficiency, BackupHeatingCapacity), or a
 								separate heating system (add reference in BackupSystem).</xs:documentation>
@@ -5311,7 +5311,7 @@
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element name="URL" type="xs:anyURI"/>
-				<xs:element name="Type" type="ExternalResourceType_simple"> </xs:element>
+				<xs:element name="Type" type="ExternalResourceType"> </xs:element>
 				<xs:element name="Description" type="HPXMLString"/>
 				<xs:element minOccurs="0" ref="extension"/>
 			</xs:sequence>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -22,9 +22,9 @@
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="AddressType" type="AddressTypeCode" minOccurs="0"/>
-			<xs:element name="Address1" type="xs:string" minOccurs="0"/>
-			<xs:element name="Address2" type="xs:string" minOccurs="0"/>
-			<xs:element name="CityMunicipality" type="xs:string" minOccurs="0"/>
+			<xs:element name="Address1" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="Address2" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="CityMunicipality" type="HPXMLString" minOccurs="0"/>
 			<xs:element name="StateCode" type="StateCode" minOccurs="0"/>
 			<xs:element name="ZipCode" type="ZipCode" minOccurs="0"/>
 			<xs:element name="USPSBarCode" type="USPSBarCode" minOccurs="0"/>
@@ -110,9 +110,9 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element name="PrefixName" type="PrefixName" minOccurs="0"/>
-						<xs:element name="FirstName" type="xs:string"/>
-						<xs:element name="MiddleName" type="xs:string" minOccurs="0"/>
-						<xs:element name="LastName" type="xs:string"/>
+						<xs:element name="FirstName" type="HPXMLString"/>
+						<xs:element name="MiddleName" type="HPXMLString" minOccurs="0"/>
+						<xs:element name="LastName" type="HPXMLString"/>
 						<xs:element name="SuffixName" type="SuffixName" minOccurs="0"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
@@ -131,9 +131,9 @@
 		<xs:complexType>
 			<xs:sequence>
 				<xs:group ref="SystemInfo"/>
-				<xs:element name="UtilityName" type="xs:string" minOccurs="0"/>
-				<xs:element minOccurs="0" name="MeterNumber" type="xs:string"/>
-				<xs:element name="UtilityAccountNumber" type="xs:string" minOccurs="0"/>
+				<xs:element name="UtilityName" type="HPXMLString" minOccurs="0"/>
+				<xs:element minOccurs="0" name="MeterNumber" type="HPXMLString"/>
+				<xs:element name="UtilityAccountNumber" type="HPXMLString" minOccurs="0"/>
 				<xs:element minOccurs="0" name="Permission" type="xs:boolean"/>
 				<xs:element name="UtilityServiceTypeProvided" type="ConsumptionType" minOccurs="0" maxOccurs="unbounded"/>
 				<xs:element minOccurs="0" name="BusinessInfo" type="BusinessInfoType"/>
@@ -155,7 +155,7 @@
 			<xs:element name="LooseFill" type="InsulationLooseFillType"/>
 			<xs:element name="Rigid" type="InsulationRigidType"/>
 			<xs:element name="SprayFoam" type="InsulationSprayFoamType"/>
-			<xs:element name="Other" type="xs:string">
+			<xs:element name="Other" type="HPXMLString">
 				<xs:annotation>
 					<xs:documentation>Describe</xs:documentation>
 				</xs:annotation>
@@ -212,8 +212,8 @@
 			<xs:element name="NumberofUnits" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
 			<xs:element name="Manufacturer" type="Manufacturer" minOccurs="0"/>
 			<xs:element name="ModelNumber" type="Model" minOccurs="0"/>
-			<xs:element minOccurs="0" name="AHRINumber" type="xs:string"/>
-			<xs:element minOccurs="0" name="SerialNumber" type="xs:string"/>
+			<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
+			<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 			<xs:element name="ModelYear" type="Year" minOccurs="0"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="ApplianceThirdPartyCertifications"/>
 		</xs:sequence>
@@ -470,7 +470,7 @@
 			<xs:element name="Other">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="Description" type="xs:string"/>
+						<xs:element minOccurs="0" name="Description" type="HPXMLString"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -493,7 +493,7 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
-						<xs:element name="SpaceName" type="xs:string" minOccurs="0"/>
+						<xs:element name="SpaceName" type="HPXMLString" minOccurs="0"/>
 						<xs:element minOccurs="0" name="NumberOfBedrooms" type="IntegerGreaterThanOrEqualToZero"/>
 						<xs:element minOccurs="0" name="FloorArea" type="SurfaceArea">
 							<xs:annotation>
@@ -522,7 +522,7 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
-						<xs:element name="ZoneName" type="xs:string" minOccurs="0"/>
+						<xs:element name="ZoneName" type="HPXMLString" minOccurs="0"/>
 						<xs:element name="ZoneType" type="ZoneType" minOccurs="0"> </xs:element>
 						<xs:element name="Spaces" type="Spaces" minOccurs="0"/>
 						<xs:element minOccurs="0" ref="extension"/>
@@ -1111,7 +1111,7 @@
 											<xs:choice>
 												<xs:element name="AirDistribution" type="AirDistributionInfo"/>
 												<xs:element name="HydronicDistribution" type="HydronicDistributionInfo"/>
-												<xs:element name="Other" type="xs:string">
+												<xs:element name="Other" type="HPXMLString">
 													<xs:annotation>
 														<xs:documentation>describe</xs:documentation>
 													</xs:annotation>
@@ -1174,8 +1174,8 @@
 											<xs:sequence>
 												<xs:group ref="SystemInfo"/>
 												<xs:element minOccurs="0" ref="ConnectedDevice"/>
-												<xs:element minOccurs="0" name="Manufacturer" type="xs:string"/>
-												<xs:element minOccurs="0" name="SerialNumber" type="xs:string"/>
+												<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
+												<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 												<xs:element minOccurs="0" name="FanType" type="VentilationFanType"/>
 												<xs:element minOccurs="0" name="RatedFlowRate" type="xs:double">
 													<xs:annotation>
@@ -1308,8 +1308,8 @@
 									<xs:element name="ModelYear" type="Year" minOccurs="0"/>
 									<xs:element name="Manufacturer" type="Manufacturer" minOccurs="0"/>
 									<xs:element name="ModelNumber" type="Model" minOccurs="0"/>
-									<xs:element minOccurs="0" name="AHRINumber" type="xs:string"/>
-									<xs:element minOccurs="0" name="SerialNumber" type="xs:string"/>
+									<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
+									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction"/>
 									<xs:element minOccurs="0" name="ThirdPartyCertification" type="DHWThirdPartyCertification" maxOccurs="unbounded"/>
 									<xs:element name="TankVolume" type="Volume" minOccurs="0">
@@ -1435,9 +1435,9 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element ref="ConnectedDevice"/>
-									<xs:element minOccurs="0" name="Model" type="xs:string"/>
-									<xs:element minOccurs="0" name="Manufacturer" type="xs:string"/>
-									<xs:element minOccurs="0" name="SerialNumber" type="xs:string"/>
+									<xs:element minOccurs="0" name="Model" type="HPXMLString"/>
+									<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
+									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="ControlTechnology" type="DHWControllerTechnology"/>
 									<xs:element minOccurs="0" name="TemperatureControl" type="DHWTemperatureControl"/>
 									<xs:element minOccurs="0" ref="extension"/>
@@ -1584,8 +1584,8 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
-									<xs:element minOccurs="0" name="Manufacturer" type="xs:string"/>
-									<xs:element minOccurs="0" name="ModelNumber" type="xs:string"/>
+									<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
+									<xs:element minOccurs="0" name="ModelNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" ref="AttachedToZone"/>
 									<xs:element name="SystemType" minOccurs="0" type="SolarThermalSystemType"/>
 									<xs:element name="CollectorArea" type="SurfaceArea" minOccurs="0">
@@ -1752,7 +1752,7 @@
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" name="Manufacturer" type="Manufacturer"/>
 									<xs:element minOccurs="0" name="ModelNumber" type="Model"/>
-									<xs:element minOccurs="0" name="SerialNumber" type="xs:string"/>
+									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
 									<xs:element minOccurs="0" name="Location" type="BatteryLocation"/>
 									<xs:element minOccurs="0" name="GridConnected" type="xs:boolean">
@@ -1809,7 +1809,7 @@
 									<xs:element minOccurs="0" name="NumberofUnits" type="IntegerGreaterThanOrEqualToZero"/>
 									<xs:element minOccurs="0" name="Manufacturer" type="Manufacturer"/>
 									<xs:element maxOccurs="1" minOccurs="0" name="ModelNumber" type="Model"/>
-									<xs:element minOccurs="0" name="SerialNumber" type="xs:string"/>
+									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
 									<xs:element minOccurs="0" name="ChargingLevel" type="EVChargingLevel"/>
 									<xs:element minOccurs="0" name="ChargingConnector" type="EVChargingConnector"/>
@@ -1848,7 +1848,7 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="Model" type="xs:string"/>
+									<xs:element minOccurs="0" name="Model" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
 									<xs:element minOccurs="0" name="ThirdPartyCertification" maxOccurs="unbounded" type="WindThirdPartyCertification"/>
 									<xs:element minOccurs="0" name="AWEARatedAnnualEnergy" type="RatedAnnualkWh">
@@ -2108,7 +2108,7 @@
 			<xs:element name="Other">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="Description" type="xs:string"/>
+						<xs:element minOccurs="0" name="Description" type="HPXMLString"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -2164,17 +2164,17 @@
 												<xs:group ref="SystemInfo"/>
 												<xs:element minOccurs="0" ref="ConnectedDevice"/>
 												<xs:element minOccurs="0" name="Type" type="PoolPumpType"/>
-												<xs:element minOccurs="0" name="Manufacturer" type="xs:string">
+												<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString">
 													<xs:annotation>
 														<xs:documentation>Manufacturer of pool pump.</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="SerialNumber" type="xs:string">
+												<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString">
 													<xs:annotation>
 														<xs:documentation>Serial number of pool pump.</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="ModelNumber" type="xs:string">
+												<xs:element minOccurs="0" name="ModelNumber" type="HPXMLString">
 													<xs:annotation>
 														<xs:documentation>Model number of pool pump.</xs:documentation>
 													</xs:annotation>
@@ -2416,7 +2416,7 @@
 												</xs:element>
 												<xs:element minOccurs="0" name="CombustionVentingSystem" type="RemoteReference"/>
 												<xs:element name="FlueVisualCondition" type="FlueCondition" minOccurs="0"/>
-												<xs:element minOccurs="0" name="FlueConditionNotes" type="xs:string"/>
+												<xs:element minOccurs="0" name="FlueConditionNotes" type="HPXMLString"/>
 												<xs:element name="OutsideTemperatureFlueDraftTest" type="Temperature" minOccurs="0">
 													<xs:annotation>
 														<xs:documentation>[deg F]</xs:documentation>
@@ -2463,7 +2463,7 @@
 																			<xs:documentation>Monitored throughout assessment, not just appliance testing</xs:documentation>
 																		</xs:annotation>
 																	</xs:element>
-																	<xs:element minOccurs="0" name="AmbientCOActionDuringCAZTesting" type="xs:string">
+																	<xs:element minOccurs="0" name="AmbientCOActionDuringCAZTesting" type="HPXMLString">
 																		<xs:annotation>
 																			<xs:documentation>BPI Gold Sheet is one example that shows action levels based upon decision logic</xs:documentation>
 																		</xs:annotation>
@@ -2485,7 +2485,7 @@
 															<xs:element name="FuelType" type="FuelType"/>
 															<xs:element name="LeaksIdentified" type="xs:boolean"/>
 															<xs:element name="LeaksAddressed" type="xs:boolean"/>
-															<xs:element minOccurs="0" name="Notes" type="xs:string"/>
+															<xs:element minOccurs="0" name="Notes" type="HPXMLString"/>
 															<xs:element minOccurs="0" ref="extension"/>
 														</xs:sequence>
 													</xs:complexType>
@@ -2494,7 +2494,7 @@
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="Notes" type="xs:string"/>
+									<xs:element minOccurs="0" name="Notes" type="HPXMLString"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 							</xs:complexType>
@@ -2511,7 +2511,7 @@
 						<xs:element name="COReading" type="COReading" minOccurs="0"/>
 						<xs:element minOccurs="0" name="TimeofCOReading" type="xs:dateTime"/>
 						<xs:element name="GasLeaksIdentified" type="xs:boolean" minOccurs="0"/>
-						<xs:element name="ActionsTaken" type="xs:string" minOccurs="0"/>
+						<xs:element name="ActionsTaken" type="HPXMLString" minOccurs="0"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -2534,7 +2534,7 @@
 								<xs:documentation>Did the contracted scope of work include window replacement?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="LeadSafeCertificationNumber" type="xs:string">
+						<xs:element minOccurs="0" name="LeadSafeCertificationNumber" type="HPXMLString">
 							<xs:annotation>
 								<xs:documentation>Certification Number of the EPA Lead-Safe Certified firm that performed the work.</xs:documentation>
 							</xs:annotation>
@@ -2569,7 +2569,7 @@
 								<xs:documentation>Was the homeowner provided with educational material?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="ActionsTaken" type="xs:string"/>
+						<xs:element minOccurs="0" name="ActionsTaken" type="HPXMLString"/>
 						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecs" type="xs:boolean">
 							<xs:annotation>
 								<xs:documentation>If moisture management of a crawlspace (e.g., installation of polyethylene sheeting) or radon mitigation measures were a part of the scope of
@@ -2667,7 +2667,7 @@
 							</xs:annotation>
 						</xs:element>
 						<xs:element minOccurs="0" name="TypeofBlowerDoorTest" type="TypeofBlowerDoorTest"/>
-						<xs:element minOccurs="0" name="ActionsTaken" type="xs:string"/>
+						<xs:element minOccurs="0" name="ActionsTaken" type="HPXMLString"/>
 						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecifications" type="xs:boolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
@@ -2853,7 +2853,7 @@
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="OtherVentilationIssue">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="Description" type="xs:string"/>
+						<xs:element name="Description" type="HPXMLString"/>
 						<xs:element name="Answer" type="YesNoRecommendInstall"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -2863,9 +2863,9 @@
 	</xs:complexType>
 	<xs:complexType name="StatusMessage">
 		<xs:sequence>
-			<xs:element name="MessageType" type="xs:string"/>
-			<xs:element name="MessageID" type="xs:string"/>
-			<xs:element name="Message" type="xs:string"/>
+			<xs:element name="MessageType" type="HPXMLString"/>
+			<xs:element name="MessageID" type="HPXMLString"/>
+			<xs:element name="Message" type="HPXMLString"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 	</xs:complexType>
@@ -2911,8 +2911,8 @@
 			<xs:element name="ModelYear" type="Year" minOccurs="0"/>
 			<xs:element name="Manufacturer" type="Manufacturer" minOccurs="0"/>
 			<xs:element name="ModelNumber" type="Model" minOccurs="0"/>
-			<xs:element minOccurs="0" name="SerialNumber" type="xs:string"/>
-			<xs:element minOccurs="0" name="AHRINumber" type="xs:string"/>
+			<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
+			<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="HVACThirdPartyCertification"/>
 			<xs:element minOccurs="0" name="HasSharedCombustionVentilation" type="xs:boolean"/>
@@ -3071,7 +3071,7 @@
 			<xs:element name="Other">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="Description" type="xs:string"/>
+						<xs:element minOccurs="0" name="Description" type="HPXMLString"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -3347,7 +3347,7 @@
 										</xs:complexType>
 									</xs:element>
 									<xs:element minOccurs="0" name="WalkingScore" type="IntegerGreaterThanOrEqualToZero"/>
-									<xs:element minOccurs="0" name="WalkingScoreSource" type="xs:string"/>
+									<xs:element minOccurs="0" name="WalkingScoreSource" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="FuelTypesAvailable">
 										<xs:annotation>
 											<xs:documentation>Fuels available on site via utility lines/pipes or delivery.</xs:documentation>
@@ -3596,12 +3596,12 @@
 											<xs:documentation>The name of the verification or certification awarded to a new or pre-existing residential or commercial structure. For example: LEED, Energy Star, ICC-700. In cases where more than one certification have been awarded, leverage multiple iterations of the green verification fields via the repeating element method.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="OtherType" type="xs:string">
+									<xs:element minOccurs="0" name="OtherType" type="HPXMLString">
 										<xs:annotation>
 											<xs:documentation>If "other" is selected for GreenBuildingVerification/Type, fill in type here.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Body" type="xs:string">
+									<xs:element minOccurs="0" name="Body" type="HPXMLString">
 										<xs:annotation>
 											<xs:documentation>The name of the body or group providing the verification/certification/rating named in the GreenBuildingVerificationType field. There is almost always a direct correlation between bodies and programs.</xs:documentation>
 										</xs:annotation>
@@ -3611,7 +3611,7 @@
 											<xs:documentation>A final score indicating the performance of energy efficiency design and measures in the home as tested by a third-party rater. Points achieved to earn a certification in the GreenVerificationRating field do not apply to this field. HERS Index is most common with new homes and runs with a lower number being more efficient. A net-zero home uses zero energy and has a HERS score of 0. A home that produces more energy than it uses has a negative score. Home Energy Score is a tool more common for existing homes and runs with a higher number being more efficient. It takes square footage into account and caps with 10 as the highest number of points.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Rating" type="xs:string">
+									<xs:element minOccurs="0" name="Rating" type="HPXMLString">
 										<xs:annotation>
 											<xs:documentation>Many verifications or certifications have a rating system that provides an indication of the structure's level of energy efficiency. When expressed in a numeric value, please use the GreenVerificationMetric field. Verifications and Certifications can also be a name, such as Gold or Silver, which is the purpose of this field.</xs:documentation>
 										</xs:annotation>
@@ -3631,7 +3631,7 @@
 											<xs:documentation>Provides a link to the specific property’s high-performance rating or scoring details directly from and hosted by the sponsoring body of the program. Typically provides thorough details, for example, which points where achieved and how, or in the case of a score what specifically was tested and the results.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Version" type="xs:string">
+									<xs:element minOccurs="0" name="Version" type="HPXMLString">
 										<xs:annotation>
 											<xs:documentation>The version of the certification or verification that was awarded. Some rating programs have a year, a version, or possibly both.</xs:documentation>
 										</xs:annotation>
@@ -3742,7 +3742,7 @@
 			<xs:element minOccurs="0" name="Quantity">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="Units" type="xs:string"/>
+						<xs:element name="Units" type="HPXMLString"/>
 						<xs:element name="Value" type="Quantity"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -3786,7 +3786,7 @@
 			<xs:element minOccurs="0" name="CustomerNotes" type="Notes"/>
 			<xs:element minOccurs="0" name="WorkscopeNotes" type="Notes"/>
 			<xs:element minOccurs="0" name="Status" type="ImprovementStatusType"/>
-			<xs:element minOccurs="0" name="NotInstalledReasonCode" type="xs:string"/>
+			<xs:element minOccurs="0" name="NotInstalledReasonCode" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="InstallingContractor" type="RemoteReference"/>
 			<xs:element minOccurs="0" name="QA">
 				<xs:annotation>
@@ -4055,7 +4055,7 @@
 						<xs:element minOccurs="0" name="FuelInterruptibility" type="FuelInterruptibility"/>
 						<xs:element minOccurs="0" name="SharedEnergySystem" type="SharedEnergySystem"/>
 						<xs:element minOccurs="0" name="IntervalType" type="IntervalType"/>
-						<xs:element minOccurs="0" name="ReadingTimeZone" type="xs:string"/>
+						<xs:element minOccurs="0" name="ReadingTimeZone" type="HPXMLString"/>
 						<xs:element minOccurs="0" name="MarginalEnergyCostRate" type="xs:double">
 							<xs:annotation>
 								<xs:documentation>[$/energy unit] The cost of providing an additional unit of output</xs:documentation>
@@ -4158,7 +4158,7 @@
 	<xs:complexType name="BusinessInfoType">
 		<xs:sequence>
 			<xs:group ref="SystemInfo"/>
-			<xs:element name="BusinessName" type="xs:string"/>
+			<xs:element name="BusinessName" type="HPXMLString"/>
 			<xs:element name="BusinessType" type="BusinessType" minOccurs="0"/>
 			<xs:element name="BusinessSpecialization" type="BusinessSpecialization" minOccurs="0"/>
 			<xs:element name="Certification" type="BusinessCertification" minOccurs="0" maxOccurs="unbounded"/>
@@ -4717,7 +4717,7 @@ If moveable insulation also provides shading, the shading should be documented h
 			<xs:element name="GuttersInstalledorRepaired" type="xs:boolean" minOccurs="0"/>
 			<xs:element name="FlashingInstalledorRepaired" type="xs:boolean" minOccurs="0"/>
 			<xs:element name="FoundationGradingImproved" type="xs:boolean" minOccurs="0"/>
-			<xs:element name="OtherMeasuresImplementedDescription" type="xs:string" minOccurs="0"/>
+			<xs:element name="OtherMeasuresImplementedDescription" type="HPXMLString" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 	</xs:complexType>
@@ -4795,7 +4795,7 @@ If moveable insulation also provides shading, the shading should be documented h
 		<xs:sequence>
 			<xs:element name="JacketInstalledIndicator" type="xs:boolean" minOccurs="0"/>
 			<xs:element name="DispositionofExistingSystem" type="DispositionofExistingSystem" minOccurs="0"/>
-			<xs:element name="RepairsDescription" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="RepairsDescription" type="HPXMLString" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="PipeInsulated" type="PipeInsulated" minOccurs="0"/>
 			<xs:element name="LengthofPipeInsulated" type="LengthMeasurement" minOccurs="0">
 				<xs:annotation>
@@ -4825,7 +4825,7 @@ If moveable insulation also provides shading, the shading should be documented h
 						<xs:element name="SiteID" type="SystemIdentifiersInfoType"/>
 						<xs:element maxOccurs="unbounded" minOccurs="0" ref="ExternalResource"/>
 						<xs:element name="Address" type="AddressInformation"/>
-						<xs:element minOccurs="0" name="SchoolDistrict" type="xs:string"/>
+						<xs:element minOccurs="0" name="SchoolDistrict" type="HPXMLString"/>
 						<xs:element minOccurs="0" name="eGridRegion" type="eGridRegions"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
@@ -4890,7 +4890,7 @@ If moveable insulation also provides shading, the shading should be documented h
 				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="Comment" type="xs:string"/>
+						<xs:element maxOccurs="unbounded" name="Comment" type="HPXMLString"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
@@ -4938,11 +4938,11 @@ If moveable insulation also provides shading, the shading should be documented h
 	<xs:complexType name="WeatherStation">
 		<xs:sequence>
 			<xs:group ref="SystemInfo"/>
-			<xs:element name="Name" type="xs:string"/>
-			<xs:element minOccurs="0" name="City" nillable="true" type="xs:string"/>
+			<xs:element name="Name" type="HPXMLString"/>
+			<xs:element minOccurs="0" name="City" nillable="true" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="State" type="StateCode"/>
-			<xs:element minOccurs="0" name="WBAN" type="xs:string"/>
-			<xs:element minOccurs="0" name="WMO" type="xs:string"/>
+			<xs:element minOccurs="0" name="WBAN" type="HPXMLString"/>
+			<xs:element minOccurs="0" name="WMO" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="Type" type="WeatherStationType"/>
 			<xs:element minOccurs="0" name="Use" nillable="true" type="WeatherStationUse"/>
 			<xs:element minOccurs="0" ref="extension"/>
@@ -4973,7 +4973,7 @@ If moveable insulation also provides shading, the shading should be documented h
 				</xs:annotation>
 			</xs:element>
 			<xs:element minOccurs="0" name="MeasurementLocation" type="AirHandlerStaticPressureMeasurementLocation"/>
-			<xs:element minOccurs="0" name="LocationDescription" type="xs:string"/>
+			<xs:element minOccurs="0" name="LocationDescription" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="StaticPressureSource" type="StaticPressureSource"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
@@ -5063,7 +5063,7 @@ If moveable insulation also provides shading, the shading should be documented h
 						</xs:restriction>
 					</xs:simpleType>
 				</xs:element>
-				<xs:element name="Description" type="xs:string"/>
+				<xs:element name="Description" type="HPXMLString"/>
 				<xs:element minOccurs="0" ref="extension"/>
 			</xs:sequence>
 			<xs:attribute name="id" use="required"/>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -98,7 +98,7 @@
 							system and to provide feedback that may result in quality improvements (BPI, 2006). </xs:documentation>
 					</xs:annotation>
 				</xs:element>
-				<xs:element minOccurs="0" name="Date" type="xs:date"/>
+				<xs:element minOccurs="0" name="Date" type="HPXMLDate"/>
 				<xs:element minOccurs="0" ref="extension"/>
 			</xs:sequence>
 		</xs:complexType>
@@ -134,7 +134,7 @@
 				<xs:element name="UtilityName" type="HPXMLString" minOccurs="0"/>
 				<xs:element minOccurs="0" name="MeterNumber" type="HPXMLString"/>
 				<xs:element name="UtilityAccountNumber" type="HPXMLString" minOccurs="0"/>
-				<xs:element minOccurs="0" name="Permission" type="xs:boolean"/>
+				<xs:element minOccurs="0" name="Permission" type="HPXMLBoolean"/>
 				<xs:element name="UtilityServiceTypeProvided" type="ConsumptionType" minOccurs="0" maxOccurs="unbounded"/>
 				<xs:element minOccurs="0" name="BusinessInfo" type="BusinessInfoType"/>
 				<xs:element maxOccurs="unbounded" minOccurs="0" name="BusinessContactInfo" type="BusinessContactInfoType"/>
@@ -182,7 +182,7 @@
 					<xs:documentation>This should indicate the effective R-value of the complete assembly including any air films or other treatments.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="MisalignedInsulation" type="xs:boolean"/>
+			<xs:element minOccurs="0" name="MisalignedInsulation" type="HPXMLBoolean"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="Layer">
 				<xs:complexType>
 					<xs:sequence maxOccurs="1">
@@ -225,18 +225,18 @@
 					<xs:element minOccurs="0" name="Type" type="ClothesDryerType"/>
 					<xs:element minOccurs="0" name="Location" type="LaundryMachineLocation"/>
 					<xs:element name="FuelType" type="FuelType" minOccurs="0"/>
-					<xs:element minOccurs="0" name="Usage" type="xs:double">
+					<xs:element minOccurs="0" name="Usage" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>loads/week</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="EnergyFactor" type="xs:double">
+					<xs:element minOccurs="0" name="EnergyFactor" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>[lbs dry clothes/kWh] The energy performance metric for ENERGY STAR certified residential clothes dryers prior to September 13, 2013. The new metric is
 								Combined Energy Factor.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="CombinedEnergyFactor" type="xs:double">
+					<xs:element minOccurs="0" name="CombinedEnergyFactor" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>[lbs dry clothes/kWh] The energy performance metric for ENERGY STAR certified residential clothes dryers as of September 13, 2013, it includes the active
 								drying cycle energy as well as energy consumed during Stand-by and Off modes.</xs:documentation>
@@ -263,29 +263,29 @@
 				<xs:sequence>
 					<xs:element name="Type" type="ClothesWasherType" minOccurs="0"/>
 					<xs:element minOccurs="0" name="Location" type="LaundryMachineLocation"/>
-					<xs:element name="ModifiedEnergyFactor" type="xs:double" minOccurs="0">
+					<xs:element name="ModifiedEnergyFactor" type="HPXMLDouble" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>The energy performance metric for ENERGY STAR certified residential clothes washers prior to March 7, 2015. The new metric is Integrated Modified Energy
 								Factor.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="IntegratedModifiedEnergyFactor" type="xs:double" minOccurs="0">
+					<xs:element name="IntegratedModifiedEnergyFactor" type="HPXMLDouble" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>The energy performance metric for ENERGY STAR certified residential clothes washers as of March 7, 2015.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="WaterFactor" type="xs:double" minOccurs="0">
+					<xs:element name="WaterFactor" type="HPXMLDouble" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>The water performance metric for ENERGY STAR certified residential clothes washers prior to March 7, 2015. The new metric is Integrated Water
 								Factor.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="IntegratedWaterFactor" type="xs:double" minOccurs="0">
+					<xs:element name="IntegratedWaterFactor" type="HPXMLDouble" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>The water performance metric for ENERGY STAR certified residential clothes washers as of March 7, 2015.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="Usage" type="xs:double">
+					<xs:element minOccurs="0" name="Usage" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>loads/week</xs:documentation>
 						</xs:annotation>
@@ -295,22 +295,22 @@
 							<xs:documentation>kWh/yr</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="LabelElectricRate" type="xs:double">
+					<xs:element minOccurs="0" name="LabelElectricRate" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>$/kWh</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="LabelGasRate" type="xs:double">
+					<xs:element minOccurs="0" name="LabelGasRate" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>$/therm</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="LabelAnnualGasCost" type="xs:double">
+					<xs:element minOccurs="0" name="LabelAnnualGasCost" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>$</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="Capacity" type="xs:double">
+					<xs:element minOccurs="0" name="Capacity" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>ft^3</xs:documentation>
 						</xs:annotation>
@@ -328,13 +328,13 @@
 				<xs:sequence>
 					<xs:element minOccurs="0" name="Type" type="DishwasherType"/>
 					<xs:element minOccurs="0" name="Fuel" type="FuelType"/>
-					<xs:element name="HeatDryDefaultOff" type="xs:boolean" minOccurs="0"/>
-					<xs:element name="AuxillaryWaterHeaterDefaultOff" type="xs:boolean" minOccurs="0"/>
+					<xs:element name="HeatDryDefaultOff" type="HPXMLBoolean" minOccurs="0"/>
+					<xs:element name="AuxillaryWaterHeaterDefaultOff" type="HPXMLBoolean" minOccurs="0"/>
 					<xs:element minOccurs="0" name="RatedAnnualkWh" type="RatedAnnualkWh"/>
 					<xs:element minOccurs="0" name="EnergyFactor" type="EnergyFactor"/>
 					<xs:element minOccurs="0" name="RatedWaterGalPerCycle" type="RatedWaterGalPerCycle"/>
 					<xs:element minOccurs="0" name="PlaceSettingCapacity" type="IntegerGreaterThanZero"/>
-					<xs:element minOccurs="0" name="Usage" type="xs:double">
+					<xs:element minOccurs="0" name="Usage" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>loads/week</xs:documentation>
 						</xs:annotation>
@@ -368,7 +368,7 @@
 					<xs:element name="Type" type="RefrigeratorStyle" minOccurs="0"/>
 					<xs:element minOccurs="0" name="Location" type="RefrigeratorLocation"/>
 					<xs:element name="RatedAnnualkWh" type="RatedAnnualkWh" minOccurs="0"/>
-					<xs:element name="PrimaryIndicator" type="xs:boolean" minOccurs="0">
+					<xs:element name="PrimaryIndicator" type="HPXMLBoolean" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>True if it is the primary refrigerator</xs:documentation>
 						</xs:annotation>
@@ -398,7 +398,7 @@
 			<xs:extension base="ApplianceTypeSummaryInfo">
 				<xs:sequence>
 					<xs:element minOccurs="0" name="Location" type="DehumidifierLocation"/>
-					<xs:element minOccurs="0" name="Efficiency" type="xs:double">
+					<xs:element minOccurs="0" name="Efficiency" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>[L/kWh]</xs:documentation>
 						</xs:annotation>
@@ -413,7 +413,7 @@
 			<xs:extension base="ApplianceTypeSummaryInfo">
 				<xs:sequence>
 					<xs:element name="FuelType" type="FuelType" minOccurs="0"/>
-					<xs:element minOccurs="0" name="IsInduction" type="xs:boolean"/>
+					<xs:element minOccurs="0" name="IsInduction" type="HPXMLBoolean"/>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -424,7 +424,7 @@
 			<xs:extension base="ApplianceTypeSummaryInfo">
 				<xs:sequence>
 					<xs:element name="FuelType" type="FuelType" minOccurs="0"/>
-					<xs:element minOccurs="0" name="IsConvection" type="xs:boolean"/>
+					<xs:element minOccurs="0" name="IsConvection" type="HPXMLBoolean"/>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -650,9 +650,9 @@
 									<xs:element minOccurs="1" name="GarageType">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="AttachedtoHouse" type="xs:boolean"/>
-												<xs:element minOccurs="0" name="Vented" type="xs:boolean"/>
-												<xs:element minOccurs="0" name="Conditioned" type="xs:boolean"/>
+												<xs:element minOccurs="0" name="AttachedtoHouse" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="Vented" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
 										</xs:complexType>
@@ -710,7 +710,7 @@
 											<xs:documentation>Pitch of roof ?/12</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="RadiantBarrier" type="xs:boolean" minOccurs="0"/>
+									<xs:element name="RadiantBarrier" type="HPXMLBoolean" minOccurs="0"/>
 									<xs:element name="RadiantBarrierLocation" type="RadiantBarrierLocation" minOccurs="0"/>
 									<xs:element minOccurs="0" name="Insulation" type="InsulationInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
@@ -950,7 +950,7 @@
 											<xs:documentation>[ft] Width from slab edge inward of horizontal under-slab insulation</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="UnderSlabInsulationSpansEntireSlab" type="xs:boolean"/>
+									<xs:element minOccurs="0" name="UnderSlabInsulationSpansEntireSlab" type="HPXMLBoolean"/>
 									<xs:element minOccurs="0" name="OnGradeExposedPerimeter" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Perimeter of slab measured in feet that is on-grade (2 ft. below grade or less) and exposed to ambient conditions.</xs:documentation>
@@ -1009,7 +1009,7 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="WindowInfo"/>
-									<xs:element minOccurs="0" name="SolarTube" type="xs:boolean"/>
+									<xs:element minOccurs="0" name="SolarTube" type="HPXMLBoolean"/>
 									<xs:element minOccurs="0" name="Pitch" type="Pitch">
 										<xs:annotation>
 											<xs:documentation>Pitch of skylight ?/12</xs:documentation>
@@ -1052,8 +1052,8 @@
 									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
 									<xs:element minOccurs="0" name="DoorType" type="DoorType"/>
 									<xs:element name="DoorMaterial" type="DoorMaterial" minOccurs="0"/>
-									<xs:element minOccurs="0" name="WeatherStripping" type="xs:boolean"/>
-									<xs:element name="StormDoor" type="xs:boolean" minOccurs="0"/>
+									<xs:element minOccurs="0" name="WeatherStripping" type="HPXMLBoolean"/>
+									<xs:element name="StormDoor" type="HPXMLBoolean" minOccurs="0"/>
 									<xs:element name="RValue" type="RValue" minOccurs="0"/>
 									<xs:element minOccurs="0" name="LeakinessDescription" type="BuildingLeakiness"/>
 									<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="DoorThirdPartyCertifications"/>
@@ -1124,14 +1124,14 @@
 											<xs:documentation>[sq.ft.] Conditioned floor area that this distribution system serves.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AnnualHeatingDistributionSystemEfficiency" type="xs:double">
+									<xs:element minOccurs="0" name="AnnualHeatingDistributionSystemEfficiency" type="HPXMLDouble">
 										<xs:annotation>
 											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for heating, the DSE may be approximated by equation
 												3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use
 												History.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AnnualCoolingDistributionSystemEfficiency" type="xs:double">
+									<xs:element minOccurs="0" name="AnnualCoolingDistributionSystemEfficiency" type="HPXMLDouble">
 										<xs:annotation>
 											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for cooling, the DSE may be approximated by equation
 												3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use
@@ -1147,7 +1147,7 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:element minOccurs="0" name="Schedule" type="HVACMaintenanceSchedule"/>
-									<xs:element minOccurs="0" name="ACReplacedinLastTenYears" type="xs:boolean"/>
+									<xs:element minOccurs="0" name="ACReplacedinLastTenYears" type="HPXMLBoolean"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 							</xs:complexType>
@@ -1177,17 +1177,17 @@
 												<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
 												<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 												<xs:element minOccurs="0" name="FanType" type="VentilationFanType"/>
-												<xs:element minOccurs="0" name="RatedFlowRate" type="xs:double">
+												<xs:element minOccurs="0" name="RatedFlowRate" type="HPXMLDouble">
 													<xs:annotation>
 														<xs:documentation>[CFM] as rated by manufacturer</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="CalculatedFlowRate" type="xs:double">
+												<xs:element minOccurs="0" name="CalculatedFlowRate" type="HPXMLDouble">
 													<xs:annotation>
 														<xs:documentation>[CFM] as calculated using duct size, prescriptive approach</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="TestedFlowRate" type="xs:double">
+												<xs:element minOccurs="0" name="TestedFlowRate" type="HPXMLDouble">
 													<xs:annotation>
 														<xs:documentation>[CFM] as tested by assessor/auditor/inspector</xs:documentation>
 													</xs:annotation>
@@ -1197,7 +1197,7 @@
 														<xs:documentation>24 = continuous, less than 24 = intermittent</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="DeliveredVentilation" type="xs:double">
+												<xs:element minOccurs="0" name="DeliveredVentilation" type="HPXMLDouble">
 													<xs:annotation>
 														<xs:documentation>[CFM]</xs:documentation>
 													</xs:annotation>
@@ -1205,16 +1205,16 @@
 												<xs:element minOccurs="0" name="FanControlProperlyLabeled" type="BooleanWithNA"/>
 												<xs:element minOccurs="0" name="ProperlyVented" type="BooleanWithNA"/>
 												<xs:element minOccurs="0" name="FanLocation" type="VentilationFanLocation"/>
-												<xs:element minOccurs="0" name="UsedForLocalVentilation" type="xs:boolean"/>
-												<xs:element minOccurs="0" name="UsedForWholeBuildingVentilation" type="xs:boolean"/>
-												<xs:element minOccurs="0" name="UsedForSeasonalCoolingLoadReduction" type="xs:boolean"/>
-												<xs:element minOccurs="0" name="UsedForGarageVentilation" type="xs:boolean"/>
-												<xs:element minOccurs="0" name="RatedNoise" type="xs:double">
+												<xs:element minOccurs="0" name="UsedForLocalVentilation" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="UsedForWholeBuildingVentilation" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="UsedForSeasonalCoolingLoadReduction" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="UsedForGarageVentilation" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="RatedNoise" type="HPXMLDouble">
 													<xs:annotation>
 														<xs:documentation>[sones] from manufacturer's info</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="TestedNoise" type="xs:double">
+												<xs:element minOccurs="0" name="TestedNoise" type="HPXMLDouble">
 													<xs:annotation>
 														<xs:documentation>[sones] as tested in field</xs:documentation>
 													</xs:annotation>
@@ -1252,7 +1252,7 @@
 															accounted for in the energy model. Values for some products can be found at the Home Ventilating Institute (hvi.org).</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="FanPower" type="xs:double">
+												<xs:element minOccurs="0" name="FanPower" type="HPXMLDouble">
 													<xs:annotation>
 														<xs:documentation>[W]</xs:documentation>
 													</xs:annotation>
@@ -1393,25 +1393,25 @@
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
-									<xs:element name="MeetsACCA5QIHVACSpecification" type="xs:boolean" minOccurs="0"/>
+									<xs:element name="MeetsACCA5QIHVACSpecification" type="HPXMLBoolean" minOccurs="0"/>
 									<xs:element name="HotWaterTemperature" type="Temperature" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg F]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HasMixingValve" type="xs:boolean"/>
-									<xs:element minOccurs="0" name="UsesDesuperheater" type="xs:boolean">
+									<xs:element minOccurs="0" name="HasMixingValve" type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="UsesDesuperheater" type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Indicates whether this water heater uses a desuperheater. The attached heat pump or air conditioner can be referenced in the
 												RelatedHVACSystem element.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HasSharedCombustionVentilation" type="xs:boolean"/>
-									<xs:element minOccurs="0" name="CombustionVentilationOrphaned" type="xs:boolean"/>
+									<xs:element minOccurs="0" name="HasSharedCombustionVentilation" type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="CombustionVentilationOrphaned" type="HPXMLBoolean"/>
 									<xs:element name="CombustionVentingSystem" minOccurs="0" type="LocalReference"> </xs:element>
-									<xs:element minOccurs="0" name="AutomaticVentDamper" type="xs:boolean"/>
-									<xs:element minOccurs="0" name="PilotLight" type="xs:boolean"/>
-									<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="xs:boolean"/>
+									<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
 									<xs:element name="RelatedHVACSystem" type="LocalReference" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>Reference a HeatingSystem, HeatPump, or CoolingSystem.</xs:documentation>
@@ -1504,7 +1504,7 @@
 										<xs:complexType>
 											<xs:sequence>
 												<xs:element minOccurs="0" name="FacilitiesConnected" type="DrainWaterHeatRecoveryFacilitiesConnected"/>
-												<xs:element minOccurs="0" name="EqualFlow" type="xs:boolean"/>
+												<xs:element minOccurs="0" name="EqualFlow" type="HPXMLBoolean"/>
 												<xs:element minOccurs="0" name="Efficiency" type="Fraction">
 													<xs:annotation>
 														<xs:documentation>Efficiency percent expressed as a fraction from 0-1.</xs:documentation>
@@ -1532,17 +1532,17 @@
 											<xs:documentation>Number of similar water fixtures.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FlowRate" type="xs:double">
+									<xs:element minOccurs="0" name="FlowRate" type="HPXMLDouble">
 										<xs:annotation>
 											<xs:documentation>[gallons per minute] flow rate of water</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="LowFlow" type="xs:boolean">
+									<xs:element minOccurs="0" name="LowFlow" type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Is the fixture considered low-flow?</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FaucetAerator" type="xs:boolean">
+									<xs:element minOccurs="0" name="FaucetAerator" type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Does this faucet have an aerator?</xs:documentation>
 										</xs:annotation>
@@ -1552,7 +1552,7 @@
 											<xs:documentation>[minutes] Number of minutes per day a water fixture operates.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="TemperatureInitiatedShowerFlowRestrictionValve" type="xs:boolean">
+									<xs:element minOccurs="0" name="TemperatureInitiatedShowerFlowRestrictionValve" type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Does the shower have a device that restricts the flow of water automatically once it has reached temperature?</xs:documentation>
 										</xs:annotation>
@@ -1755,7 +1755,7 @@
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
 									<xs:element minOccurs="0" name="Location" type="BatteryLocation"/>
-									<xs:element minOccurs="0" name="GridConnected" type="xs:boolean">
+									<xs:element minOccurs="0" name="GridConnected" type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Has the ability to feed electricity back on to the grid.</xs:documentation>
 										</xs:annotation>
@@ -1782,7 +1782,7 @@
 											<xs:documentation>[W] The peak power that the battery can generate for a short period of time.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NominalVoltage" type="xs:decimal">
+									<xs:element minOccurs="0" name="NominalVoltage" type="HPXMLDecimal">
 										<xs:annotation>
 											<xs:documentation>[V] The nominal voltage is the battery voltage when the state of charge is 0.5 (midway between being fully charged, and fully discharged) with a 0.2C discharge current.</xs:documentation>
 										</xs:annotation>
@@ -1857,7 +1857,7 @@
 												mph)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AWEARatedSoundLevel" type="xs:double">
+									<xs:element minOccurs="0" name="AWEARatedSoundLevel" type="HPXMLDouble">
 										<xs:annotation>
 											<xs:documentation>[dBA] the sound pressure level not exceeded by the wind turbine 95% of the time at a distance of 60 meters from the rotor with an average
 												wind speed of 5 m/s (11.2 mph). </xs:documentation>
@@ -1931,7 +1931,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="AttachedToSpace"/>
 						<xs:element minOccurs="0" name="Location" type="LightingLocation"/>
-						<xs:element name="NumberofUnits" type="xs:integer" minOccurs="0"/>
+						<xs:element name="NumberofUnits" type="HPXMLInteger" minOccurs="0"/>
 						<xs:element minOccurs="0" name="FractionofUnitsInLocation" type="Fraction">
 							<xs:annotation>
 								<xs:documentation>The fraction of lighting units in the specified Location, where all the fractions for the Location sum to 1. If a Location is not specified, fractions
@@ -1939,14 +1939,14 @@
 							</xs:annotation>
 						</xs:element>
 						<xs:element minOccurs="0" name="LightingType" type="LightingType"/>
-						<xs:element minOccurs="0" name="AverageLumens" type="xs:double">
+						<xs:element minOccurs="0" name="AverageLumens" type="HPXMLDouble">
 							<xs:annotation>
 								<xs:documentation>Lumens is a measure of light output (brightness) as opposed to watts, which measures energy consumption. The EPA and DOE encourages people to
 									determine the amount of light they need (or brightness) first before purchasing a light bulb. Once brightness is determined, you can look for the bulb with the
 									lowest watts.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="AverageWattage" type="xs:double" minOccurs="0">
+						<xs:element name="AverageWattage" type="HPXMLDouble" minOccurs="0">
 							<xs:annotation>
 								<xs:documentation>[W] per unit</xs:documentation>
 							</xs:annotation>
@@ -2014,12 +2014,12 @@
 											</xs:restriction>
 										</xs:simpleType>
 									</xs:element>
-									<xs:element minOccurs="0" name="Airflow" type="xs:double">
+									<xs:element minOccurs="0" name="Airflow" type="HPXMLDouble">
 										<xs:annotation>
 											<xs:documentation>[CFM]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Efficiency" type="xs:double">
+									<xs:element minOccurs="0" name="Efficiency" type="HPXMLDouble">
 										<xs:annotation>
 											<xs:documentation>[CFM/watt] The efficiency rating of a ceiling fan as determined by the test procedure defined by the Environmental Protection Agency's
 												ENERGY STAR Testing Facility Guidance Manual: Building a Testing Facility and Performing the Solid State Test Method for ENERGY STAR Qualified Ceiling
@@ -2047,7 +2047,7 @@
 			<xs:element name="Incandescent">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="Halogen" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="Halogen" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -2211,7 +2211,7 @@
 															(e.g., total horsepower = rated horsepower * service factor) (ANSI/APSP/ICC-15 2011).</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="ServiceFactor" type="xs:double">
+												<xs:element minOccurs="0" name="ServiceFactor" type="HPXMLDouble">
 													<xs:annotation>
 														<xs:documentation>A multiplier applied to the rated horsepower of a pump motor to indicate the percent above nameplate horsepower at which the
 															motor can operate continuously without exceeding its allowable insulation class temperature limit, provided that other design parameters,
@@ -2327,7 +2327,7 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:element name="Units" type="PlugLoadUnits"/>
-									<xs:element name="Value" type="xs:double"/>
+									<xs:element name="Value" type="HPXMLDouble"/>
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
@@ -2343,8 +2343,8 @@
 			<xs:element minOccurs="0" name="General">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="TestsCompleted" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="TestsPassed" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="TestsCompleted" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="TestsPassed" type="HPXMLBoolean"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
@@ -2400,12 +2400,12 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element name="DepressurizationFindingPoorCase" type="DepressurizationFindingPoorCase" minOccurs="0"/>
-									<xs:element name="AmountAmbientCOinCAZduringTesting" type="xs:double" minOccurs="0">
+									<xs:element name="AmountAmbientCOinCAZduringTesting" type="HPXMLDouble" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>parts per million (ppm)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="AmbientCOinCAZExceeded35ppmduringTesting" type="xs:boolean" minOccurs="0"/>
+									<xs:element name="AmbientCOinCAZExceeded35ppmduringTesting" type="HPXMLBoolean" minOccurs="0"/>
 									<xs:element minOccurs="0" name="CombustionApplianceTest" maxOccurs="unbounded">
 										<xs:complexType>
 											<xs:sequence minOccurs="0">
@@ -2458,7 +2458,7 @@
 														<xs:complexContent>
 															<xs:extension base="CAZApplianceReading">
 																<xs:sequence>
-																	<xs:element name="MaxAmbientCOinLivingSpaceDuringAudit" minOccurs="0" type="xs:double">
+																	<xs:element name="MaxAmbientCOinLivingSpaceDuringAudit" minOccurs="0" type="HPXMLDouble">
 																		<xs:annotation>
 																			<xs:documentation>Monitored throughout assessment, not just appliance testing</xs:documentation>
 																		</xs:annotation>
@@ -2483,8 +2483,8 @@
 													<xs:complexType>
 														<xs:sequence>
 															<xs:element name="FuelType" type="FuelType"/>
-															<xs:element name="LeaksIdentified" type="xs:boolean"/>
-															<xs:element name="LeaksAddressed" type="xs:boolean"/>
+															<xs:element name="LeaksIdentified" type="HPXMLBoolean"/>
+															<xs:element name="LeaksAddressed" type="HPXMLBoolean"/>
 															<xs:element minOccurs="0" name="Notes" type="HPXMLString"/>
 															<xs:element minOccurs="0" ref="extension"/>
 														</xs:sequence>
@@ -2507,10 +2507,10 @@
 					<xs:sequence>
 						<xs:element name="StoveID" type="SystemIdentifiersInfoType"/>
 						<xs:element minOccurs="0" name="StoveFuel" type="FuelType"/>
-						<xs:element name="HeatingStoveProperlyVented" type="xs:boolean" minOccurs="0"/>
+						<xs:element name="HeatingStoveProperlyVented" type="HPXMLBoolean" minOccurs="0"/>
 						<xs:element name="COReading" type="COReading" minOccurs="0"/>
-						<xs:element minOccurs="0" name="TimeofCOReading" type="xs:dateTime"/>
-						<xs:element name="GasLeaksIdentified" type="xs:boolean" minOccurs="0"/>
+						<xs:element minOccurs="0" name="TimeofCOReading" type="HPXMLDateTime"/>
+						<xs:element name="GasLeaksIdentified" type="HPXMLBoolean" minOccurs="0"/>
 						<xs:element name="ActionsTaken" type="HPXMLString" minOccurs="0"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
@@ -2519,17 +2519,17 @@
 			<xs:element minOccurs="0" name="LeadPaint">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="Disturbed6SqFtIntPaint" type="xs:boolean" minOccurs="0">
+						<xs:element name="Disturbed6SqFtIntPaint" type="HPXMLBoolean" minOccurs="0">
 							<xs:annotation>
 								<xs:documentation>For a home built before 1978, did the contracted scope of work disturb greater than 6 sq.ft. of interior painted surfaces? </xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="Disturbed20SqFtExtPaint" type="xs:boolean">
+						<xs:element minOccurs="0" name="Disturbed20SqFtExtPaint" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>For a home built before 1978, did the contracted scope of work disturb greater than 20 sf of exterior painted surfaces?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="WindowReplacement" type="xs:boolean">
+						<xs:element minOccurs="0" name="WindowReplacement" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Did the contracted scope of work include window replacement?</xs:documentation>
 							</xs:annotation>
@@ -2546,15 +2546,15 @@
 			<xs:element minOccurs="0" name="Radon">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="RadonTested" type="xs:boolean" minOccurs="0"/>
+						<xs:element name="RadonTested" type="HPXMLBoolean" minOccurs="0"/>
 						<xs:element maxOccurs="unbounded" minOccurs="0" name="RadonTest">
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="StartDateTime" type="xs:dateTime"/>
-									<xs:element minOccurs="0" name="EndDateTime" type="xs:dateTime"/>
+									<xs:element minOccurs="0" name="StartDateTime" type="HPXMLDateTime"/>
+									<xs:element minOccurs="0" name="EndDateTime" type="HPXMLDateTime"/>
 									<xs:element minOccurs="0" name="TestLocation" type="RadonTestLocation"/>
-									<xs:element name="RadonTestResults" type="xs:double" minOccurs="0">
+									<xs:element name="RadonTestResults" type="HPXMLDouble" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>in pCi/L</xs:documentation>
 										</xs:annotation>
@@ -2564,13 +2564,13 @@
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
-						<xs:element minOccurs="0" name="EducationMaterialProvided" type="xs:boolean">
+						<xs:element minOccurs="0" name="EducationMaterialProvided" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Was the homeowner provided with educational material?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element minOccurs="0" name="ActionsTaken" type="HPXMLString"/>
-						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecs" type="xs:boolean">
+						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecs" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>If moisture management of a crawlspace (e.g., installation of polyethylene sheeting) or radon mitigation measures were a part of the scope of
 									work,were measures installed to be compliant with one of the following: - Specifications of EPA’s Indoor airPLUS program - Techniques detailed in EPA's
@@ -2578,7 +2578,7 @@
 									7.3)</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="ResultBelowActionLevel" type="xs:boolean">
+						<xs:element minOccurs="0" name="ResultBelowActionLevel" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Was the result less than 4 pCi/L</xs:documentation>
 							</xs:annotation>
@@ -2590,32 +2590,32 @@
 			<xs:element minOccurs="0" name="SourcePollutants">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="UnventedCombustionAppliancesinLivingArea" type="xs:boolean">
+						<xs:element minOccurs="0" name="UnventedCombustionAppliancesinLivingArea" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Are there unvented combustion heating or hearth appliances present in the living area?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="ConformanceWithANSIZ21_11_2" type="xs:boolean">
+						<xs:element minOccurs="0" name="ConformanceWithANSIZ21_11_2" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>If yes, does the appliance conform with ANSI Z21.11.2? </xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="PrimaryHeatingSource" type="xs:boolean">
+						<xs:element minOccurs="0" name="PrimaryHeatingSource" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>If yes, is the appliance used as a primary source of heating?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="AttachedGarage" type="xs:boolean">
+						<xs:element minOccurs="0" name="AttachedGarage" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Does home have attached garage?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="GarageContinuousAirBarrier" type="xs:boolean">
+						<xs:element minOccurs="0" name="GarageContinuousAirBarrier" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>If yes, is there a continuous air barrier between garage and living space?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="GarageExhaustFan" type="xs:boolean">
+						<xs:element minOccurs="0" name="GarageExhaustFan" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>If yes, is there an exhaust fan in garage?</xs:documentation>
 							</xs:annotation>
@@ -2627,17 +2627,17 @@
 			<xs:element minOccurs="0" name="Pests">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="IndicationsofPests" type="xs:boolean">
+						<xs:element minOccurs="0" name="IndicationsofPests" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Indications of pest entry or damage?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="EvidenceofPesticide" type="xs:boolean">
+						<xs:element minOccurs="0" name="EvidenceofPesticide" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Evidence of pesticide, insecticide use?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="IndustryStandardCompliance" type="xs:boolean">
+						<xs:element minOccurs="0" name="IndustryStandardCompliance" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Do measures comply with industry standards to prevent pest entry? NOTE: This is for ALL measures that may create entry points for vermin. For example,
 									air sealing measures identified to reduce infiltration should have proper sealants - even if those measures were not recommended/installed for pest control
@@ -2651,24 +2651,24 @@
 			<xs:element minOccurs="0" name="Asbestos">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="AsbestosSuspected" type="xs:boolean">
+						<xs:element minOccurs="0" name="AsbestosSuspected" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Was asbestos suspected?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="TestedForAsbestos" type="xs:boolean">
+						<xs:element minOccurs="0" name="TestedForAsbestos" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Was substance tested for asbestos?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="AsbestosFound" type="xs:boolean">
+						<xs:element minOccurs="0" name="AsbestosFound" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Was asbestos found?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element minOccurs="0" name="TypeofBlowerDoorTest" type="TypeofBlowerDoorTest"/>
 						<xs:element minOccurs="0" name="ActionsTaken" type="HPXMLString"/>
-						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecifications" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecifications" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -2676,7 +2676,7 @@
 			<xs:element minOccurs="0" name="SprayFoam">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="SprayFoamInstalled" type="xs:boolean">
+						<xs:element minOccurs="0" name="SprayFoamInstalled" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Was spray foam polyurethane foam and / or other potential sources of indoor pollutants installed or applied as part of the scope of
 									work?</xs:documentation>
@@ -2691,8 +2691,8 @@
 	</xs:complexType>
 	<xs:complexType name="CAZApplianceReading">
 		<xs:sequence>
-			<xs:element minOccurs="0" name="PoorScenario" type="xs:double"/>
-			<xs:element minOccurs="0" name="CurrentCondition" type="xs:double">
+			<xs:element minOccurs="0" name="PoorScenario" type="HPXMLDouble"/>
+			<xs:element minOccurs="0" name="CurrentCondition" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>This element is formerly known as "spillage, draft, and CO readings under natural conditions" as explained in BPI's Gold Sheet "Combustion Safety Test Procedure
 						for Vented Appliances."</xs:documentation>
@@ -2706,11 +2706,11 @@
 			<xs:element minOccurs="0" name="ItemsRunning">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="BathExhaustFan" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="KitchenExhaustFan" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="ClothesDryer" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="CentralVacuum" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="AirHandler" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="BathExhaustFan" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="KitchenExhaustFan" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="ClothesDryer" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="CentralVacuum" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="AirHandler" type="HPXMLBoolean"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
@@ -2722,7 +2722,7 @@
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="Pressure" type="xs:double">
+			<xs:element minOccurs="0" name="Pressure" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[Pa]</xs:documentation>
 				</xs:annotation>
@@ -2774,15 +2774,15 @@
 					<xs:documentation>ASHRAE 62.2-2010 has an infiltration credit. ASHRAE 62-89 and 62.2-2013 do not have infiltration credits.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="LocalWeatherFactor" type="xs:double"/>
-			<xs:element minOccurs="0" name="NFactor" type="xs:double"/>
-			<xs:element minOccurs="0" name="InfiltrationCreditCFMnat" type="xs:integer">
+			<xs:element minOccurs="0" name="LocalWeatherFactor" type="HPXMLDouble"/>
+			<xs:element minOccurs="0" name="NFactor" type="HPXMLDouble"/>
+			<xs:element minOccurs="0" name="InfiltrationCreditCFMnat" type="HPXMLInteger">
 				<xs:annotation>
 					<xs:documentation>This is just the # of the calculated infiltration credit.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:sequence minOccurs="0">
-				<xs:element name="RequiredVentilationRate" type="xs:double">
+				<xs:element name="RequiredVentilationRate" type="HPXMLDouble">
 					<xs:annotation>
 						<xs:documentation>This is the net amount of continuous ventilation needed AFTER infiltration credit is applied (if any)</xs:documentation>
 					</xs:annotation>
@@ -2797,32 +2797,32 @@
 		<xs:sequence>
 			<xs:group ref="SystemInfo"/>
 			<xs:element minOccurs="0" name="Location" type="SpotVentilationLocation"/>
-			<xs:element minOccurs="0" name="IntermittentExhaustRate" type="xs:double">
+			<xs:element minOccurs="0" name="IntermittentExhaustRate" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>This is amount without taking into consideration any infiltration credit</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="ContinuousExhaustRate" type="xs:double">
+			<xs:element minOccurs="0" name="ContinuousExhaustRate" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>This is amount without taking into consideration any infiltration credit</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="WindowOpeningCredit" type="xs:double">
+			<xs:element minOccurs="0" name="WindowOpeningCredit" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Should be 20 cfm, if the local AHJ permits windows to be used for local exhaust</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="RequiredIntermittentExhaustRate" type="xs:double">
+			<xs:element minOccurs="0" name="RequiredIntermittentExhaustRate" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>This is the net amount of continuous ventilation needed AFTER window credit is applied (if any)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="RequiredContinuousExhaustRate" type="xs:double">
+			<xs:element minOccurs="0" name="RequiredContinuousExhaustRate" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>This is the net amount of continuous ventilation needed AFTER window credit is applied (if any)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="InitialAirflorDeficit" type="xs:double">
+			<xs:element minOccurs="0" name="InitialAirflorDeficit" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>The airflow deficit for each bathroom or kitchen is the required airflow less the airflow rating of the exhaust equipment. If there is no exhaust device or if the
 						existing device cannot be measured nor read it, the exhaust device airflow is assumed to be zero.</xs:documentation>
@@ -2873,9 +2873,9 @@
 		<xs:sequence>
 			<xs:element name="Fuel" type="FuelType"/>
 			<xs:element name="Units" type="energyUnitType" minOccurs="0"/>
-			<xs:element name="TotalSavings" type="xs:double" minOccurs="0"/>
-			<xs:element name="TotalDollarSavings" type="xs:double" minOccurs="0"/>
-			<xs:element minOccurs="0" name="PctReduction" type="xs:double">
+			<xs:element name="TotalSavings" type="HPXMLDouble" minOccurs="0"/>
+			<xs:element name="TotalDollarSavings" type="HPXMLDouble" minOccurs="0"/>
+			<xs:element minOccurs="0" name="PctReduction" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>should be represented as a fraction (ie 0.5 instead of 50%)</xs:documentation>
 				</xs:annotation>
@@ -2887,7 +2887,7 @@
 	<xs:complexType name="EndUseInfoType">
 		<xs:sequence>
 			<xs:element name="EndUse" type="endUseType"/>
-			<xs:element name="EndUseValue" type="xs:double">
+			<xs:element name="EndUseValue" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Energy use will be negative for energy producing end uses such as PV and SolarThermal.</xs:documentation>
 				</xs:annotation>
@@ -2915,7 +2915,7 @@
 			<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="HVACThirdPartyCertification"/>
-			<xs:element minOccurs="0" name="HasSharedCombustionVentilation" type="xs:boolean"/>
+			<xs:element minOccurs="0" name="HasSharedCombustionVentilation" type="HPXMLBoolean"/>
 			<xs:element minOccurs="0" name="CombustionVentingSystem" type="LocalReference"/>
 			<xs:element name="DistributionSystem" type="LocalReference" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element minOccurs="0" name="Installation">
@@ -2923,7 +2923,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" name="Standard" type="HVACInstallationStandard"/>
 						<xs:element minOccurs="0" name="SizingCalculation" type="HVACSizingCalcs"/>
-						<xs:element minOccurs="0" name="EnvelopeImprovementsUsedinSizing" type="xs:boolean">
+						<xs:element minOccurs="0" name="EnvelopeImprovementsUsedinSizing" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Air sealing and insulation implemented prior to replacement and used in calculations for sizing new / replacement system?</xs:documentation>
 							</xs:annotation>
@@ -2960,7 +2960,7 @@
 							<xs:documentation>[sq.ft.]</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="ElectricAuxiliaryEnergy" type="xs:double">
+					<xs:element minOccurs="0" name="ElectricAuxiliaryEnergy" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>The average annual auxiliary electrical energy consumption for, e.g., a gas furnace or boiler, in kilowatt-hours per year. Published in the AHRI
 								Consumer’s Directory of Certified Efficiency Ratings.</xs:documentation>
@@ -2976,14 +2976,14 @@
 			<xs:element name="Furnace">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="SealedCombustion" type="xs:boolean"/>
-						<xs:element name="CondensingSystem" type="xs:boolean" minOccurs="0"/>
-						<xs:element minOccurs="0" name="AtmosphericBurner" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="PowerBurner" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="AutomaticVentDamper" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="PilotLight" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="RetentionHead" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="SealedCombustion" type="HPXMLBoolean"/>
+						<xs:element name="CondensingSystem" type="HPXMLBoolean" minOccurs="0"/>
+						<xs:element minOccurs="0" name="AtmosphericBurner" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="PowerBurner" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="RetentionHead" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -2994,15 +2994,15 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element minOccurs="0" name="BoilerType" type="BoilerType"/>
-						<xs:element minOccurs="0" name="SealedCombustion" type="xs:boolean"/>
-						<xs:element name="CondensingSystem" type="xs:boolean" minOccurs="0"/>
-						<xs:element minOccurs="0" name="AtmosphericBurner" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="PowerBurner" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="RotaryCup" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="AutomaticVentDamper" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="PilotLight" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="RetentionHead" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="SealedCombustion" type="HPXMLBoolean"/>
+						<xs:element name="CondensingSystem" type="HPXMLBoolean" minOccurs="0"/>
+						<xs:element minOccurs="0" name="AtmosphericBurner" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="PowerBurner" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="RotaryCup" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="RetentionHead" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -3018,14 +3018,14 @@
 			<xs:element name="Fireplace">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="SmokeEmissionRate" type="xs:double">
+						<xs:element minOccurs="0" name="SmokeEmissionRate" type="HPXMLDouble">
 							<xs:annotation>
 								<xs:documentation>[grams per hour] from EPA label http://www.epa.gov/compliance/monitoring/programs/caa/woodheaters.html</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="AutomaticVentDamper" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="PilotLight" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -3033,14 +3033,14 @@
 			<xs:element name="Stove">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="SmokeEmissionRate" type="xs:double">
+						<xs:element minOccurs="0" name="SmokeEmissionRate" type="HPXMLDouble">
 							<xs:annotation>
 								<xs:documentation>[grams per hour] from EPA label http://www.epa.gov/compliance/monitoring/programs/caa/woodheaters.html</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="AutomaticVentDamper" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="PilotLight" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -3150,7 +3150,7 @@
 				<xs:sequence>
 					<xs:element name="CoolingSystemType" type="CoolingSystemType" minOccurs="0"/>
 					<xs:element minOccurs="0" name="CoolingSystemFuel" type="FuelType"/>
-					<xs:element minOccurs="0" name="CoolingCapacity" type="xs:double">
+					<xs:element minOccurs="0" name="CoolingCapacity" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>[Btuh]</xs:documentation>
 						</xs:annotation>
@@ -3213,13 +3213,13 @@
 			<xs:element minOccurs="0" name="PumpandZoneValve">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="ValveCorrections" type="xs:boolean">
+						<xs:element minOccurs="0" name="ValveCorrections" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>System Pump and Zone Valve Corrections made</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="ThermostaticRadiatorValves" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="VariableSpeedPump" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="ThermostaticRadiatorValves" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="VariableSpeedPump" type="HPXMLBoolean"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
@@ -3231,7 +3231,7 @@
 			<xs:element name="AirDistributionType" type="AirDistributionType" minOccurs="0"/>
 			<xs:element name="AirHandlerMotorType" type="AirHandlerMotorType" minOccurs="0"/>
 			<xs:element minOccurs="0" name="DuctLeakageMeasurement" type="DuctLeakageMeasurementType" maxOccurs="unbounded"/>
-			<xs:element minOccurs="0" name="DuctSystemSizingAppropriate" type="xs:boolean"/>
+			<xs:element minOccurs="0" name="DuctSystemSizingAppropriate" type="HPXMLBoolean"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="Ducts">
 				<xs:complexType>
 					<xs:sequence>
@@ -3384,8 +3384,8 @@
 											<xs:documentation>less than 18 years old</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="PubliclySubsidized" type="xs:boolean"/>
-									<xs:element minOccurs="0" name="LowIncome" type="xs:boolean"/>
+									<xs:element minOccurs="0" name="PubliclySubsidized" type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="LowIncome" type="HPXMLBoolean"/>
 									<xs:element minOccurs="0" name="OccupantIncomeRange" type="FractionGreaterThanOne">
 										<xs:annotation>
 											<xs:documentation>Percentage as a fraction (50% = 0.5)</xs:documentation>
@@ -3408,7 +3408,7 @@
 									<xs:element minOccurs="0" name="YearBuiltKnownOrEstimated" type="KnownOrEstimated"/>
 									<xs:element minOccurs="0" name="YearofLastRemodel" type="Year"/>
 									<xs:element name="ResidentialFacilityType" type="ResidentialFacilityType" minOccurs="0"/>
-									<xs:element minOccurs="0" name="PassiveSolar" type="xs:boolean">
+									<xs:element minOccurs="0" name="PassiveSolar" type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Passive solar design—also known as climatic design—involves using a building's windows, walls, and floors to collect, store, and
 												distribute solar energy in the form of heat in the winter and reject solar heat in the summer. (source:
@@ -3544,7 +3544,7 @@
 									<xs:element name="AverageWallRValue" type="RValue" minOccurs="0"/>
 									<xs:element name="AverageFloorRValue" type="RValue" minOccurs="0"/>
 									<xs:element name="AverageDuctRValue" type="RValue" minOccurs="0"/>
-									<xs:element minOccurs="0" name="GaragePresent" type="xs:boolean"/>
+									<xs:element minOccurs="0" name="GaragePresent" type="HPXMLBoolean"/>
 									<xs:element minOccurs="0" name="GarageLocation" type="GarageLocation"/>
 									<xs:element minOccurs="0" name="SpaceAboveGarage" type="SpaceAboveGarage"/>
 									<xs:element minOccurs="0" ref="extension"/>
@@ -3569,8 +3569,8 @@
 						<xs:element name="ClimateZoneIECC" minOccurs="0" type="IECCClimateZoneType" maxOccurs="unbounded"/>
 						<xs:element name="RadonZone" type="RadonZone" minOccurs="0"/>
 						<xs:element name="TermiteZone" type="TermiteZone" minOccurs="0"/>
-						<xs:element name="HurricaneZone" type="xs:boolean" minOccurs="0"/>
-						<xs:element name="FloodZone" type="xs:boolean" minOccurs="0"/>
+						<xs:element name="HurricaneZone" type="HPXMLBoolean" minOccurs="0"/>
+						<xs:element name="FloodZone" type="HPXMLBoolean" minOccurs="0"/>
 						<xs:element name="EarthquakeZone" type="EarthquakeZone" minOccurs="0"/>
 						<xs:element maxOccurs="unbounded" minOccurs="0" name="WeatherStation" type="WeatherStation">
 							<xs:annotation>
@@ -3606,7 +3606,7 @@
 											<xs:documentation>The name of the body or group providing the verification/certification/rating named in the GreenBuildingVerificationType field. There is almost always a direct correlation between bodies and programs.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Metric" type="xs:integer">
+									<xs:element minOccurs="0" name="Metric" type="HPXMLInteger">
 										<xs:annotation>
 											<xs:documentation>A final score indicating the performance of energy efficiency design and measures in the home as tested by a third-party rater. Points achieved to earn a certification in the GreenVerificationRating field do not apply to this field. HERS Index is most common with new homes and runs with a lower number being more efficient. A net-zero home uses zero energy and has a HERS score of 0. A home that produces more energy than it uses has a negative score. Home Energy Score is a tool more common for existing homes and runs with a higher number being more efficient. It takes square footage into account and caps with 10 as the highest number of points.</xs:documentation>
 										</xs:annotation>
@@ -3751,7 +3751,7 @@
 			<xs:element name="EstimatedLife" type="EstimatedLife" minOccurs="0"/>
 			<xs:element name="InstallationDate" type="InstallationDate" minOccurs="0"/>
 			<xs:element name="Cost" type="Cost" minOccurs="0"/>
-			<xs:element name="UnitPricingIndicator" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="UnitPricingIndicator" type="HPXMLBoolean" minOccurs="0"/>
 			<xs:element minOccurs="0" name="Incentives">
 				<xs:complexType>
 					<xs:sequence>
@@ -3830,12 +3830,12 @@
 			</xs:element>
 			<xs:element minOccurs="0" name="EnergySavingsReported" type="GrossOrNet"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="FuelSavings" type="FuelSavingsType"/>
-			<xs:element name="DemandSavings" minOccurs="0" type="xs:double">
+			<xs:element name="DemandSavings" minOccurs="0" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[kW] Demand savings from energy efficiency programs</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="AnnualPercentReduction" type="xs:double" minOccurs="0">
+			<xs:element name="AnnualPercentReduction" type="HPXMLDouble" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>should be represented as a fraction (ie 0.5 instead of 50%)</xs:documentation>
 				</xs:annotation>
@@ -3847,15 +3847,15 @@
 		<xs:sequence>
 			<xs:element minOccurs="0" name="WaterSavingsType" type="MeasuredOrEstimated"/>
 			<xs:element minOccurs="0" name="Units" type="waterUnitType"/>
-			<xs:element minOccurs="0" name="TotalSavings" type="xs:double"/>
-			<xs:element minOccurs="0" name="TotalDollarSavings" type="xs:double"/>
-			<xs:element minOccurs="0" name="PctReduction" type="xs:double">
+			<xs:element minOccurs="0" name="TotalSavings" type="HPXMLDouble"/>
+			<xs:element minOccurs="0" name="TotalDollarSavings" type="HPXMLDouble"/>
+			<xs:element minOccurs="0" name="PctReduction" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>should be represented as a fraction (ie 0.5 instead of 50%)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="RainBarrels" type="xs:double"/>
-			<xs:element minOccurs="0" name="ReclaimedWaterSystem" type="xs:boolean"/>
+			<xs:element minOccurs="0" name="RainBarrels" type="HPXMLDouble"/>
+			<xs:element minOccurs="0" name="ReclaimedWaterSystem" type="HPXMLBoolean"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 	</xs:complexType>
@@ -3897,29 +3897,29 @@
 				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="Consumption" type="xs:double">
+						<xs:element name="Consumption" type="HPXMLDouble">
 							<xs:annotation>
 								<xs:documentation>Negative number for renewable generation. Positive number for consumption.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="StartDateTime" type="xs:dateTime" minOccurs="0">
+						<xs:element name="StartDateTime" type="HPXMLDateTime" minOccurs="0">
 							<xs:annotation>
 								<xs:documentation>Date/time stamp in the ISO 8601 format when the usage measured began.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="EndDateTime" type="xs:dateTime" minOccurs="0">
+						<xs:element name="EndDateTime" type="HPXMLDateTime" minOccurs="0">
 							<xs:annotation>
 								<xs:documentation>Date/time stamp of the meter reading.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element minOccurs="0" name="ReadingType" type="MeterReadingType"/>
-						<xs:element name="ConsumptionCost" type="xs:double" minOccurs="0"/>
+						<xs:element name="ConsumptionCost" type="HPXMLDouble" minOccurs="0"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="MarginalRate" type="xs:double" minOccurs="0"/>
-			<xs:element minOccurs="0" name="BaseLoad" type="xs:double">
+			<xs:element name="MarginalRate" type="HPXMLDouble" minOccurs="0"/>
+			<xs:element minOccurs="0" name="BaseLoad" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Baseload power is the energy consumed for the day-to-day operation of a home that is not used as a response to outside weather (i.e. excludes heating and cooling)
 						(Krigger and Dorsi, 2009).</xs:documentation>
@@ -3935,83 +3935,83 @@
 	</xs:complexType>
 	<xs:complexType name="BPI2400Inputs">
 		<xs:sequence>
-			<xs:element minOccurs="0" name="WeatherRegressionBeginDate" type="xs:date"/>
-			<xs:element minOccurs="0" name="WeatherRegressionEndDate" type="xs:date"/>
+			<xs:element minOccurs="0" name="WeatherRegressionBeginDate" type="HPXMLDate"/>
+			<xs:element minOccurs="0" name="WeatherRegressionEndDate" type="HPXMLDate"/>
 			<xs:element minOccurs="0" name="CalibrationQualification" type="BPI2400CalibrationQualification">
 				<xs:annotation>
 					<xs:documentation>This identifies which data quality requirements (if any) were met by the bills for the relevant energy source and therefore which calibration metrics (if any) are
 						used to determine whether the calibrated model is accepted.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="CalibrationWeatherRegressionCVRMSE" type="xs:double">
+			<xs:element minOccurs="0" name="CalibrationWeatherRegressionCVRMSE" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Detailed Calibration Weather Regression CV-RMSE. Eqn. 3.2.2.G.i of BPI-2400. Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="WeatherNormalizedHeatingUsage" type="xs:double">
+			<xs:element minOccurs="0" name="WeatherNormalizedHeatingUsage" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Weather Normalized Annual Heating Usage</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="WeatherNormalizedCoolingUsage" type="xs:double">
+			<xs:element minOccurs="0" name="WeatherNormalizedCoolingUsage" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Weather Normalized Annual Cooling Usage</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="WeatherNormalizedBaseloadUsage" type="xs:double">
+			<xs:element minOccurs="0" name="WeatherNormalizedBaseloadUsage" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Weather Normalized Annual Baseload Usage</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingBiasError" type="xs:double">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingBiasError" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Eqn. 3.2.3.A.i of BPI-2400. Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingAbsoluteError" type="xs:double">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingAbsoluteError" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Eqn. 3.2.3.A.ii of BPI-2400. In either kWh for electricity or MMBTU for all other fuels.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingBiasError" type="xs:double">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingBiasError" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingAbsoluteError" type="xs:double">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingAbsoluteError" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>In either kWh for electricity or MMBTU for all other fuels.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadBiasError" type="xs:double">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadBiasError" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadAbsoluteError" type="xs:double">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadAbsoluteError" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>In either kWh for electricity or MMBTU for all other fuels.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SimplifiedModelCalibrationHeatingBiasError" nillable="true" type="xs:double">
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationHeatingBiasError" nillable="true" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% =
 						0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SimplifiedModelCalibrationCoolingBiasError" type="xs:double">
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationCoolingBiasError" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% =
 						0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SimplifiedModelCalibrationBaseloadBiasError" nillable="true" type="xs:double">
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationBaseloadBiasError" nillable="true" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% =
 						0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SimplifiedModelCalibrationTotalBiasError" type="xs:double">
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationTotalBiasError" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% =
 						0.1)</xs:documentation>
@@ -4045,7 +4045,7 @@
 											<xs:sequence>
 												<xs:element name="EmissionType" type="EmissionType"/>
 												<xs:element name="EmissionUnits" type="EmissionUnits"/>
-												<xs:element name="Emissions" type="xs:double"/>
+												<xs:element name="Emissions" type="HPXMLDouble"/>
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
@@ -4056,12 +4056,12 @@
 						<xs:element minOccurs="0" name="SharedEnergySystem" type="SharedEnergySystem"/>
 						<xs:element minOccurs="0" name="IntervalType" type="IntervalType"/>
 						<xs:element minOccurs="0" name="ReadingTimeZone" type="HPXMLString"/>
-						<xs:element minOccurs="0" name="MarginalEnergyCostRate" type="xs:double">
+						<xs:element minOccurs="0" name="MarginalEnergyCostRate" type="HPXMLDouble">
 							<xs:annotation>
 								<xs:documentation>[$/energy unit] The cost of providing an additional unit of output</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="EnergyUseIntensity" type="xs:double">
+						<xs:element minOccurs="0" name="EnergyUseIntensity" type="HPXMLDouble">
 							<xs:annotation>
 								<xs:documentation>[kBtu/ft^2] Energy use intensity (EUI) is a unit of measurement that describes a building's energy use. EUI represents the energy consumed by a
 									building relative to its size.</xs:documentation>
@@ -4081,7 +4081,7 @@
 					<xs:sequence>
 						<xs:element name="WaterType" type="WaterType"/>
 						<xs:element name="UnitofMeasure" type="waterUnitType"/>
-						<xs:element minOccurs="0" name="MarginalWaterCostRate" type="xs:double"/>
+						<xs:element minOccurs="0" name="MarginalWaterCostRate" type="HPXMLDouble"/>
 						<xs:element minOccurs="0" name="WaterUseIntensity">
 							<xs:annotation>
 								<xs:documentation>Water use intensity is defined as annual water use divided by total gross square footage of facility space reported in gallons per square foot (DOE,
@@ -4090,7 +4090,7 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:element name="Units" type="WaterUseIntensityUnits"/>
-									<xs:element name="Value" type="xs:double"/>
+									<xs:element name="Value" type="HPXMLDouble"/>
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
@@ -4108,16 +4108,16 @@
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="UnitofMeasure" type="energyUnitType"/>
-			<xs:element minOccurs="0" name="AnnualConsumption" type="xs:double"/>
-			<xs:element minOccurs="0" name="AnnualFuelCost" type="xs:double"/>
+			<xs:element minOccurs="0" name="AnnualConsumption" type="HPXMLDouble"/>
+			<xs:element minOccurs="0" name="AnnualFuelCost" type="HPXMLDouble"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="ConsumptionByEndUse" type="EndUseInfoType"/>
-			<xs:element minOccurs="0" name="BaseLoad" type="xs:double">
+			<xs:element minOccurs="0" name="BaseLoad" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Baseload power is the energy consumed for the day-to-day operation of a home that is not used as a response to outside weather (i.e. excludes heating and cooling)
 						(Krigger and Dorsi, 2009).</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="ElectricityDemandKW" type="xs:double"/>
+			<xs:element minOccurs="0" name="ElectricityDemandKW" type="HPXMLDouble"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
@@ -4142,7 +4142,7 @@
 		<xs:sequence>
 			<xs:element name="TelephoneType" type="TelephoneTypeCode" minOccurs="0"/>
 			<xs:element name="TelephoneNumber" type="TelephoneNumber"/>
-			<xs:element minOccurs="0" name="PreferredContactMethod" type="xs:boolean"/>
+			<xs:element minOccurs="0" name="PreferredContactMethod" type="HPXMLBoolean"/>
 			<xs:element name="TelephoneExtension" type="TelephoneExtension" minOccurs="0"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
@@ -4151,7 +4151,7 @@
 		<xs:sequence>
 			<xs:element name="EmailType" type="EmailTypeCode" minOccurs="0"/>
 			<xs:element name="EmailAddress" type="EmailAddress"/>
-			<xs:element minOccurs="0" name="PreferredContactMethod" type="xs:boolean"/>
+			<xs:element minOccurs="0" name="PreferredContactMethod" type="HPXMLBoolean"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
@@ -4202,7 +4202,7 @@
 			<xs:element name="UFactor" type="UFactor" minOccurs="0"/>
 			<xs:element name="SHGC" type="SHGC" minOccurs="0"/>
 			<xs:element minOccurs="0" name="VisibleTransmittance" type="Fraction"/>
-			<xs:element name="NFRCCertified" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="NFRCCertified" type="HPXMLBoolean" minOccurs="0"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="WindowThirdPartyCertification"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="WindowFilm">
 				<xs:complexType>
@@ -4266,7 +4266,7 @@ If moveable insulation also provides shading, the shading should be documented h
 						<xs:group ref="SystemInfo"/>
 						<xs:element minOccurs="0" name="GlassType" type="GlassType"/>
 						<xs:element minOccurs="0" name="FrameType" type="WindowFrameType"/>
-						<xs:element minOccurs="0" name="Operable" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="Operable" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="Condition" type="WindowCondition"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
@@ -4305,8 +4305,8 @@ If moveable insulation also provides shading, the shading should be documented h
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="WeatherStripping" type="xs:boolean"/>
-			<xs:element minOccurs="0" name="Operable" type="xs:boolean"/>
+			<xs:element minOccurs="0" name="WeatherStripping" type="HPXMLBoolean"/>
+			<xs:element minOccurs="0" name="Operable" type="HPXMLBoolean"/>
 			<xs:element minOccurs="0" name="LeakinessDescription" type="BuildingLeakiness"/>
 		</xs:sequence>
 	</xs:group>
@@ -4315,7 +4315,7 @@ If moveable insulation also provides shading, the shading should be documented h
 			<xs:element name="Aluminum">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="ThermalBreak" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="ThermalBreak" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -4337,7 +4337,7 @@ If moveable insulation also provides shading, the shading should be documented h
 			<xs:element name="Metal">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="ThermalBreak" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="ThermalBreak" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -4408,7 +4408,7 @@ If moveable insulation also provides shading, the shading should be documented h
 	<xs:complexType name="AirInfiltrationMeasurementType">
 		<xs:sequence>
 			<xs:group ref="SystemInfo"/>
-			<xs:element minOccurs="0" name="Date" type="xs:date"/>
+			<xs:element minOccurs="0" name="Date" type="HPXMLDate"/>
 			<xs:element minOccurs="0" name="BusinessConductingTest" type="RemoteReference"/>
 			<xs:element minOccurs="0" name="IndividualConductingTest" type="RemoteReference"/>
 			<xs:element minOccurs="0" name="OutsideTemperature" type="Temperature">
@@ -4439,13 +4439,13 @@ If moveable insulation also provides shading, the shading should be documented h
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="EffectiveLeakageArea" type="xs:double">
+			<xs:element minOccurs="0" name="EffectiveLeakageArea" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[sq.in.] The Effective Leakage Area is defined as the area of a special nozzle-shaped hole (similar to the inlet of a blower door fan) that would leak the same
 						amount of air as the building does at a pressure of 4 Pascals.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="InfiltrationVolume" type="xs:double">
+			<xs:element minOccurs="0" name="InfiltrationVolume" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[sq. ft.] The volume of the building that is applicable to the air infiltration measurement test. The volume can be defined as the conditioned building volume
 						plus the volume of crawlspaces, attics, and/or basements that are connected to the building's conditioned space via open doors or hatches.</xs:documentation>
@@ -4467,8 +4467,8 @@ If moveable insulation also provides shading, the shading should be documented h
 			<xs:element name="Basement">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="Finished" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="Conditioned" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="Finished" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -4476,8 +4476,8 @@ If moveable insulation also provides shading, the shading should be documented h
 			<xs:element name="Crawlspace">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="Vented" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="Conditioned" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="Vented" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -4492,7 +4492,7 @@ If moveable insulation also provides shading, the shading should be documented h
 			<xs:element name="Garage">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="Conditioned" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -4548,12 +4548,12 @@ If moveable insulation also provides shading, the shading should be documented h
 			<xs:element name="WoodStud">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="ExpandedPolystyreneSheathing" type="xs:boolean">
+						<xs:element minOccurs="0" name="ExpandedPolystyreneSheathing" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Sheathing insulation should be specified in the Insulation element as well.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="OptimumValueEngineering" type="xs:boolean">
+						<xs:element minOccurs="0" name="OptimumValueEngineering" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Please specify stud spacing and framing factor in the appropriate places as well.</xs:documentation>
 							</xs:annotation>
@@ -4565,7 +4565,7 @@ If moveable insulation also provides shading, the shading should be documented h
 			<xs:element name="DoubleWoodStud">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="Staggered" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="Staggered" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -4706,38 +4706,38 @@ If moveable insulation also provides shading, the shading should be documented h
 	</xs:complexType>
 	<xs:complexType name="HVACControlTypeAdjustments">
 		<xs:sequence>
-			<xs:element minOccurs="0" name="Day" type="xs:boolean"/>
-			<xs:element minOccurs="0" name="Night" type="xs:boolean"/>
+			<xs:element minOccurs="0" name="Day" type="HPXMLBoolean"/>
+			<xs:element minOccurs="0" name="Night" type="HPXMLBoolean"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="MoistureControlImprovementInfo">
 		<xs:sequence>
-			<xs:element name="VaporRetardersInstalled" type="xs:boolean" minOccurs="0"/>
-			<xs:element name="GuttersInstalledorRepaired" type="xs:boolean" minOccurs="0"/>
-			<xs:element name="FlashingInstalledorRepaired" type="xs:boolean" minOccurs="0"/>
-			<xs:element name="FoundationGradingImproved" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="VaporRetardersInstalled" type="HPXMLBoolean" minOccurs="0"/>
+			<xs:element name="GuttersInstalledorRepaired" type="HPXMLBoolean" minOccurs="0"/>
+			<xs:element name="FlashingInstalledorRepaired" type="HPXMLBoolean" minOccurs="0"/>
+			<xs:element name="FoundationGradingImproved" type="HPXMLBoolean" minOccurs="0"/>
 			<xs:element name="OtherMeasuresImplementedDescription" type="HPXMLString" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="HVACDistributionImprovementInfo">
 		<xs:sequence>
-			<xs:element name="DuctSystemSealed" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="DuctSystemSealed" type="HPXMLBoolean" minOccurs="0"/>
 			<xs:element minOccurs="0" name="DuctSystemSealedYearMonth" type="xs:gYearMonth">
 				<xs:annotation>
 					<xs:documentation>The year and month the duct system was sealed.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="DuctOutsideEnvelopeInsulatedaspartofRetrofit" type="xs:boolean" minOccurs="0"/>
-			<xs:element name="DuctSystemReplaced" type="xs:boolean" minOccurs="0"/>
-			<xs:element name="SystemPumpandZoneValveCorrectionsMade" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="DuctOutsideEnvelopeInsulatedaspartofRetrofit" type="HPXMLBoolean" minOccurs="0"/>
+			<xs:element name="DuctSystemReplaced" type="HPXMLBoolean" minOccurs="0"/>
+			<xs:element name="SystemPumpandZoneValveCorrectionsMade" type="HPXMLBoolean" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="HVACMaintenance">
 		<xs:sequence>
-			<xs:element minOccurs="0" name="TuneAndRepair" type="xs:boolean"/>
+			<xs:element minOccurs="0" name="TuneAndRepair" type="HPXMLBoolean"/>
 			<xs:element minOccurs="0" name="TuneAndRepairYearMonth" type="xs:gYearMonth">
 				<xs:annotation>
 					<xs:documentation>Year and month of the last tune and repair for this HVAC equipment.</xs:documentation>
@@ -4793,7 +4793,7 @@ If moveable insulation also provides shading, the shading should be documented h
 	</xs:complexType>
 	<xs:complexType name="WaterHeaterImprovementInfo">
 		<xs:sequence>
-			<xs:element name="JacketInstalledIndicator" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="JacketInstalledIndicator" type="HPXMLBoolean" minOccurs="0"/>
 			<xs:element name="DispositionofExistingSystem" type="DispositionofExistingSystem" minOccurs="0"/>
 			<xs:element name="RepairsDescription" type="HPXMLString" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="PipeInsulated" type="PipeInsulated" minOccurs="0"/>
@@ -4803,14 +4803,14 @@ If moveable insulation also provides shading, the shading should be documented h
 				</xs:annotation>
 			</xs:element>
 			<xs:element minOccurs="0" name="DiameterofPipeInsulated" type="PipeDiameterType"/>
-			<xs:element name="SystemReplaced" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="SystemReplaced" type="HPXMLBoolean" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="VentilationImprovementInfo">
 		<xs:sequence>
-			<xs:element name="GarageDuctsandAirHandlersAirSealed" type="xs:boolean" minOccurs="0"/>
-			<xs:element name="MechanicalVentilationInstalled" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="GarageDuctsandAirHandlersAirSealed" type="HPXMLBoolean" minOccurs="0"/>
+			<xs:element name="MechanicalVentilationInstalled" type="HPXMLBoolean" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 	</xs:complexType>
@@ -4967,7 +4967,7 @@ If moveable insulation also provides shading, the shading should be documented h
 	</xs:complexType>
 	<xs:complexType name="TotalExternalStaticPressureMeasurement">
 		<xs:sequence>
-			<xs:element name="StaticPressure" type="xs:double">
+			<xs:element name="StaticPressure" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[Pa] positive for supply side measurements, negative for return side.</xs:documentation>
 				</xs:annotation>
@@ -4980,13 +4980,13 @@ If moveable insulation also provides shading, the shading should be documented h
 	</xs:complexType>
 	<xs:complexType name="WallAndFloorFurnace">
 		<xs:sequence>
-			<xs:element minOccurs="0" name="SealedCombustion" type="xs:boolean"/>
-			<xs:element minOccurs="0" name="AtmosphericBurner" type="xs:boolean"/>
-			<xs:element minOccurs="0" name="PowerBurner" type="xs:boolean"/>
-			<xs:element minOccurs="0" name="AutomaticVentDamper" type="xs:boolean"/>
-			<xs:element minOccurs="0" name="PilotLight" type="xs:boolean"/>
-			<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="xs:boolean"/>
-			<xs:element minOccurs="0" name="RetentionHead" type="xs:boolean"/>
+			<xs:element minOccurs="0" name="SealedCombustion" type="HPXMLBoolean"/>
+			<xs:element minOccurs="0" name="AtmosphericBurner" type="HPXMLBoolean"/>
+			<xs:element minOccurs="0" name="PowerBurner" type="HPXMLBoolean"/>
+			<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
+			<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
+			<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
+			<xs:element minOccurs="0" name="RetentionHead" type="HPXMLBoolean"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 	</xs:complexType>
@@ -4995,9 +4995,9 @@ If moveable insulation also provides shading, the shading should be documented h
 			<xs:element name="Attic">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="Vented" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="Conditioned" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="CapeCod" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="Vented" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="CapeCod" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -5073,11 +5073,11 @@ If moveable insulation also provides shading, the shading should be documented h
 		<xs:complexType>
 			<xs:sequence>
 				<xs:group ref="SystemInfo"/>
-				<xs:element name="IsConnected" type="xs:boolean"/>
+				<xs:element name="IsConnected" type="HPXMLBoolean"/>
 				<xs:element maxOccurs="unbounded" minOccurs="0" name="CommunicatesWith" type="LocalReference"/>
 				<xs:element minOccurs="0" name="CommunicationProtocol" type="ConnectedDeviceCommunicationProtocol" maxOccurs="unbounded"/>
-				<xs:element minOccurs="0" name="DemandResponseCapability" type="xs:boolean"/>
-				<xs:element minOccurs="0" name="OccupancySensor" type="xs:boolean"/>
+				<xs:element minOccurs="0" name="DemandResponseCapability" type="HPXMLBoolean"/>
+				<xs:element minOccurs="0" name="OccupancySensor" type="HPXMLBoolean"/>
 				<xs:element minOccurs="0" ref="extension"/>
 			</xs:sequence>
 		</xs:complexType>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -258,15 +258,7 @@
 								drying cycle energy as well as energy consumed during Stand-by and Off modes.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element maxOccurs="unbounded" minOccurs="0" name="ControlType">
-						<xs:simpleType>
-							<xs:restriction base="xs:string">
-								<xs:enumeration value="timer"/>
-								<xs:enumeration value="moisture"/>
-								<xs:enumeration value="temperature"/>
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:element>
+					<xs:element maxOccurs="unbounded" minOccurs="0" name="ControlType" type="ClothesDryerControlType_simple"> </xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -1693,28 +1685,17 @@
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorRatedOpticalEfficiency">
+									<xs:element minOccurs="0" name="CollectorRatedOpticalEfficiency" type="CollectorRatedOpticalEfficiency_simple">
 										<xs:annotation>
 											<xs:documentation>Often referred to as Fr-tau-alpha (FRta), this describes the optical efficiency portion of the overall collector efficiency. In the OG-100
 												SRCC Certified Solar Thermal Collector Directory, this is the y-intercept of the efficiency curve.</xs:documentation>
 										</xs:annotation>
-										<xs:simpleType>
-											<xs:restriction base="xs:double">
-												<xs:minExclusive value="0"/>
-												<xs:maxExclusive value="1"/>
-											</xs:restriction>
-										</xs:simpleType>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorRatedThermalLosses">
+									<xs:element minOccurs="0" name="CollectorRatedThermalLosses" type="CollectorRatedThermalLosses_simple">
 										<xs:annotation>
 											<xs:documentation>Often referred to as Fr-Ul (FRUl), this describes the collector thermal losses portion of the overall collector efficiency. In the OG-100
 												SRCC Certified Solar Thermal Collector Directory, this is the slope of the efficiency curve.</xs:documentation>
 										</xs:annotation>
-										<xs:simpleType>
-											<xs:restriction base="xs:double">
-												<xs:minExclusive value="0"/>
-											</xs:restriction>
-										</xs:simpleType>
 									</xs:element>
 									<xs:element minOccurs="0" name="StorageVolume" type="Volume">
 										<xs:annotation>
@@ -1722,30 +1703,19 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="ConnectedTo" type="LocalReference"/>
-									<xs:element minOccurs="0" name="SolarFraction">
+									<xs:element minOccurs="0" name="SolarFraction" type="SolarFraction_simple">
 										<xs:annotation>
 											<xs:documentation>The Solar Fraction is the portion of the total conventional hot water heating load (delivered energy and tank standby losses). The higher
 												the solar fraction, the greater the solar contribution to water heating, which reduces the energy required by the backup water heater. This value can be
 												found in the OG-300 SRCC Certified Solar Water Heating System Directory.</xs:documentation>
 										</xs:annotation>
-										<xs:simpleType>
-											<xs:restriction base="xs:double">
-												<xs:minExclusive value="0"/>
-												<xs:maxInclusive value="1"/>
-											</xs:restriction>
-										</xs:simpleType>
 									</xs:element>
-									<xs:element minOccurs="0" name="SolarEnergyFactor">
+									<xs:element minOccurs="0" name="SolarEnergyFactor" type="SolarThermalSystemEnergyFactor_simple">
 										<xs:annotation>
 											<xs:documentation>The Solar Energy Factor is defined as the energy delivered by the system divided by the electrical or gas energy put into the system. The
 												higher the number, the more energy efficient. This value can be found in the OG-300 SRCC Certified Solar Water Heating System
 												Directory.</xs:documentation>
 										</xs:annotation>
-										<xs:simpleType>
-											<xs:restriction base="xs:double">
-												<xs:minExclusive value="0"/>
-											</xs:restriction>
-										</xs:simpleType>
 									</xs:element>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
@@ -1766,25 +1736,8 @@
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
 									<xs:element minOccurs="0" name="Location" type="PVSystemLocation"/>
 									<xs:element minOccurs="0" name="Ownership" type="PVSystemOwnership"/>
-									<xs:element minOccurs="0" name="ModuleType">
-										<xs:simpleType>
-											<xs:restriction base="xs:string">
-												<xs:enumeration value="standard"/>
-												<xs:enumeration value="premium"/>
-												<xs:enumeration value="thin film"/>
-											</xs:restriction>
-										</xs:simpleType>
-									</xs:element>
-									<xs:element maxOccurs="1" minOccurs="0" name="Tracking">
-										<xs:simpleType>
-											<xs:restriction base="xs:string">
-												<xs:enumeration value="fixed"/>
-												<xs:enumeration value="1-axis"/>
-												<xs:enumeration value="1-axis backtracked"/>
-												<xs:enumeration value="2-axis"/>
-											</xs:restriction>
-										</xs:simpleType>
-									</xs:element>
+									<xs:element minOccurs="0" name="ModuleType" type="PVModuleType_simple"> </xs:element>
+									<xs:element maxOccurs="1" minOccurs="0" name="Tracking" type="PVTracking_simple"> </xs:element>
 									<xs:element minOccurs="0" name="ArrayOrientation" type="OrientationType"/>
 									<xs:element minOccurs="0" name="ArrayAzimuth" type="AzimuthType">
 										<xs:annotation>
@@ -2114,15 +2067,7 @@
 							</xs:annotation>
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element minOccurs="0" name="FanSpeed">
-										<xs:simpleType>
-											<xs:restriction base="xs:string">
-												<xs:enumeration value="low"/>
-												<xs:enumeration value="medium"/>
-												<xs:enumeration value="high"/>
-											</xs:restriction>
-										</xs:simpleType>
-									</xs:element>
+									<xs:element minOccurs="0" name="FanSpeed" type="FanSpeed_simple"> </xs:element>
 									<xs:element minOccurs="0" name="Airflow" type="HPXMLDouble">
 										<xs:annotation>
 											<xs:documentation>[CFM]</xs:documentation>
@@ -2201,14 +2146,7 @@
 									<xs:element name="Sodium">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="Pressure">
-													<xs:simpleType>
-														<xs:restriction base="xs:string">
-															<xs:enumeration value="high"/>
-															<xs:enumeration value="low"/>
-														</xs:restriction>
-													</xs:simpleType>
-												</xs:element>
+												<xs:element minOccurs="0" name="Pressure" type="SodiumLight_Pressure_simple"> </xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
 											<xs:attribute ref="dataSource"/>
@@ -3277,17 +3215,11 @@
 					</xs:element>
 					<xs:element minOccurs="0" name="CoolingSensibleHeatFraction" type="Fraction"/>
 					<xs:element name="GeothermalLoop" type="GeothermalLoop" minOccurs="0"/>
-					<xs:element minOccurs="0" name="BackupType">
+					<xs:element minOccurs="0" name="BackupType" type="HeatPumpBackupType_simple">
 						<xs:annotation>
 							<xs:documentation>Whether the heat pump backup is integrated into the unit (describe in BackupSystemFuel, BackupAnnualHeatingEfficiency, BackupHeatingCapacity), or a
 								separate heating system (add reference in BackupSystem).</xs:documentation>
 						</xs:annotation>
-						<xs:simpleType>
-							<xs:restriction base="xs:string">
-								<xs:enumeration value="integrated"/>
-								<xs:enumeration value="separate"/>
-							</xs:restriction>
-						</xs:simpleType>
 					</xs:element>
 					<xs:element minOccurs="0" name="BackupSystem" type="LocalReference">
 						<xs:annotation>
@@ -5379,18 +5311,7 @@
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element name="URL" type="xs:anyURI"/>
-				<xs:element name="Type">
-					<xs:simpleType>
-						<xs:restriction base="xs:string">
-							<xs:enumeration value="photo"/>
-							<xs:enumeration value="illustration"/>
-							<xs:enumeration value="document"/>
-							<xs:enumeration value="spreadsheet"/>
-							<xs:enumeration value="website"/>
-							<xs:enumeration value="other"/>
-						</xs:restriction>
-					</xs:simpleType>
-				</xs:element>
+				<xs:element name="Type" type="ExternalResourceType_simple"> </xs:element>
 				<xs:element name="Description" type="HPXMLString"/>
 				<xs:element minOccurs="0" ref="extension"/>
 			</xs:sequence>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.0">
 	<xs:include schemaLocation="HPXMLDataTypes.xsd"/>
 	<xs:attribute name="dataSource" type="DataSource"/>
@@ -14,6 +14,7 @@
 				<xs:element name="Transaction" type="TransactionType"/>
 				<xs:element minOccurs="0" ref="extension"/>
 			</xs:sequence>
+			<xs:attribute ref="dataSource"/>
 		</xs:complexType>
 	</xs:element>
 	<xs:complexType name="AddressInformation">
@@ -30,6 +31,7 @@
 			<xs:element name="USPSBarCode" type="USPSBarCode" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="SystemIdentifiersInfoType">
 		<xs:annotation>
@@ -52,9 +54,11 @@
 				<xs:documentation>Use to reference the id of the same object on the base building where the object has not been replaced.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="LocalReference">
 		<xs:attribute name="idref" type="xs:IDREF"/>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="RemoteReference">
 		<xs:annotation>
@@ -72,6 +76,7 @@
 				<xs:documentation>Id reference in the current document. Optional. If the element isn't available in the current document, don't use this.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:element name="ContractorSystemIdentifiers">
 		<xs:annotation>
@@ -81,12 +86,14 @@
 			<xs:sequence>
 				<xs:element maxOccurs="unbounded" ref="SystemIdentifiersInfo"/>
 			</xs:sequence>
+			<xs:attribute ref="dataSource"/>
 		</xs:complexType>
 	</xs:element>
 	<xs:complexType name="extensionType">
 		<xs:sequence>
 			<xs:any maxOccurs="unbounded" minOccurs="0" namespace="##any" processContents="skip"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:element name="extension" type="extensionType"> </xs:element>
 	<xs:element name="ProjectStatus">
@@ -101,6 +108,7 @@
 				<xs:element minOccurs="0" name="Date" type="HPXMLDate"/>
 				<xs:element minOccurs="0" ref="extension"/>
 			</xs:sequence>
+			<xs:attribute ref="dataSource"/>
 		</xs:complexType>
 	</xs:element>
 	<xs:complexType name="IndividualInfo">
@@ -116,6 +124,7 @@
 						<xs:element name="SuffixName" type="SuffixName" minOccurs="0"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="IndividualType" type="IndividualType"/>
@@ -123,6 +132,7 @@
 			<xs:element minOccurs="0" maxOccurs="unbounded" name="Email" type="EmailInfoType"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:element name="UtilityFuelProvider">
 		<xs:annotation>
@@ -140,6 +150,7 @@
 				<xs:element maxOccurs="unbounded" minOccurs="0" name="BusinessContactInfo" type="BusinessContactInfoType"/>
 				<xs:element ref="extension" minOccurs="0"/>
 			</xs:sequence>
+			<xs:attribute ref="dataSource"/>
 		</xs:complexType>
 	</xs:element>
 	<xs:complexType name="IECCClimateZoneType">
@@ -148,6 +159,7 @@
 			<xs:element name="ClimateZone" type="ClimateZoneIECC"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="InsulationMaterial">
 		<xs:choice>
@@ -171,6 +183,7 @@
 				</xs:annotation>
 			</xs:element>
 		</xs:choice>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="InsulationInfo">
 		<xs:sequence>
@@ -196,10 +209,12 @@
 						</xs:element>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:element name="CoolingSystemInfo" type="CoolingSystemInfoType"/>
 	<xs:element name="HeatPumpInfo" type="HeatPumpInfoType"/>
@@ -217,6 +232,7 @@
 			<xs:element name="ModelYear" type="Year" minOccurs="0"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="ApplianceThirdPartyCertifications"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="ClothesDryerInfoType">
 		<xs:complexContent>
@@ -437,6 +453,7 @@
 				<xs:element name="SoftwareProgramVersion" type="SoftwareProgramVersion" minOccurs="0"/>
 				<xs:element ref="extension" minOccurs="0"/>
 			</xs:sequence>
+			<xs:attribute ref="dataSource"/>
 		</xs:complexType>
 	</xs:element>
 	<xs:complexType name="BusinessContactType">
@@ -446,6 +463,7 @@
 					<xs:sequence>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Auditor">
@@ -456,6 +474,7 @@
 						<xs:element minOccurs="0" name="YearsExperience" type="IntegerGreaterThanOrEqualToZero"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Implementer">
@@ -465,6 +484,7 @@
 						<xs:element minOccurs="0" name="StateWhereQualificationHeld" type="StateCode"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Other">
@@ -473,9 +493,11 @@
 						<xs:element minOccurs="0" name="Description" type="HPXMLString"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:choice>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="ContractorType">
 		<xs:sequence>
@@ -484,6 +506,7 @@
 			<xs:element name="SubContractor" type="ContractorType" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:element name="AttachedToSpace" type="LocalReference"/>
 	<xs:element name="AttachedToZone" type="LocalReference"/>
@@ -512,9 +535,11 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="Zones">
 		<xs:sequence>
@@ -527,9 +552,11 @@
 						<xs:element name="Spaces" type="Spaces" minOccurs="0"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="Enclosure">
 		<xs:sequence>
@@ -549,9 +576,11 @@
 												<xs:element maxOccurs="unbounded" minOccurs="0" name="BasementCrawlspace" type="BasementCrawlspaceComponentsAirSealed"/>
 												<xs:element maxOccurs="unbounded" minOccurs="0" name="LivingSpace" type="LivingSpaceComponentsAirSealed"/>
 											</xs:sequence>
+											<xs:attribute ref="dataSource"/>
 										</xs:complexType>
 									</xs:element>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element name="AnnualEnergyUse" minOccurs="0">
@@ -559,10 +588,12 @@
 								<xs:sequence>
 									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Attics">
@@ -590,13 +621,16 @@
 											<xs:sequence>
 												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
+											<xs:attribute ref="dataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Foundations" minOccurs="0">
@@ -623,13 +657,16 @@
 											<xs:sequence>
 												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
+											<xs:attribute ref="dataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Garages">
@@ -655,6 +692,7 @@
 												<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
+											<xs:attribute ref="dataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element minOccurs="0" name="AttachedToRoof" type="LocalReference" maxOccurs="unbounded"/>
@@ -667,13 +705,16 @@
 											<xs:sequence>
 												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
+											<xs:attribute ref="dataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Roofs">
@@ -715,9 +756,11 @@
 									<xs:element minOccurs="0" name="Insulation" type="InsulationInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="RimJoists">
@@ -755,13 +798,16 @@
 											<xs:sequence>
 												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
+											<xs:attribute ref="dataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Walls" minOccurs="0">
@@ -803,13 +849,16 @@
 											<xs:sequence>
 												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
+											<xs:attribute ref="dataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="FoundationWalls">
@@ -873,9 +922,11 @@
 									<xs:element maxOccurs="1" minOccurs="0" name="Insulation" type="InsulationInfo"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="FrameFloors">
@@ -903,9 +954,11 @@
 									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"> </xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Slabs">
@@ -966,9 +1019,11 @@
 									<xs:element minOccurs="0" name="UnderSlabInsulation" type="InsulationInfo"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Windows" minOccurs="0">
@@ -989,13 +1044,16 @@
 											<xs:sequence>
 												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
+											<xs:attribute ref="dataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Skylights">
@@ -1021,13 +1079,16 @@
 											<xs:sequence>
 												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
+											<xs:attribute ref="dataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Doors" minOccurs="0">
@@ -1062,17 +1123,21 @@
 											<xs:sequence>
 												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
+											<xs:attribute ref="dataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="Systems">
 		<xs:sequence>
@@ -1091,6 +1156,7 @@
 												<xs:element minOccurs="0" name="PrimaryHeatingSystem" type="LocalReference"/>
 												<xs:element minOccurs="0" name="PrimaryCoolingSystem" type="LocalReference"/>
 											</xs:sequence>
+											<xs:attribute ref="dataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element minOccurs="0" maxOccurs="unbounded" name="HeatingSystem" type="HeatingSystemInfoType"/>
@@ -1098,6 +1164,7 @@
 									<xs:element minOccurs="0" maxOccurs="unbounded" name="HeatPump" type="HeatPumpInfoType"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element maxOccurs="unbounded" minOccurs="0" name="HVACControl" type="HVACControlType"> </xs:element>
@@ -1117,6 +1184,7 @@
 													</xs:annotation>
 												</xs:element>
 											</xs:choice>
+											<xs:attribute ref="dataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element minOccurs="0" name="ConditionedFloorAreaServed" type="SurfaceArea">
@@ -1141,6 +1209,7 @@
 									<xs:element minOccurs="0" name="HVACDistributionImprovement" type="HVACDistributionImprovementInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" name="Maintenance">
@@ -1150,6 +1219,7 @@
 									<xs:element minOccurs="0" name="ACReplacedinLastTenYears" type="HPXMLBoolean"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element name="AnnualEnergyUse" minOccurs="0">
@@ -1157,10 +1227,12 @@
 								<xs:sequence>
 									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType" maxOccurs="unbounded"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="MechanicalVentilation">
@@ -1266,13 +1338,16 @@
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
+											<xs:attribute ref="dataSource"/>
 										</xs:complexType>
 									</xs:element>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="CombustionVentilation">
@@ -1286,9 +1361,11 @@
 									<xs:element minOccurs="0" ref="AttachedToZone"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="WaterHeating" minOccurs="0">
@@ -1370,6 +1447,7 @@
 															</xs:element>
 															<xs:element minOccurs="0" ref="extension"/>
 														</xs:sequence>
+														<xs:attribute ref="dataSource"/>
 													</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="TankWall">
@@ -1388,9 +1466,11 @@
 															</xs:element>
 															<xs:element minOccurs="0" ref="extension"/>
 														</xs:sequence>
+														<xs:attribute ref="dataSource"/>
 													</xs:complexType>
 												</xs:element>
 											</xs:sequence>
+											<xs:attribute ref="dataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element name="MeetsACCA5QIHVACSpecification" type="HPXMLBoolean" minOccurs="0"/>
@@ -1423,11 +1503,13 @@
 												<xs:element minOccurs="0" name="Standard" type="HVACInstallationStandard"/>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
+											<xs:attribute ref="dataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element minOccurs="0" name="WaterHeaterImprovement" type="WaterHeaterImprovementInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element maxOccurs="unbounded" minOccurs="0" name="WaterHeatingControl">
@@ -1442,6 +1524,7 @@
 									<xs:element minOccurs="0" name="TemperatureControl" type="DHWTemperatureControl"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element maxOccurs="unbounded" minOccurs="0" name="HotWaterDistribution">
@@ -1468,6 +1551,7 @@
 															</xs:element>
 															<xs:element minOccurs="0" ref="extension"/>
 														</xs:sequence>
+														<xs:attribute ref="dataSource"/>
 													</xs:complexType>
 												</xs:element>
 												<xs:element name="Recirculation">
@@ -1494,9 +1578,11 @@
 															</xs:element>
 															<xs:element minOccurs="0" ref="extension"/>
 														</xs:sequence>
+														<xs:attribute ref="dataSource"/>
 													</xs:complexType>
 												</xs:element>
 											</xs:choice>
+											<xs:attribute ref="dataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element minOccurs="0" name="PipeInsulation" type="PipeInsulationType"/>
@@ -1512,10 +1598,12 @@
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
+											<xs:attribute ref="dataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element maxOccurs="unbounded" minOccurs="0" name="WaterFixture">
@@ -1564,6 +1652,7 @@
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element name="AnnualEnergyUse" minOccurs="0">
@@ -1571,9 +1660,11 @@
 								<xs:sequence>
 									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="SolarThermal">
@@ -1658,9 +1749,11 @@
 									</xs:element>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Photovoltaics">
@@ -1738,9 +1831,11 @@
 									</xs:element>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Batteries">
@@ -1764,7 +1859,8 @@
 									<xs:element minOccurs="0" name="CoolingStrategy" type="BatteryCoolingStrategy"/>
 									<xs:element minOccurs="0" name="NominalCapacity" type="BatteryCapacity">
 										<xs:annotation>
-											<xs:documentation>[Ah] The total Ampere hours available when the battery is discharged starting from 100% state of charge until it reaches the cut-off voltage. Capacity is computed by multiplying the discharge current (Amps) by the discharge time (hours).</xs:documentation>
+											<xs:documentation>[Ah] The total Ampere hours available when the battery is discharged starting from 100% state of charge until it reaches the cut-off
+												voltage. Capacity is computed by multiplying the discharge current (Amps) by the discharge time (hours).</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="UsableCapacity" type="BatteryCapacity">
@@ -1784,19 +1880,23 @@
 									</xs:element>
 									<xs:element minOccurs="0" name="NominalVoltage" type="HPXMLDecimal">
 										<xs:annotation>
-											<xs:documentation>[V] The nominal voltage is the battery voltage when the state of charge is 0.5 (midway between being fully charged, and fully discharged) with a 0.2C discharge current.</xs:documentation>
+											<xs:documentation>[V] The nominal voltage is the battery voltage when the state of charge is 0.5 (midway between being fully charged, and fully discharged)
+												with a 0.2C discharge current.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="RoundTripEfficiency" type="Fraction">
 										<xs:annotation>
-											<xs:documentation>Not all the power that is used to charge the battery is available during discharge. Round trip efficiency is the ratio of the energy put in to the energy retrieved from storage.</xs:documentation>
+											<xs:documentation>Not all the power that is used to charge the battery is available during discharge. Round trip efficiency is the ratio of the energy put
+												in to the energy retrieved from storage.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="ElectricVehicleChargers">
@@ -1836,9 +1936,11 @@
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Wind">
@@ -1893,13 +1995,16 @@
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="Appliances">
 		<xs:sequence>
@@ -1913,6 +2018,7 @@
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="Oven" type="OvenInfoType"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="Lighting">
 		<xs:sequence>
@@ -1969,6 +2075,7 @@
 						</xs:element>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="LightingFixture">
@@ -1979,6 +2086,7 @@
 						<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="LightingFixtureThirdPartyCertification"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="LightingControl" minOccurs="0" maxOccurs="unbounded">
@@ -1992,6 +2100,7 @@
 						<xs:element name="Location" type="LightingLocation" minOccurs="0"> </xs:element>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="CeilingFan">
@@ -2027,6 +2136,7 @@
 										</xs:annotation>
 									</xs:element>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" name="ThirdPartyCertification" type="ApplianceThirdPartyCertifications" maxOccurs="unbounded"/>
@@ -2037,10 +2147,12 @@
 						</xs:element>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="LightingType">
 		<xs:choice>
@@ -2050,6 +2162,7 @@
 						<xs:element minOccurs="0" name="Halogen" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="FluorescentTube">
@@ -2059,6 +2172,7 @@
 						<xs:element minOccurs="0" name="BallastType" type="FluorescentBallastType"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="CompactFluorescent">
@@ -2066,6 +2180,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="LightEmittingDiode">
@@ -2073,6 +2188,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="HighIntensityDischarge">
@@ -2095,14 +2211,17 @@
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
+											<xs:attribute ref="dataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element name="MetalHalide"/>
 								</xs:choice>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Other">
@@ -2111,9 +2230,11 @@
 						<xs:element minOccurs="0" name="Description" type="HPXMLString"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:choice>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="Pools">
 		<xs:sequence>
@@ -2246,13 +2367,16 @@
 															</xs:element>
 															<xs:element minOccurs="0" ref="extension"/>
 														</xs:sequence>
+														<xs:attribute ref="dataSource"/>
 													</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
+											<xs:attribute ref="dataSource"/>
 										</xs:complexType>
 									</xs:element>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" name="Cleaner">
@@ -2272,6 +2396,7 @@
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" name="Heater">
@@ -2291,13 +2416,16 @@
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="MiscLoads">
 		<xs:sequence>
@@ -2312,6 +2440,7 @@
 						<xs:element name="PlugLoadControlType" minOccurs="0" type="PlugLoadControlType"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="PlugLoad" minOccurs="0" maxOccurs="unbounded">
@@ -2329,14 +2458,17 @@
 									<xs:element name="Units" type="PlugLoadUnits"/>
 									<xs:element name="Value" type="HPXMLDouble"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="HealthAndSafety">
 		<xs:sequence>
@@ -2346,6 +2478,7 @@
 						<xs:element minOccurs="0" name="TestsCompleted" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="TestsPassed" type="HPXMLBoolean"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Ventilation" minOccurs="0">
@@ -2357,6 +2490,7 @@
 						<xs:element minOccurs="0" name="VentilationImprovement" type="VentilationImprovementInfo"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="MoistureControl" minOccurs="0">
@@ -2366,6 +2500,7 @@
 						<xs:element minOccurs="0" name="MoistureControlImprovement" type="MoistureControlImprovementInfo"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="CombustionAppliances">
@@ -2488,18 +2623,22 @@
 															<xs:element minOccurs="0" name="Notes" type="HPXMLString"/>
 															<xs:element minOccurs="0" ref="extension"/>
 														</xs:sequence>
+														<xs:attribute ref="dataSource"/>
 													</xs:complexType>
 												</xs:element>
 												<xs:element ref="extension" minOccurs="0"/>
 											</xs:sequence>
+											<xs:attribute ref="dataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element minOccurs="0" name="Notes" type="HPXMLString"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="StoveTest">
@@ -2514,6 +2653,7 @@
 						<xs:element name="ActionsTaken" type="HPXMLString" minOccurs="0"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="LeadPaint">
@@ -2541,6 +2681,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Radon">
@@ -2562,6 +2703,7 @@
 									<xs:element minOccurs="0" name="RadonTestMethod" type="RadonTestTypes"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" name="EducationMaterialProvided" type="HPXMLBoolean">
@@ -2585,6 +2727,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="SourcePollutants">
@@ -2622,6 +2765,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Pests">
@@ -2646,6 +2790,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Asbestos">
@@ -2671,6 +2816,7 @@
 						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecifications" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="SprayFoam">
@@ -2684,10 +2830,12 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="CAZApplianceReading">
 		<xs:sequence>
@@ -2700,6 +2848,7 @@
 			</xs:element>
 			<xs:element minOccurs="0" name="TestResult" type="TestResultType"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="CAZTestConfiguration">
 		<xs:sequence>
@@ -2712,6 +2861,7 @@
 						<xs:element minOccurs="0" name="CentralVacuum" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="AirHandler" type="HPXMLBoolean"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="DoorsOpenClosed">
@@ -2720,6 +2870,7 @@
 						<xs:element minOccurs="0" name="BasementDoors" type="OpenClosed"/>
 						<xs:element minOccurs="0" name="OtherDoors" type="OpenClosed"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Pressure" type="HPXMLDouble">
@@ -2729,6 +2880,7 @@
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="YesNoRecommendInstall">
 		<xs:choice>
@@ -2742,6 +2894,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="No">
@@ -2754,6 +2907,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="NA">
@@ -2761,9 +2915,11 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:choice>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="WholeBldgVentDesignInfo">
 		<xs:sequence>
@@ -2792,6 +2948,7 @@
 			<xs:element minOccurs="0" name="VentilationImprovementRecommendation" type="Recommendation"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="SpotVentDesignInfo">
 		<xs:sequence>
@@ -2831,6 +2988,7 @@
 			<xs:element minOccurs="0" name="AirflowRateUnits" type="SpotVentilationUnits"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="OtherVentIssues">
 		<xs:sequence>
@@ -2856,10 +3014,12 @@
 						<xs:element name="Description" type="HPXMLString"/>
 						<xs:element name="Answer" type="YesNoRecommendInstall"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="StatusMessage">
 		<xs:sequence>
@@ -2868,6 +3028,7 @@
 			<xs:element name="Message" type="HPXMLString"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="FuelSavingsType">
 		<xs:sequence>
@@ -2883,6 +3044,7 @@
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="EndUseSavings" type="EndUseInfoType"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="EndUseInfoType">
 		<xs:sequence>
@@ -2894,6 +3056,7 @@
 			</xs:element>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:group name="SystemInfo">
 		<xs:sequence>
@@ -2930,6 +3093,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="AnnualEnergyUse">
@@ -2937,10 +3101,12 @@
 					<xs:sequence>
 						<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="HVACMaintenance" type="HVACMaintenance"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="HeatingSystemInfoType">
 		<xs:complexContent>
@@ -2986,6 +3152,7 @@
 						<xs:element minOccurs="0" name="RetentionHead" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="WallFurnace" type="WallAndFloorFurnace"> </xs:element>
@@ -3005,6 +3172,7 @@
 						<xs:element minOccurs="0" name="RetentionHead" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="ElectricResistance">
@@ -3013,6 +3181,7 @@
 						<xs:element name="ElectricDistribution" type="ElectricDistributionType" minOccurs="0"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Fireplace">
@@ -3028,6 +3197,7 @@
 						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Stove">
@@ -3043,6 +3213,7 @@
 						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="PortableHeater">
@@ -3050,6 +3221,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="SolarThermal">
@@ -3058,6 +3230,7 @@
 						<xs:element minOccurs="0" name="SolarThermalSystem" type="LocalReference"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="DistrictSteam">
@@ -3066,6 +3239,7 @@
 						<xs:element minOccurs="0" name="DistrictSteamType" type="DistrictSteamType"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Other">
@@ -3074,9 +3248,11 @@
 						<xs:element minOccurs="0" name="Description" type="HPXMLString"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:choice>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="HeatPumpInfoType">
 		<xs:complexContent>
@@ -3173,6 +3349,7 @@
 			<xs:element name="Units" type="CoolingEfficiencyUnits"/>
 			<xs:element name="Value" type="Efficiency"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="HeatingEfficiencyType">
 		<xs:sequence>
@@ -3183,6 +3360,7 @@
 			</xs:element>
 			<xs:element name="Value" type="Efficiency"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="HydronicDistributionInfo">
 		<xs:sequence>
@@ -3221,10 +3399,12 @@
 						<xs:element minOccurs="0" name="ThermostaticRadiatorValves" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="VariableSpeedPump" type="HPXMLBoolean"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="AirDistributionInfo">
 		<xs:sequence>
@@ -3259,6 +3439,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="NumberofReturnRegisters" type="IntegerGreaterThanOrEqualToZero"/>
@@ -3268,10 +3449,12 @@
 						<xs:element minOccurs="0" name="Supply" type="TotalExternalStaticPressureMeasurement"/>
 						<xs:element minOccurs="0" name="Return" type="TotalExternalStaticPressureMeasurement"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:element name="BuildingSystemIdentifiers">
 		<xs:annotation>
@@ -3282,6 +3465,7 @@
 			<xs:sequence>
 				<xs:element ref="SystemIdentifiersInfo"/>
 			</xs:sequence>
+			<xs:attribute ref="dataSource"/>
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="Associations" type="AssociationsType"> </xs:element>
@@ -3299,6 +3483,7 @@
 			<xs:element name="IncentiveAmount" type="IncentiveAmount" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="BuildingDetailsType">
 		<xs:sequence>
@@ -3344,6 +3529,7 @@
 													</xs:annotation>
 												</xs:element>
 											</xs:sequence>
+											<xs:attribute ref="dataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element minOccurs="0" name="WalkingScore" type="IntegerGreaterThanOrEqualToZero"/>
@@ -3356,10 +3542,12 @@
 											<xs:sequence>
 												<xs:element maxOccurs="unbounded" name="Fuel" type="FuelType"/>
 											</xs:sequence>
+											<xs:attribute ref="dataSource"/>
 										</xs:complexType>
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" name="BuildingOccupancy">
@@ -3399,6 +3587,7 @@
 									<xs:element minOccurs="0" name="HighestLevelofOccupantEducation" type="EducationLevels"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" name="BuildingConstruction">
@@ -3549,6 +3738,7 @@
 									<xs:element minOccurs="0" name="SpaceAboveGarage" type="SpaceAboveGarage"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element name="AnnualEnergyUse" minOccurs="0">
@@ -3556,10 +3746,12 @@
 								<xs:sequence>
 									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType" maxOccurs="unbounded"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="ClimateandRiskZones" minOccurs="0">
@@ -3579,6 +3771,7 @@
 						</xs:element>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="GreenBuildingVerifications">
@@ -3593,7 +3786,9 @@
 									<xs:group ref="SystemInfo"/>
 									<xs:element name="Type" type="GreenBuildingVerificationType">
 										<xs:annotation>
-											<xs:documentation>The name of the verification or certification awarded to a new or pre-existing residential or commercial structure. For example: LEED, Energy Star, ICC-700. In cases where more than one certification have been awarded, leverage multiple iterations of the green verification fields via the repeating element method.</xs:documentation>
+											<xs:documentation>The name of the verification or certification awarded to a new or pre-existing residential or commercial structure. For example: LEED,
+												Energy Star, ICC-700. In cases where more than one certification have been awarded, leverage multiple iterations of the green verification fields via
+												the repeating element method.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="OtherType" type="HPXMLString">
@@ -3603,37 +3798,52 @@
 									</xs:element>
 									<xs:element minOccurs="0" name="Body" type="HPXMLString">
 										<xs:annotation>
-											<xs:documentation>The name of the body or group providing the verification/certification/rating named in the GreenBuildingVerificationType field. There is almost always a direct correlation between bodies and programs.</xs:documentation>
+											<xs:documentation>The name of the body or group providing the verification/certification/rating named in the GreenBuildingVerificationType field. There is
+												almost always a direct correlation between bodies and programs.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="Metric" type="HPXMLInteger">
 										<xs:annotation>
-											<xs:documentation>A final score indicating the performance of energy efficiency design and measures in the home as tested by a third-party rater. Points achieved to earn a certification in the GreenVerificationRating field do not apply to this field. HERS Index is most common with new homes and runs with a lower number being more efficient. A net-zero home uses zero energy and has a HERS score of 0. A home that produces more energy than it uses has a negative score. Home Energy Score is a tool more common for existing homes and runs with a higher number being more efficient. It takes square footage into account and caps with 10 as the highest number of points.</xs:documentation>
+											<xs:documentation>A final score indicating the performance of energy efficiency design and measures in the home as tested by a third-party rater. Points
+												achieved to earn a certification in the GreenVerificationRating field do not apply to this field. HERS Index is most common with new homes and runs with
+												a lower number being more efficient. A net-zero home uses zero energy and has a HERS score of 0. A home that produces more energy than it uses has a
+												negative score. Home Energy Score is a tool more common for existing homes and runs with a higher number being more efficient. It takes square footage
+												into account and caps with 10 as the highest number of points.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="Rating" type="HPXMLString">
 										<xs:annotation>
-											<xs:documentation>Many verifications or certifications have a rating system that provides an indication of the structure's level of energy efficiency. When expressed in a numeric value, please use the GreenVerificationMetric field. Verifications and Certifications can also be a name, such as Gold or Silver, which is the purpose of this field.</xs:documentation>
+											<xs:documentation>Many verifications or certifications have a rating system that provides an indication of the structure's level of energy efficiency. When
+												expressed in a numeric value, please use the GreenVerificationMetric field. Verifications and Certifications can also be a name, such as Gold or Silver,
+												which is the purpose of this field.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="Source" type="GreenBuildingVerificationSource">
 										<xs:annotation>
-											<xs:documentation>The source of the green data. May address photovoltaic characteristics, or a verified score, certification, label, etc. This may be a pick list of options showing the source. i.e. Program Sponsor, Program Verifier, Public Record, Assessor, etc.</xs:documentation>
+											<xs:documentation>The source of the green data. May address photovoltaic characteristics, or a verified score, certification, label, etc. This may be a pick
+												list of options showing the source. i.e. Program Sponsor, Program Verifier, Public Record, Assessor, etc.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="Status" type="GreenBuildingVerificationStatus">
 										<xs:annotation>
-											<xs:documentation>Many verification programs include a multi-step process that may begin with plans and specs, involve testing and/or submission of building specifications along the way and include a final verification step. When ratings are involved it is not uncommon for the final rating to be either higher or lower than the target preliminary rating. Sometimes the final approval is not available until after sale and occupancy. Status indicates what the target was at the time of listing and may be updated when verification is complete. To limit liability concerns this field reflects information that was available at the time of listing or updated later and should be confirmed by the buyer.</xs:documentation>
+											<xs:documentation>Many verification programs include a multi-step process that may begin with plans and specs, involve testing and/or submission of building
+												specifications along the way and include a final verification step. When ratings are involved it is not uncommon for the final rating to be either
+												higher or lower than the target preliminary rating. Sometimes the final approval is not available until after sale and occupancy. Status indicates what
+												the target was at the time of listing and may be updated when verification is complete. To limit liability concerns this field reflects information that
+												was available at the time of listing or updated later and should be confirmed by the buyer.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="URL" type="xs:anyURI">
 										<xs:annotation>
-											<xs:documentation>Provides a link to the specific property’s high-performance rating or scoring details directly from and hosted by the sponsoring body of the program. Typically provides thorough details, for example, which points where achieved and how, or in the case of a score what specifically was tested and the results.</xs:documentation>
+											<xs:documentation>Provides a link to the specific property’s high-performance rating or scoring details directly from and hosted by the sponsoring body of
+												the program. Typically provides thorough details, for example, which points where achieved and how, or in the case of a score what specifically was
+												tested and the results.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="Version" type="HPXMLString">
 										<xs:annotation>
-											<xs:documentation>The version of the certification or verification that was awarded. Some rating programs have a year, a version, or possibly both.</xs:documentation>
+											<xs:documentation>The version of the certification or verification that was awarded. Some rating programs have a year, a version, or possibly
+												both.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="Year" type="Year">
@@ -3643,9 +3853,11 @@
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Zones" type="Zones"/>
@@ -3658,6 +3870,7 @@
 			<xs:element minOccurs="0" name="HealthAndSafety" type="HealthAndSafety"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="ProjectDetailsType">
 		<xs:sequence>
@@ -3704,6 +3917,7 @@
 					<xs:sequence>
 						<xs:element maxOccurs="unbounded" name="Incentive" type="IncentiveDetailsType"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType" maxOccurs="2"/>
@@ -3713,16 +3927,19 @@
 					<xs:sequence>
 						<xs:element maxOccurs="unbounded" name="Measure" type="MeasureDetailsType"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="TotalCostType">
 		<xs:sequence>
 			<xs:element name="TotalCostHealthSafetyMeasures" type="TotalCostHealthSafetyMeasures" minOccurs="1"/>
 			<xs:element name="TotalCostQualEnergyMeasures" type="TotalCostQualEnergyMeasures" minOccurs="1"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="MeasureDetailsType">
 		<xs:sequence>
@@ -3734,6 +3951,7 @@
 					<xs:sequence>
 						<xs:element maxOccurs="unbounded" ref="SystemIdentifiersInfo"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element maxOccurs="unbounded" minOccurs="0" ref="ExternalResource"/>
@@ -3745,6 +3963,7 @@
 						<xs:element name="Units" type="HPXMLString"/>
 						<xs:element name="Value" type="Quantity"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Location" type="UnitLocation" minOccurs="0"/>
@@ -3757,6 +3976,7 @@
 					<xs:sequence>
 						<xs:element maxOccurs="unbounded" name="Incentive" type="IncentiveDetailsType"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="ResourceSavingsInfo">
@@ -3776,9 +3996,11 @@
 									<xs:element name="AnnualAmount" type="AnnualAmount" minOccurs="0"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType" maxOccurs="2"/>
@@ -3799,6 +4021,7 @@
 						<xs:element name="QAComments" type="Notes"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="ReplacedComponents">
@@ -3809,6 +4032,7 @@
 					<xs:sequence>
 						<xs:element maxOccurs="unbounded" name="ReplacedComponent" type="RemoteReference"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="InstalledComponents">
@@ -3816,10 +4040,12 @@
 					<xs:sequence>
 						<xs:element minOccurs="1" name="InstalledComponent" type="RemoteReference" maxOccurs="unbounded"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="EnergySavingsType">
 		<xs:sequence>
@@ -3842,6 +4068,7 @@
 			</xs:element>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="WaterSavingsType">
 		<xs:sequence>
@@ -3858,6 +4085,7 @@
 			<xs:element minOccurs="0" name="ReclaimedWaterSystem" type="HPXMLBoolean"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="DuctLeakageMeasurementType">
 		<xs:sequence>
@@ -3875,6 +4103,7 @@
 						<xs:element name="Value" type="MeasuredDuctLeakage" minOccurs="0"/>
 						<xs:element minOccurs="0" name="TotalOrToOutside" type="DuctLeakageTotalOrToOutside"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="EffectiveLeakageArea" type="SurfaceArea">
@@ -3885,6 +4114,7 @@
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="ConsumptionInfoType">
 		<xs:sequence>
@@ -3916,6 +4146,7 @@
 						<xs:element name="ConsumptionCost" type="HPXMLDouble" minOccurs="0"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="MarginalRate" type="HPXMLDouble" minOccurs="0"/>
@@ -3932,6 +4163,7 @@
 			</xs:element>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="BPI2400Inputs">
 		<xs:sequence>
@@ -4019,6 +4251,7 @@
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="EnergyAndWaterUseTypeDescription">
 		<xs:choice>
@@ -4047,9 +4280,11 @@
 												<xs:element name="EmissionUnits" type="EmissionUnits"/>
 												<xs:element name="Emissions" type="HPXMLDouble"/>
 											</xs:sequence>
+											<xs:attribute ref="dataSource"/>
 										</xs:complexType>
 									</xs:element>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" name="FuelInterruptibility" type="FuelInterruptibility"/>
@@ -4074,6 +4309,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Water">
@@ -4092,13 +4328,16 @@
 									<xs:element name="Units" type="WaterUseIntensityUnits"/>
 									<xs:element name="Value" type="HPXMLDouble"/>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:choice>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="ModeledUsageType">
 		<xs:sequence>
@@ -4120,6 +4359,7 @@
 			<xs:element minOccurs="0" name="ElectricityDemandKW" type="HPXMLDouble"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="StudProperties">
 		<xs:sequence>
@@ -4137,6 +4377,7 @@
 			<xs:element minOccurs="0" name="Material" type="StudMaterial"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="TelephoneInfoType">
 		<xs:sequence>
@@ -4146,6 +4387,7 @@
 			<xs:element name="TelephoneExtension" type="TelephoneExtension" minOccurs="0"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="EmailInfoType">
 		<xs:sequence>
@@ -4154,6 +4396,7 @@
 			<xs:element minOccurs="0" name="PreferredContactMethod" type="HPXMLBoolean"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="BusinessInfoType">
 		<xs:sequence>
@@ -4167,6 +4410,7 @@
 			<xs:element minOccurs="0" maxOccurs="unbounded" name="EmailInfo" type="EmailInfoType"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="BusinessContactInfoType">
 		<xs:sequence>
@@ -4174,6 +4418,7 @@
 			<xs:element minOccurs="0" name="Person" type="IndividualInfo"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:group name="WindowInfo">
 		<xs:sequence>
@@ -4215,6 +4460,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="ExteriorShading">
@@ -4224,23 +4470,24 @@
 						<xs:element minOccurs="0" name="Type" type="ExteriorShading"/>
 						<xs:element minOccurs="0" name="SummerShadingCoefficient" type="Fraction">
 							<xs:annotation>
-								<xs:documentation>The shading coefficient to apply during the summer months. Shading coefficients are defined as a multiplier on transmittance: 1 is transparent, 0 is opaque. </xs:documentation>
+								<xs:documentation>The shading coefficient to apply during the summer months. Shading coefficients are defined as a multiplier on transmittance: 1 is transparent, 0 is
+									opaque. </xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element minOccurs="0" name="WinterShadingCoefficient" type="Fraction">
 							<xs:annotation>
-								<xs:documentation>The shading coefficient to apply during the winter months. Shading coefficients are defined as a multiplier on transmittance: 1 is transparent, 0 is opaque. </xs:documentation>
+								<xs:documentation>The shading coefficient to apply during the winter months. Shading coefficients are defined as a multiplier on transmittance: 1 is transparent, 0 is
+									opaque. </xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="InteriorShading">
 				<xs:annotation>
-					<xs:documentation>Used to describe drapes, blinds, etc. 
-
-If moveable insulation also provides shading, the shading should be documented here. </xs:documentation>
+					<xs:documentation>Used to describe drapes, blinds, etc. If moveable insulation also provides shading, the shading should be documented here. </xs:documentation>
 				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
@@ -4248,16 +4495,19 @@ If moveable insulation also provides shading, the shading should be documented h
 						<xs:element minOccurs="0" name="Type" type="InteriorShading"/>
 						<xs:element minOccurs="0" name="SummerShadingCoefficient" type="Fraction">
 							<xs:annotation>
-								<xs:documentation>The shading coefficient to apply during the summer months. Shading coefficients are defined as a multiplier on transmittance: 1 is transparent, 0 is opaque. </xs:documentation>
+								<xs:documentation>The shading coefficient to apply during the summer months. Shading coefficients are defined as a multiplier on transmittance: 1 is transparent, 0 is
+									opaque. </xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element minOccurs="0" name="WinterShadingCoefficient" type="Fraction">
 							<xs:annotation>
-								<xs:documentation>The shading coefficient to apply during the winter months. Shading coefficients are defined as a multiplier on transmittance: 1 is transparent, 0 is opaque. </xs:documentation>
+								<xs:documentation>The shading coefficient to apply during the winter months. Shading coefficients are defined as a multiplier on transmittance: 1 is transparent, 0 is
+									opaque. </xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="StormWindow">
@@ -4270,6 +4520,7 @@ If moveable insulation also provides shading, the shading should be documented h
 						<xs:element minOccurs="0" name="Condition" type="WindowCondition"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="MoveableInsulation">
@@ -4282,6 +4533,7 @@ If moveable insulation also provides shading, the shading should be documented h
 						<xs:element minOccurs="0" name="RValue" type="RValue"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Overhangs">
@@ -4303,6 +4555,7 @@ If moveable insulation also provides shading, the shading should be documented h
 							</xs:annotation>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="WeatherStripping" type="HPXMLBoolean"/>
@@ -4318,6 +4571,7 @@ If moveable insulation also provides shading, the shading should be documented h
 						<xs:element minOccurs="0" name="ThermalBreak" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Composite">
@@ -4325,6 +4579,7 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Fiberglass">
@@ -4332,6 +4587,7 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Metal">
@@ -4340,6 +4596,7 @@ If moveable insulation also provides shading, the shading should be documented h
 						<xs:element minOccurs="0" name="ThermalBreak" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Vinyl">
@@ -4347,6 +4604,7 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Wood">
@@ -4354,6 +4612,7 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Other">
@@ -4362,9 +4621,11 @@ If moveable insulation also provides shading, the shading should be documented h
 						<xs:element minOccurs="0" name="Description"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:choice>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="AssociationsType">
 		<xs:all minOccurs="0">
@@ -4377,14 +4638,17 @@ If moveable insulation also provides shading, the shading should be documented h
 									<xs:element name="Measure" minOccurs="0" maxOccurs="unbounded">
 										<xs:complexType>
 											<xs:attribute name="ID" type="xs:int" use="required"/>
+											<xs:attribute ref="dataSource"/>
 										</xs:complexType>
 									</xs:element>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element name="JobRole" type="JobRole" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="ID" type="xs:int" use="required"/>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Locations" minOccurs="0">
@@ -4393,17 +4657,21 @@ If moveable insulation also provides shading, the shading should be documented h
 						<xs:element name="Location" minOccurs="0" maxOccurs="unbounded">
 							<xs:complexType>
 								<xs:attribute name="ID" type="xs:int" use="required"/>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Contractor" minOccurs="0">
 				<xs:complexType>
 					<xs:attribute name="ID" type="xs:int"/>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:all>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="AirInfiltrationMeasurementType">
 		<xs:sequence>
@@ -4437,6 +4705,7 @@ If moveable insulation also provides shading, the shading should be documented h
 						<xs:element name="UnitofMeasure" type="BuildingAirLeakageUnit" minOccurs="0"/>
 						<xs:element name="AirLeakage" type="BuildingAirLeakage" minOccurs="0"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="EffectiveLeakageArea" type="HPXMLDouble">
@@ -4453,6 +4722,7 @@ If moveable insulation also provides shading, the shading should be documented h
 			</xs:element>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="MoistureControlInfoType">
 		<xs:sequence>
@@ -4461,6 +4731,7 @@ If moveable insulation also provides shading, the shading should be documented h
 			<xs:element name="InteriorLocationsofWaterLeaksorDamage" type="InteriorLocationsofWaterLeaksorDamage" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="FoundationType">
 		<xs:choice>
@@ -4471,6 +4742,7 @@ If moveable insulation also provides shading, the shading should be documented h
 						<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Crawlspace">
@@ -4480,6 +4752,7 @@ If moveable insulation also provides shading, the shading should be documented h
 						<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="SlabOnGrade">
@@ -4487,6 +4760,7 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Garage">
@@ -4495,6 +4769,7 @@ If moveable insulation also provides shading, the shading should be documented h
 						<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="AboveApartment">
@@ -4505,6 +4780,7 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Combination">
@@ -4512,6 +4788,7 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Ambient">
@@ -4522,6 +4799,7 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="RubbleStone">
@@ -4529,6 +4807,7 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Other">
@@ -4536,9 +4815,11 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:choice>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="WallType">
 		<xs:annotation>
@@ -4560,6 +4841,7 @@ If moveable insulation also provides shading, the shading should be documented h
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="DoubleWoodStud">
@@ -4568,6 +4850,7 @@ If moveable insulation also provides shading, the shading should be documented h
 						<xs:element minOccurs="0" name="Staggered" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="ConcreteMasonryUnit">
@@ -4578,6 +4861,7 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="StructurallyInsulatedPanel">
@@ -4588,6 +4872,7 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="InsulatedConcreteForms">
@@ -4598,6 +4883,7 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="SteelFrame">
@@ -4605,6 +4891,7 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="SolidConcrete">
@@ -4612,6 +4899,7 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="StructuralBrick">
@@ -4619,6 +4907,7 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="StrawBale">
@@ -4626,6 +4915,7 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Stone">
@@ -4633,6 +4923,7 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="LogWall">
@@ -4640,6 +4931,7 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Other">
@@ -4647,9 +4939,11 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:choice>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="HVACControlType">
 		<xs:sequence>
@@ -4703,6 +4997,7 @@ If moveable insulation also provides shading, the shading should be documented h
 			<xs:element name="HVACSystemsServed" type="LocalReference" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="HVACControlTypeAdjustments">
 		<xs:sequence>
@@ -4710,6 +5005,7 @@ If moveable insulation also provides shading, the shading should be documented h
 			<xs:element minOccurs="0" name="Night" type="HPXMLBoolean"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="MoistureControlImprovementInfo">
 		<xs:sequence>
@@ -4720,6 +5016,7 @@ If moveable insulation also provides shading, the shading should be documented h
 			<xs:element name="OtherMeasuresImplementedDescription" type="HPXMLString" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="HVACDistributionImprovementInfo">
 		<xs:sequence>
@@ -4734,6 +5031,7 @@ If moveable insulation also provides shading, the shading should be documented h
 			<xs:element name="SystemPumpandZoneValveCorrectionsMade" type="HPXMLBoolean" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="HVACMaintenance">
 		<xs:sequence>
@@ -4771,6 +5069,7 @@ If moveable insulation also provides shading, the shading should be documented h
 										</xs:annotation>
 									</xs:element>
 								</xs:sequence>
+								<xs:attribute ref="dataSource"/>
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" name="MERVRating" type="MERV">
@@ -4786,10 +5085,12 @@ If moveable insulation also provides shading, the shading should be documented h
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="WaterHeaterImprovementInfo">
 		<xs:sequence>
@@ -4806,6 +5107,7 @@ If moveable insulation also provides shading, the shading should be documented h
 			<xs:element name="SystemReplaced" type="HPXMLBoolean" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="VentilationImprovementInfo">
 		<xs:sequence>
@@ -4813,6 +5115,7 @@ If moveable insulation also provides shading, the shading should be documented h
 			<xs:element name="MechanicalVentilationInstalled" type="HPXMLBoolean" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="Building">
 		<xs:sequence>
@@ -4829,6 +5132,7 @@ If moveable insulation also provides shading, the shading should be documented h
 						<xs:element minOccurs="0" name="eGridRegion" type="eGridRegions"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="ContractorID" type="RemoteReference"/>
@@ -4849,10 +5153,12 @@ If moveable insulation also provides shading, the shading should be documented h
 						</xs:element>
 						<xs:element maxOccurs="unbounded" name="ModeledUsage" type="ModeledUsageType"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="Project">
 		<xs:sequence>
@@ -4862,12 +5168,14 @@ If moveable insulation also provides shading, the shading should be documented h
 			<xs:element name="ProjectDetails" type="ProjectDetailsType"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="Contractor">
 		<xs:sequence>
 			<xs:element name="ContractorDetails" type="ContractorType"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="Customer">
 		<xs:sequence>
@@ -4882,6 +5190,7 @@ If moveable insulation also provides shading, the shading should be documented h
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="Comments">
@@ -4892,6 +5201,7 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element maxOccurs="unbounded" name="Comment" type="HPXMLString"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="OtherContact">
@@ -4901,10 +5211,12 @@ If moveable insulation also provides shading, the shading should be documented h
 						<xs:element name="Address" type="AddressInformation"> </xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="Utility">
 		<xs:sequence>
@@ -4916,10 +5228,12 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element maxOccurs="unbounded" ref="UtilityFuelProvider"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="Consumption">
 		<xs:sequence>
@@ -4930,10 +5244,12 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element maxOccurs="unbounded" name="ConsumptionInfo" type="ConsumptionInfoType"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="WeatherStation">
 		<xs:sequence>
@@ -4947,6 +5263,7 @@ If moveable insulation also provides shading, the shading should be documented h
 			<xs:element minOccurs="0" name="Use" nillable="true" type="WeatherStationUse"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="PipeInsulationType">
 		<xs:sequence>
@@ -4964,6 +5281,7 @@ If moveable insulation also provides shading, the shading should be documented h
 			</xs:element>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="TotalExternalStaticPressureMeasurement">
 		<xs:sequence>
@@ -4977,6 +5295,7 @@ If moveable insulation also provides shading, the shading should be documented h
 			<xs:element minOccurs="0" name="StaticPressureSource" type="StaticPressureSource"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="WallAndFloorFurnace">
 		<xs:sequence>
@@ -4989,6 +5308,7 @@ If moveable insulation also provides shading, the shading should be documented h
 			<xs:element minOccurs="0" name="RetentionHead" type="HPXMLBoolean"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="AtticType">
 		<xs:choice>
@@ -5000,6 +5320,7 @@ If moveable insulation also provides shading, the shading should be documented h
 						<xs:element minOccurs="0" name="CapeCod" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="CathedralCeiling">
@@ -5007,6 +5328,7 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="FlatRoof">
@@ -5014,6 +5336,7 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Other">
@@ -5021,15 +5344,18 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:choice>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="VentilationType">
 		<xs:sequence>
 			<xs:element name="UnitofMeasure" type="VentilationUnit" minOccurs="0"/>
 			<xs:element name="Value" type="BuildingAirLeakage" minOccurs="0"/>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:complexType name="PipeDiameterType">
 		<xs:sequence>
@@ -5043,9 +5369,11 @@ If moveable insulation also provides shading, the shading should be documented h
 							</xs:annotation>
 						</xs:element>
 					</xs:sequence>
+					<xs:attribute ref="dataSource"/>
 				</xs:complexType>
 			</xs:element>
 		</xs:sequence>
+		<xs:attribute ref="dataSource"/>
 	</xs:complexType>
 	<xs:element name="ExternalResource">
 		<xs:complexType>
@@ -5067,6 +5395,7 @@ If moveable insulation also provides shading, the shading should be documented h
 				<xs:element minOccurs="0" ref="extension"/>
 			</xs:sequence>
 			<xs:attribute name="id" use="required"/>
+			<xs:attribute ref="dataSource"/>
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="ConnectedDevice">
@@ -5080,6 +5409,7 @@ If moveable insulation also provides shading, the shading should be documented h
 				<xs:element minOccurs="0" name="OccupancySensor" type="HPXMLBoolean"/>
 				<xs:element minOccurs="0" ref="extension"/>
 			</xs:sequence>
+			<xs:attribute ref="dataSource"/>
 		</xs:complexType>
 	</xs:element>
 </xs:schema>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -2,6 +2,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2014/6"
 	targetNamespace="http://hpxmlonline.com/2014/6" elementFormDefault="qualified" version="2.3">
 	<xs:include schemaLocation="HPXMLDataTypes.xsd"/>
+	<xs:attribute name="dataSource" type="DataSource"/>
 	<xs:element name="XMLTransactionHeaderInformation">
 		<xs:annotation>
 			<xs:documentation>These are a series of elements that indicate the type of XML and basic descriptive data about the XML.</xs:documentation>

--- a/schemas/HPXML.xsd
+++ b/schemas/HPXML.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.0">
     <xs:include schemaLocation="BaseElements.xsd"/>
 
@@ -16,7 +16,7 @@
                 <xs:element maxOccurs="unbounded" minOccurs="0" name="Consumption" nillable="true" type="Consumption"/>
             </xs:sequence>
             <xs:attribute name="schemaVersion" type="schemaVersionType" use="required"/>
-            <xs:attribute ref="dataSource"/>
+            <xs:attribute name="dataSource" type="DataSource"/>
         </xs:complexType>
     </xs:element>
 </xs:schema>

--- a/schemas/HPXML.xsd
+++ b/schemas/HPXML.xsd
@@ -16,6 +16,7 @@
                 <xs:element maxOccurs="unbounded" minOccurs="0" name="Consumption" nillable="true" type="Consumption"/>
             </xs:sequence>
             <xs:attribute name="schemaVersion" type="schemaVersionType" use="required"/>
+            <xs:attribute ref="dataSource"/>
         </xs:complexType>
     </xs:element>
 </xs:schema>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -9,49 +9,49 @@
 	<xs:complexType name="HPXMLString">
 		<xs:simpleContent>
 			<xs:extension base="xs:string">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
 	<xs:complexType name="HPXMLDate">
 		<xs:simpleContent>
 			<xs:extension base="xs:date">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
 	<xs:complexType name="HPXMLDateTime">
 		<xs:simpleContent>
 			<xs:extension base="xs:dateTime">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
 	<xs:complexType name="HPXMLBoolean">
 		<xs:simpleContent>
 			<xs:extension base="xs:boolean">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
 	<xs:complexType name="HPXMLDouble">
 		<xs:simpleContent>
 			<xs:extension base="xs:double">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
 	<xs:complexType name="HPXMLDecimal">
 		<xs:simpleContent>
 			<xs:extension base="xs:decimal">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
 	<xs:complexType name="HPXMLInteger">
 		<xs:simpleContent>
 			<xs:extension base="xs:integer">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -70,7 +70,7 @@
 	<xs:complexType name="AddressTypeCode">
 		<xs:simpleContent>
 			<xs:extension base="AddressTypeCode_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -80,7 +80,7 @@
 	<xs:complexType name="StateCode">
 		<xs:simpleContent>
 			<xs:extension base="StateCode_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -92,7 +92,7 @@
 	<xs:complexType name="ZipCode">
 		<xs:simpleContent>
 			<xs:extension base="ZipCode_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -102,7 +102,7 @@
 	<xs:complexType name="USPSBarCode">
 		<xs:simpleContent>
 			<xs:extension base="USPSBarCode_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -113,7 +113,7 @@
 	<xs:complexType name="PrefixName">
 		<xs:simpleContent>
 			<xs:extension base="PrefixName_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -123,7 +123,7 @@
 	<xs:complexType name="SuffixName">
 		<xs:simpleContent>
 			<xs:extension base="SuffixName_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -140,7 +140,7 @@
 	<xs:complexType name="IndividualType">
 		<xs:simpleContent>
 			<xs:extension base="IndividualType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -154,7 +154,7 @@
 	<xs:complexType name="BusinessCertification">
 		<xs:simpleContent>
 			<xs:extension base="BusinessCertification_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -169,7 +169,7 @@
 	<xs:complexType name="TelephoneTypeCode">
 		<xs:simpleContent>
 			<xs:extension base="TelephoneTypeCode_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -179,7 +179,7 @@
 	<xs:complexType name="TelephoneNumber">
 		<xs:simpleContent>
 			<xs:extension base="TelephoneNumber_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -189,7 +189,7 @@
 	<xs:complexType name="TelephoneExtension">
 		<xs:simpleContent>
 			<xs:extension base="TelephoneExtension_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -204,7 +204,7 @@
 	<xs:complexType name="EmailTypeCode">
 		<xs:simpleContent>
 			<xs:extension base="EmailTypeCode_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -214,7 +214,7 @@
 	<xs:complexType name="EmailAddress">
 		<xs:simpleContent>
 			<xs:extension base="EmailAddress_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -225,7 +225,7 @@
 	<xs:complexType name="SendingSystemIdentifierType">
 		<xs:simpleContent>
 			<xs:extension base="SendingSystemIdentifierType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -235,7 +235,7 @@
 	<xs:complexType name="SendingSystemIdentifierValue">
 		<xs:simpleContent>
 			<xs:extension base="SendingSystemIdentifierValue_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -245,7 +245,7 @@
 	<xs:complexType name="ReceivingSystemIdentifierType">
 		<xs:simpleContent>
 			<xs:extension base="ReceivingSystemIdentifierType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -255,7 +255,7 @@
 	<xs:complexType name="ReceivingSystemIdentifierValue">
 		<xs:simpleContent>
 			<xs:extension base="ReceivingSystemIdentifierValue_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -266,7 +266,7 @@
 	<xs:complexType name="XMLType">
 		<xs:simpleContent>
 			<xs:extension base="XMLType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -276,7 +276,7 @@
 	<xs:complexType name="XMLGeneratedBy">
 		<xs:simpleContent>
 			<xs:extension base="XMLGeneratedBy_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -286,7 +286,7 @@
 	<xs:complexType name="CreatedDateAndTime">
 		<xs:simpleContent>
 			<xs:extension base="CreatedDateAndTime_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -305,7 +305,7 @@
 	<xs:complexType name="BuildingLeakiness">
 		<xs:simpleContent>
 			<xs:extension base="BuildingLeakiness_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -318,7 +318,7 @@
 	<xs:complexType name="WindConditions">
 		<xs:simpleContent>
 			<xs:extension base="WindConditions_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -330,7 +330,7 @@
 	<xs:complexType name="BuildingAirLeakage">
 		<xs:simpleContent>
 			<xs:extension base="BuildingAirLeakage_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -345,7 +345,7 @@
 	<xs:complexType name="BuildingAirLeakageUnit">
 		<xs:simpleContent>
 			<xs:extension base="BuildingAirLeakageUnit_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -355,7 +355,7 @@
 	<xs:complexType name="FanPressure">
 		<xs:simpleContent>
 			<xs:extension base="FanPressure_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -369,7 +369,7 @@
 	<xs:complexType name="FanRingUsed">
 		<xs:simpleContent>
 			<xs:extension base="FanRingUsed_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -379,7 +379,7 @@
 	<xs:complexType name="TestDate">
 		<xs:simpleContent>
 			<xs:extension base="TestDate_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -392,7 +392,7 @@
 	<xs:complexType name="TestInorOut">
 		<xs:simpleContent>
 			<xs:extension base="TestInorOut_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -405,7 +405,7 @@
 	<xs:complexType name="TypeofBlowerDoorTest">
 		<xs:simpleContent>
 			<xs:extension base="TypeofBlowerDoorTest_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -417,7 +417,7 @@
 	<xs:complexType name="HousePressure">
 		<xs:simpleContent>
 			<xs:extension base="HousePressure_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -432,7 +432,7 @@
 	<xs:complexType name="TypeofInfiltrationMeasurement">
 		<xs:simpleContent>
 			<xs:extension base="TypeofInfiltrationMeasurement_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -452,7 +452,7 @@
 	<xs:complexType name="ClimateZoneDOE">
 		<xs:simpleContent>
 			<xs:extension base="ClimateZoneDOE_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -467,7 +467,7 @@
 	<xs:complexType name="IECCYear">
 		<xs:simpleContent>
 			<xs:extension base="IECCYear_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -498,7 +498,7 @@
 	<xs:complexType name="ClimateZoneIECC">
 		<xs:simpleContent>
 			<xs:extension base="ClimateZoneIECC_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -508,7 +508,7 @@
 	<xs:complexType name="EarthquakeZone">
 		<xs:simpleContent>
 			<xs:extension base="EarthquakeZone_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -521,7 +521,7 @@
 	<xs:complexType name="RadonZone">
 		<xs:simpleContent>
 			<xs:extension base="RadonZone_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -536,7 +536,7 @@
 	<xs:complexType name="TermiteZone">
 		<xs:simpleContent>
 			<xs:extension base="TermiteZone_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -560,7 +560,7 @@
 	<xs:complexType name="ResidentialFacilityType">
 		<xs:simpleContent>
 			<xs:extension base="ResidentialFacilityType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -581,7 +581,7 @@
 	<xs:complexType name="EducationLevels">
 		<xs:simpleContent>
 			<xs:extension base="EducationLevels_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -600,7 +600,7 @@
 	<xs:complexType name="FootprintShape">
 		<xs:simpleContent>
 			<xs:extension base="FootprintShape_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -619,7 +619,7 @@
 	<xs:complexType name="OrientationType">
 		<xs:simpleContent>
 			<xs:extension base="OrientationType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -631,7 +631,7 @@
 	<xs:complexType name="NumberOfFloorsType">
 		<xs:simpleContent>
 			<xs:extension base="NumberOfFloorsType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -643,7 +643,7 @@
 	<xs:complexType name="IntegerGreaterThanZero">
 		<xs:simpleContent>
 			<xs:extension base="IntegerGreaterThanZero_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -655,7 +655,7 @@
 	<xs:complexType name="IntegerGreaterThanOrEqualToZero">
 		<xs:simpleContent>
 			<xs:extension base="IntegerGreaterThanOrEqualToZero_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -669,7 +669,7 @@
 	<xs:complexType name="SiteType">
 		<xs:simpleContent>
 			<xs:extension base="SiteType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -684,7 +684,7 @@
 	<xs:complexType name="Surroundings">
 		<xs:simpleContent>
 			<xs:extension base="Surroundings_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -699,7 +699,7 @@
 	<xs:complexType name="VerticalSurroundings">
 		<xs:simpleContent>
 			<xs:extension base="VerticalSurroundings_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -713,7 +713,7 @@
 	<xs:complexType name="ShieldingofHome">
 		<xs:simpleContent>
 			<xs:extension base="ShieldingofHome_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -727,7 +727,7 @@
 	<xs:complexType name="GarageLocation">
 		<xs:simpleContent>
 			<xs:extension base="GarageLocation_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -741,7 +741,7 @@
 	<xs:complexType name="SpaceAboveGarage">
 		<xs:simpleContent>
 			<xs:extension base="SpaceAboveGarage_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -760,7 +760,7 @@
 	<xs:complexType name="HouseholdType">
 		<xs:simpleContent>
 			<xs:extension base="HouseholdType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -779,7 +779,7 @@
 	<xs:complexType name="ResidentPopulationType">
 		<xs:simpleContent>
 			<xs:extension base="ResidentPopulationType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -794,7 +794,7 @@
 	<xs:complexType name="Occupancy">
 		<xs:simpleContent>
 			<xs:extension base="Occupancy_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -810,7 +810,7 @@
 	<xs:complexType name="OccupantIncomeRangeUnits">
 		<xs:simpleContent>
 			<xs:extension base="OccupantIncomeRangeUnits_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -820,7 +820,7 @@
 	<xs:complexType name="Year">
 		<xs:simpleContent>
 			<xs:extension base="Year_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -856,7 +856,7 @@
 	<xs:complexType name="ConsumptionType">
 		<xs:simpleContent>
 			<xs:extension base="ConsumptionType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -870,7 +870,7 @@
 	<xs:complexType name="MeteringConfiguration">
 		<xs:simpleContent>
 			<xs:extension base="MeteringConfiguration_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -885,7 +885,7 @@
 	<xs:complexType name="EmissionType">
 		<xs:simpleContent>
 			<xs:extension base="EmissionType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -900,7 +900,7 @@
 	<xs:complexType name="EmissionUnits">
 		<xs:simpleContent>
 			<xs:extension base="EmissionUnits_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -914,7 +914,7 @@
 	<xs:complexType name="FuelInterruptibility">
 		<xs:simpleContent>
 			<xs:extension base="FuelInterruptibility_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -928,7 +928,7 @@
 	<xs:complexType name="SharedEnergySystem">
 		<xs:simpleContent>
 			<xs:extension base="SharedEnergySystem_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -944,7 +944,7 @@
 	<xs:complexType name="IntervalType">
 		<xs:simpleContent>
 			<xs:extension base="IntervalType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -957,7 +957,7 @@
 	<xs:complexType name="PeakSeason">
 		<xs:simpleContent>
 			<xs:extension base="PeakSeason_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -967,7 +967,7 @@
 	<xs:complexType name="COReading">
 		<xs:simpleContent>
 			<xs:extension base="COReading_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -984,7 +984,7 @@
 	<xs:complexType name="RadonTestTypes">
 		<xs:simpleContent>
 			<xs:extension base="RadonTestTypes_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1001,7 +1001,7 @@
 	<xs:complexType name="RadonTestLocation">
 		<xs:simpleContent>
 			<xs:extension base="RadonTestLocation_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1037,7 +1037,7 @@
 	<xs:complexType name="FuelType">
 		<xs:simpleContent>
 			<xs:extension base="FuelType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1057,7 +1057,7 @@
 	<xs:complexType name="EventType">
 		<xs:simpleContent>
 			<xs:extension base="EventType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1081,7 +1081,7 @@
 	<xs:complexType name="AtticComponentsAirSealed">
 		<xs:simpleContent>
 			<xs:extension base="AtticComponentsAirSealed_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1102,7 +1102,7 @@
 	<xs:complexType name="BasementCrawlspaceComponentsAirSealed">
 		<xs:simpleContent>
 			<xs:extension base="BasementCrawlspaceComponentsAirSealed_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1122,7 +1122,7 @@
 	<xs:complexType name="LivingSpaceComponentsAirSealed">
 		<xs:simpleContent>
 			<xs:extension base="LivingSpaceComponentsAirSealed_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1139,7 +1139,7 @@
 	<xs:complexType name="FoundationWallType">
 		<xs:simpleContent>
 			<xs:extension base="FoundationWallType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1174,7 +1174,7 @@
 	<xs:complexType name="AdjacentTo">
 		<xs:simpleContent>
 			<xs:extension base="AdjacentTo_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1195,7 +1195,7 @@
 	<xs:complexType name="StudSize">
 		<xs:simpleContent>
 			<xs:extension base="StudSize_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1208,7 +1208,7 @@
 	<xs:complexType name="StudMaterial">
 		<xs:simpleContent>
 			<xs:extension base="StudMaterial_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1225,7 +1225,7 @@
 	<xs:complexType name="DoorMaterial">
 		<xs:simpleContent>
 			<xs:extension base="DoorMaterial_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1239,7 +1239,7 @@
 	<xs:complexType name="DoorType">
 		<xs:simpleContent>
 			<xs:extension base="DoorType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1251,7 +1251,7 @@
 	<xs:complexType name="RValue">
 		<xs:simpleContent>
 			<xs:extension base="RValue_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1265,7 +1265,7 @@
 	<xs:complexType name="DoorThirdPartyCertifications">
 		<xs:simpleContent>
 			<xs:extension base="DoorThirdPartyCertifications_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1280,7 +1280,7 @@
 	<xs:complexType name="InstallationType">
 		<xs:simpleContent>
 			<xs:extension base="InstallationType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1295,7 +1295,7 @@
 	<xs:complexType name="InsulationBattType">
 		<xs:simpleContent>
 			<xs:extension base="InsulationBattType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1311,7 +1311,7 @@
 	<xs:complexType name="InsulationLooseFillType">
 		<xs:simpleContent>
 			<xs:extension base="InsulationLooseFillType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1326,7 +1326,7 @@
 	<xs:complexType name="InsulationRigidType">
 		<xs:simpleContent>
 			<xs:extension base="InsulationRigidType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1340,7 +1340,7 @@
 	<xs:complexType name="InsulationSprayFoamType">
 		<xs:simpleContent>
 			<xs:extension base="InsulationSprayFoamType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1354,7 +1354,7 @@
 	<xs:complexType name="InsulationCondition">
 		<xs:simpleContent>
 			<xs:extension base="InsulationCondition_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1369,7 +1369,7 @@
 	<xs:complexType name="InsulationLocation">
 		<xs:simpleContent>
 			<xs:extension base="InsulationLocation_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1384,7 +1384,7 @@
 	<xs:complexType name="LightingLocation">
 		<xs:simpleContent>
 			<xs:extension base="LightingLocation_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1404,7 +1404,7 @@
 	<xs:complexType name="FluorescentTubeType">
 		<xs:simpleContent>
 			<xs:extension base="FluorescentTubeType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1420,7 +1420,7 @@
 	<xs:complexType name="FluorescentBallastType">
 		<xs:simpleContent>
 			<xs:extension base="FluorescentBallastType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1440,7 +1440,7 @@
 	<xs:complexType name="LightingThirdPartyCertification">
 		<xs:simpleContent>
 			<xs:extension base="LightingThirdPartyCertification_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1455,7 +1455,7 @@
 	<xs:complexType name="LightingDailyHours">
 		<xs:simpleContent>
 			<xs:extension base="LightingDailyHours_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1475,7 +1475,7 @@
 	<xs:complexType name="LightingControls">
 		<xs:simpleContent>
 			<xs:extension base="LightingControls_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1495,7 +1495,7 @@
 	<xs:complexType name="ExteriorLocationsWaterIntrusionorDamage">
 		<xs:simpleContent>
 			<xs:extension base="ExteriorLocationsWaterIntrusionorDamage_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1510,7 +1510,7 @@
 	<xs:complexType name="InteriorLocationsofWaterLeaksorDamage">
 		<xs:simpleContent>
 			<xs:extension base="InteriorLocationsofWaterLeaksorDamage_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1528,7 +1528,7 @@
 	<xs:complexType name="PlugLoadControlType">
 		<xs:simpleContent>
 			<xs:extension base="PlugLoadControlType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1547,7 +1547,7 @@
 	<xs:complexType name="RadiantBarrierLocation">
 		<xs:simpleContent>
 			<xs:extension base="RadiantBarrierLocation_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1567,7 +1567,7 @@
 	<xs:complexType name="HVACThirdPartyCertification">
 		<xs:simpleContent>
 			<xs:extension base="HVACThirdPartyCertification_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1583,7 +1583,7 @@
 	<xs:complexType name="DHWThirdPartyCertification">
 		<xs:simpleContent>
 			<xs:extension base="DHWThirdPartyCertification_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1599,7 +1599,7 @@
 	<xs:complexType name="GlassLayers">
 		<xs:simpleContent>
 			<xs:extension base="GlassLayers_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1612,7 +1612,7 @@
 	<xs:complexType name="WindowThirdPartyCertification">
 		<xs:simpleContent>
 			<xs:extension base="WindowThirdPartyCertification_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1625,7 +1625,7 @@
 	<xs:complexType name="SHGC">
 		<xs:simpleContent>
 			<xs:extension base="SHGC_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1643,7 +1643,7 @@
 	<xs:complexType name="InteriorShading">
 		<xs:simpleContent>
 			<xs:extension base="InteriorShading_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1663,7 +1663,7 @@
 	<xs:complexType name="ExteriorShading">
 		<xs:simpleContent>
 			<xs:extension base="ExteriorShading_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1675,7 +1675,7 @@
 	<xs:complexType name="UFactor">
 		<xs:simpleContent>
 			<xs:extension base="UFactor_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1689,7 +1689,7 @@
 	<xs:complexType name="FlueCondition">
 		<xs:simpleContent>
 			<xs:extension base="FlueCondition_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1700,7 +1700,7 @@
 	<xs:complexType name="CAZDepressurizationLimit">
 		<xs:simpleContent>
 			<xs:extension base="CAZDepressurizationLimit_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1713,7 +1713,7 @@
 	<xs:complexType name="OpenClosed">
 		<xs:simpleContent>
 			<xs:extension base="OpenClosed_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1726,7 +1726,7 @@
 	<xs:complexType name="DepressurizationFindingPoorCase">
 		<xs:simpleContent>
 			<xs:extension base="DepressurizationFindingPoorCase_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1736,7 +1736,7 @@
 	<xs:complexType name="NetPressureChange">
 		<xs:simpleContent>
 			<xs:extension base="NetPressureChange_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1753,7 +1753,7 @@
 	<xs:complexType name="CoolingSystemType">
 		<xs:simpleContent>
 			<xs:extension base="CoolingSystemType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1768,7 +1768,7 @@
 	<xs:complexType name="CoolingEfficiencyUnits">
 		<xs:simpleContent>
 			<xs:extension base="CoolingEfficiencyUnits_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1783,7 +1783,7 @@
 	<xs:complexType name="HeatingEfficiencyUnits">
 		<xs:simpleContent>
 			<xs:extension base="HeatingEfficiencyUnits_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1797,7 +1797,7 @@
 	<xs:complexType name="DistrictSteamType">
 		<xs:simpleContent>
 			<xs:extension base="DistrictSteamType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1809,7 +1809,7 @@
 	<xs:complexType name="Efficiency">
 		<xs:simpleContent>
 			<xs:extension base="Efficiency_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1824,7 +1824,7 @@
 	<xs:complexType name="GeothermalLoop">
 		<xs:simpleContent>
 			<xs:extension base="GeothermalLoop_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1842,7 +1842,7 @@
 	<xs:complexType name="HeatPumpType">
 		<xs:simpleContent>
 			<xs:extension base="HeatPumpType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1859,7 +1859,7 @@
 	<xs:complexType name="VentSystem">
 		<xs:simpleContent>
 			<xs:extension base="VentSystem_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1873,7 +1873,7 @@
 	<xs:complexType name="AFUE">
 		<xs:simpleContent>
 			<xs:extension base="AFUE_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1885,7 +1885,7 @@
 	<xs:complexType name="COP">
 		<xs:simpleContent>
 			<xs:extension base="COP_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1898,7 +1898,7 @@
 	<xs:complexType name="HSPF">
 		<xs:simpleContent>
 			<xs:extension base="HSPF_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1910,7 +1910,7 @@
 	<xs:complexType name="SEER">
 		<xs:simpleContent>
 			<xs:extension base="SEER_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1922,7 +1922,7 @@
 	<xs:complexType name="EER">
 		<xs:simpleContent>
 			<xs:extension base="EER_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1934,7 +1934,7 @@
 	<xs:complexType name="kWperTon">
 		<xs:simpleContent>
 			<xs:extension base="kWperTon_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1947,7 +1947,7 @@
 	<xs:complexType name="DuctType">
 		<xs:simpleContent>
 			<xs:extension base="DuctType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1964,7 +1964,7 @@
 	<xs:complexType name="DuctMaterial">
 		<xs:simpleContent>
 			<xs:extension base="DuctMaterial_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -1998,7 +1998,7 @@
 	<xs:complexType name="DuctLocation">
 		<xs:simpleContent>
 			<xs:extension base="DuctLocation_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2013,7 +2013,7 @@
 	<xs:complexType name="DuctLeakageTestMethod">
 		<xs:simpleContent>
 			<xs:extension base="DuctLeakageTestMethod_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2028,7 +2028,7 @@
 	<xs:complexType name="DuctLeakageTestUnitofMeasure">
 		<xs:simpleContent>
 			<xs:extension base="DuctLeakageTestUnitofMeasure_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2044,7 +2044,7 @@
 	<xs:complexType name="LeakinessObservedVisualInspection">
 		<xs:simpleContent>
 			<xs:extension base="LeakinessObservedVisualInspection_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2054,7 +2054,7 @@
 	<xs:complexType name="MeasuredDuctLeakage">
 		<xs:simpleContent>
 			<xs:extension base="MeasuredDuctLeakage_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2068,7 +2068,7 @@
 	<xs:complexType name="AirHandlerStaticPressureMeasurementLocation">
 		<xs:simpleContent>
 			<xs:extension base="AirHandlerStaticPressureMeasurementLocation_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2082,7 +2082,7 @@
 	<xs:complexType name="StaticPressureSource">
 		<xs:simpleContent>
 			<xs:extension base="StaticPressureSource_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2092,7 +2092,7 @@
 	<xs:complexType name="Capacity">
 		<xs:simpleContent>
 			<xs:extension base="Capacity_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2114,7 +2114,7 @@
 	<xs:complexType name="HVACMaintenanceSchedule">
 		<xs:simpleContent>
 			<xs:extension base="HVACMaintenanceSchedule_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2124,7 +2124,7 @@
 	<xs:complexType name="DispositionofExistingSystem">
 		<xs:simpleContent>
 			<xs:extension base="DispositionofExistingSystem_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2134,7 +2134,7 @@
 	<xs:complexType name="Manufacturer">
 		<xs:simpleContent>
 			<xs:extension base="Manufacturer_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2144,7 +2144,7 @@
 	<xs:complexType name="Model">
 		<xs:simpleContent>
 			<xs:extension base="Model_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2177,7 +2177,7 @@
 	<xs:complexType name="UnitLocation">
 		<xs:simpleContent>
 			<xs:extension base="UnitLocation_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2188,7 +2188,7 @@
 	<xs:complexType name="Temperature">
 		<xs:simpleContent>
 			<xs:extension base="Temperature_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2205,7 +2205,7 @@
 	<xs:complexType name="ThermostatType">
 		<xs:simpleContent>
 			<xs:extension base="ThermostatType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2218,7 +2218,7 @@
 	<xs:complexType name="HotWaterResetControl">
 		<xs:simpleContent>
 			<xs:extension base="HotWaterResetControl_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2228,7 +2228,7 @@
 	<xs:complexType name="Hours">
 		<xs:simpleContent>
 			<xs:extension base="Hours_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2242,7 +2242,7 @@
 	<xs:complexType name="EnergyFactor">
 		<xs:simpleContent>
 			<xs:extension base="EnergyFactor_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2252,7 +2252,7 @@
 	<xs:complexType name="PipeInsulated">
 		<xs:simpleContent>
 			<xs:extension base="PipeInsulated_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2265,7 +2265,7 @@
 	<xs:complexType name="RecoveryEfficiency">
 		<xs:simpleContent>
 			<xs:extension base="RecoveryEfficiency_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2277,7 +2277,7 @@
 	<xs:complexType name="Volume">
 		<xs:simpleContent>
 			<xs:extension base="Volume_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2290,7 +2290,7 @@
 	<xs:complexType name="ThermalEfficiency">
 		<xs:simpleContent>
 			<xs:extension base="ThermalEfficiency_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2300,7 +2300,7 @@
 	<xs:complexType name="ProjectType">
 		<xs:simpleContent>
 			<xs:extension base="ProjectType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2319,7 +2319,7 @@
 	<xs:complexType name="ApplianceThirdPartyCertifications">
 		<xs:simpleContent>
 			<xs:extension base="ApplianceThirdPartyCertifications_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2337,7 +2337,7 @@
 	<xs:complexType name="DishwasherType">
 		<xs:simpleContent>
 			<xs:extension base="DishwasherType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2349,7 +2349,7 @@
 	<xs:complexType name="RatedAnnualkWh">
 		<xs:simpleContent>
 			<xs:extension base="RatedAnnualkWh_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2361,7 +2361,7 @@
 	<xs:complexType name="RatedWaterGalPerCycle">
 		<xs:simpleContent>
 			<xs:extension base="RatedWaterGalPerCycle_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2374,7 +2374,7 @@
 	<xs:complexType name="TotalCostHealthSafetyMeasures">
 		<xs:simpleContent>
 			<xs:extension base="TotalCostHealthSafetyMeasures_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2384,7 +2384,7 @@
 	<xs:complexType name="TotalCostQualEnergyMeasures">
 		<xs:simpleContent>
 			<xs:extension base="TotalCostQualEnergyMeasures_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2401,7 +2401,7 @@
 	<xs:complexType name="HomeownerQuestionaireScore">
 		<xs:simpleContent>
 			<xs:extension base="HomeownerQuestionaireScore_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2412,7 +2412,7 @@
 	<xs:complexType name="SoftwareProgramUsed">
 		<xs:simpleContent>
 			<xs:extension base="SoftwareProgramUsed_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2422,7 +2422,7 @@
 	<xs:complexType name="SoftwareProgramVersion">
 		<xs:simpleContent>
 			<xs:extension base="SoftwareProgramVersion_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2442,7 +2442,7 @@
 	<xs:complexType name="BusinessSpecialization">
 		<xs:simpleContent>
 			<xs:extension base="BusinessSpecialization_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2457,7 +2457,7 @@
 	<xs:complexType name="BusinessType">
 		<xs:simpleContent>
 			<xs:extension base="BusinessType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2474,7 +2474,7 @@
 	<xs:complexType name="AuditorQualification">
 		<xs:simpleContent>
 			<xs:extension base="AuditorQualification_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2496,7 +2496,7 @@
 	<xs:complexType name="ImplementerQualification">
 		<xs:simpleContent>
 			<xs:extension base="ImplementerQualification_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2512,7 +2512,7 @@
 	<xs:complexType name="AzimuthType">
 		<xs:simpleContent>
 			<xs:extension base="AzimuthType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2542,7 +2542,7 @@
 	<xs:complexType name="energyUnitType">
 		<xs:simpleContent>
 			<xs:extension base="energyUnitType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2560,7 +2560,7 @@
 	<xs:complexType name="waterUnitType">
 		<xs:simpleContent>
 			<xs:extension base="waterUnitType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2577,7 +2577,7 @@
 	<xs:complexType name="MeterReadingType">
 		<xs:simpleContent>
 			<xs:extension base="MeterReadingType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2592,7 +2592,7 @@
 	<xs:complexType name="WaterType">
 		<xs:simpleContent>
 			<xs:extension base="WaterType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2605,7 +2605,7 @@
 	<xs:complexType name="WaterUseIntensityUnits">
 		<xs:simpleContent>
 			<xs:extension base="WaterUseIntensityUnits_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2624,7 +2624,7 @@
 	<xs:complexType name="endUseType">
 		<xs:simpleContent>
 			<xs:extension base="endUseType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2637,7 +2637,7 @@
 	<xs:complexType name="MeasuredOrEstimated">
 		<xs:simpleContent>
 			<xs:extension base="MeasuredOrEstimated_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2650,7 +2650,7 @@
 	<xs:complexType name="GrossOrNet">
 		<xs:simpleContent>
 			<xs:extension base="GrossOrNet_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2662,7 +2662,7 @@
 	<xs:complexType name="SurfaceArea">
 		<xs:simpleContent>
 			<xs:extension base="SurfaceArea_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2675,7 +2675,7 @@
 	<xs:complexType name="TransactionType">
 		<xs:simpleContent>
 			<xs:extension base="TransactionType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2685,7 +2685,7 @@
 	<xs:complexType name="AuditorRelationship">
 		<xs:simpleContent>
 			<xs:extension base="AuditorRelationship_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2698,7 +2698,7 @@
 	<xs:complexType name="HVACInstallationStandard">
 		<xs:simpleContent>
 			<xs:extension base="HVACInstallationStandard_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2712,7 +2712,7 @@
 	<xs:complexType name="HVACSizingCalcs">
 		<xs:simpleContent>
 			<xs:extension base="HVACSizingCalcs_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2728,7 +2728,7 @@
 	<xs:complexType name="HydronicDistributionType">
 		<xs:simpleContent>
 			<xs:extension base="HydronicDistributionType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2742,7 +2742,7 @@
 	<xs:complexType name="AirDistributionType">
 		<xs:simpleContent>
 			<xs:extension base="AirDistributionType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2756,7 +2756,7 @@
 	<xs:complexType name="ElectricDistributionType">
 		<xs:simpleContent>
 			<xs:extension base="ElectricDistributionType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2770,7 +2770,7 @@
 	<xs:complexType name="AirHandlerMotorType">
 		<xs:simpleContent>
 			<xs:extension base="AirHandlerMotorType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2792,7 +2792,7 @@
 	<xs:complexType name="PlugLoadType">
 		<xs:simpleContent>
 			<xs:extension base="PlugLoadType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2805,7 +2805,7 @@
 	<xs:complexType name="PlugLoadLocation">
 		<xs:simpleContent>
 			<xs:extension base="PlugLoadLocation_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2818,7 +2818,7 @@
 	<xs:complexType name="PlugLoadUnits">
 		<xs:simpleContent>
 			<xs:extension base="PlugLoadUnits_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2832,7 +2832,7 @@
 	<xs:complexType name="WindowCondition">
 		<xs:simpleContent>
 			<xs:extension base="WindowCondition_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2846,7 +2846,7 @@
 	<xs:complexType name="GasFill">
 		<xs:simpleContent>
 			<xs:extension base="GasFill_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2862,7 +2862,7 @@
 	<xs:complexType name="GlassType">
 		<xs:simpleContent>
 			<xs:extension base="GlassType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2877,7 +2877,7 @@
 	<xs:complexType name="ClothesWasherType">
 		<xs:simpleContent>
 			<xs:extension base="ClothesWasherType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2891,7 +2891,7 @@
 	<xs:complexType name="ClothesDryerType">
 		<xs:simpleContent>
 			<xs:extension base="ClothesDryerType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2912,7 +2912,7 @@
 	<xs:complexType name="LaundryMachineLocation">
 		<xs:simpleContent>
 			<xs:extension base="LaundryMachineLocation_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2928,7 +2928,7 @@
 	<xs:complexType name="FreezerStyle">
 		<xs:simpleContent>
 			<xs:extension base="FreezerStyle_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2951,7 +2951,7 @@
 	<xs:complexType name="RefrigeratorStyle">
 		<xs:simpleContent>
 			<xs:extension base="RefrigeratorStyle_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2972,7 +2972,7 @@
 	<xs:complexType name="RefrigeratorLocation">
 		<xs:simpleContent>
 			<xs:extension base="RefrigeratorLocation_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -2986,7 +2986,7 @@
 	<xs:complexType name="DehumidifierLocation">
 		<xs:simpleContent>
 			<xs:extension base="DehumidifierLocation_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3003,7 +3003,7 @@
 	<xs:complexType name="WaterHeaterType">
 		<xs:simpleContent>
 			<xs:extension base="WaterHeaterType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3018,7 +3018,7 @@
 	<xs:complexType name="SolarThermalSystemType">
 		<xs:simpleContent>
 			<xs:extension base="SolarThermalSystemType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3034,7 +3034,7 @@
 	<xs:complexType name="SolarThermalCollectorLoopType">
 		<xs:simpleContent>
 			<xs:extension base="SolarThermalCollectorLoopType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3051,7 +3051,7 @@
 	<xs:complexType name="SolarThermalCollectorType">
 		<xs:simpleContent>
 			<xs:extension base="SolarThermalCollectorType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3061,7 +3061,7 @@
 	<xs:complexType name="ResourceTypeCode">
 		<xs:simpleContent>
 			<xs:extension base="ResourceTypeCode_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3071,7 +3071,7 @@
 	<xs:complexType name="Quantity">
 		<xs:simpleContent>
 			<xs:extension base="Quantity_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3081,7 +3081,7 @@
 	<xs:complexType name="ProgramName">
 		<xs:simpleContent>
 			<xs:extension base="ProgramName_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3091,7 +3091,7 @@
 	<xs:complexType name="Title">
 		<xs:simpleContent>
 			<xs:extension base="Title_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3101,7 +3101,7 @@
 	<xs:complexType name="StartDate">
 		<xs:simpleContent>
 			<xs:extension base="StartDate_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3111,7 +3111,7 @@
 	<xs:complexType name="CompleteDateEstimated">
 		<xs:simpleContent>
 			<xs:extension base="CompleteDateEstimated_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3121,7 +3121,7 @@
 	<xs:complexType name="CompleteDateActual">
 		<xs:simpleContent>
 			<xs:extension base="CompleteDateActual_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3131,7 +3131,7 @@
 	<xs:complexType name="Notes">
 		<xs:simpleContent>
 			<xs:extension base="Notes_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3141,7 +3141,7 @@
 	<xs:complexType name="MeasureCode">
 		<xs:simpleContent>
 			<xs:extension base="MeasureCode_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3151,7 +3151,7 @@
 	<xs:complexType name="MeasureDescription">
 		<xs:simpleContent>
 			<xs:extension base="MeasureDescription_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3161,7 +3161,7 @@
 	<xs:complexType name="EstimatedLife">
 		<xs:simpleContent>
 			<xs:extension base="EstimatedLife_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3171,7 +3171,7 @@
 	<xs:complexType name="InstallationDate">
 		<xs:simpleContent>
 			<xs:extension base="InstallationDate_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3181,7 +3181,7 @@
 	<xs:complexType name="Cost">
 		<xs:simpleContent>
 			<xs:extension base="Cost_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3191,7 +3191,7 @@
 	<xs:complexType name="FundingSourceCode">
 		<xs:simpleContent>
 			<xs:extension base="FundingSourceCode_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3201,7 +3201,7 @@
 	<xs:complexType name="TotalAmount">
 		<xs:simpleContent>
 			<xs:extension base="TotalAmount_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3211,7 +3211,7 @@
 	<xs:complexType name="FundingSourceName">
 		<xs:simpleContent>
 			<xs:extension base="FundingSourceName_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3221,7 +3221,7 @@
 	<xs:complexType name="IncentiveAmount">
 		<xs:simpleContent>
 			<xs:extension base="IncentiveAmount_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3231,7 +3231,7 @@
 	<xs:complexType name="LoadProfile">
 		<xs:simpleContent>
 			<xs:extension base="LoadProfile_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3241,7 +3241,7 @@
 	<xs:complexType name="AnnualAmount">
 		<xs:simpleContent>
 			<xs:extension base="AnnualAmount_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3251,7 +3251,7 @@
 	<xs:complexType name="JobRole">
 		<xs:simpleContent>
 			<xs:extension base="JobRole_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3267,7 +3267,7 @@
 	<xs:complexType name="Fraction">
 		<xs:simpleContent>
 			<xs:extension base="Fraction_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3282,7 +3282,7 @@
 	<xs:complexType name="FractionGreaterThanOne">
 		<xs:simpleContent>
 			<xs:extension base="FractionGreaterThanOne_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3296,7 +3296,7 @@
 	<xs:complexType name="ImprovementStatusType">
 		<xs:simpleContent>
 			<xs:extension base="ImprovementStatusType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3310,7 +3310,7 @@
 	<xs:complexType name="TestResultType">
 		<xs:simpleContent>
 			<xs:extension base="TestResultType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3323,7 +3323,7 @@
 	<xs:complexType name="FoundationThermalBoundary">
 		<xs:simpleContent>
 			<xs:extension base="FoundationThermalBoundary_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3339,7 +3339,7 @@
 	<xs:complexType name="WallAndRoofColor">
 		<xs:simpleContent>
 			<xs:extension base="WallAndRoofColor_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3362,7 +3362,7 @@
 	<xs:complexType name="RoofType">
 		<xs:simpleContent>
 			<xs:extension base="RoofType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3377,7 +3377,7 @@
 	<xs:complexType name="DeckType">
 		<xs:simpleContent>
 			<xs:extension base="DeckType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3399,7 +3399,7 @@
 	<xs:complexType name="Siding">
 		<xs:simpleContent>
 			<xs:extension base="Siding_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3411,7 +3411,7 @@
 	<xs:complexType name="LengthMeasurement">
 		<xs:simpleContent>
 			<xs:extension base="LengthMeasurement_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3424,7 +3424,7 @@
 	<xs:complexType name="InsulationGrade">
 		<xs:simpleContent>
 			<xs:extension base="InsulationGrade_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3440,7 +3440,7 @@
 	<xs:complexType name="FloorCovering">
 		<xs:simpleContent>
 			<xs:extension base="FloorCovering_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3452,7 +3452,7 @@
 	<xs:complexType name="Pitch">
 		<xs:simpleContent>
 			<xs:extension base="Pitch_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3465,7 +3465,7 @@
 	<xs:complexType name="Tilt">
 		<xs:simpleContent>
 			<xs:extension base="Tilt_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3479,7 +3479,7 @@
 	<xs:complexType name="PVSystemLocation">
 		<xs:simpleContent>
 			<xs:extension base="PVSystemLocation_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3495,7 +3495,7 @@
 	<xs:complexType name="PVSystemOwnership">
 		<xs:simpleContent>
 			<xs:extension base="PVSystemOwnership_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3508,7 +3508,7 @@
 	<xs:complexType name="EVChargingLevel">
 		<xs:simpleContent>
 			<xs:extension base="EVChargingLevel_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3523,7 +3523,7 @@
 	<xs:complexType name="EVChargingConnector">
 		<xs:simpleContent>
 			<xs:extension base="EVChargingConnector_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3535,7 +3535,7 @@
 	<xs:complexType name="Current">
 		<xs:simpleContent>
 			<xs:extension base="Current_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3547,7 +3547,7 @@
 	<xs:complexType name="Voltage">
 		<xs:simpleContent>
 			<xs:extension base="Voltage_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3559,7 +3559,7 @@
 	<xs:complexType name="Power">
 		<xs:simpleContent>
 			<xs:extension base="Power_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3572,7 +3572,7 @@
 	<xs:complexType name="ZoneType">
 		<xs:simpleContent>
 			<xs:extension base="ZoneType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3587,7 +3587,7 @@
 	<xs:complexType name="WholeBldgVentilationRequirementMethod">
 		<xs:simpleContent>
 			<xs:extension base="WholeBldgVentilationRequirementMethod_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3601,7 +3601,7 @@
 	<xs:complexType name="BooleanWithNA">
 		<xs:simpleContent>
 			<xs:extension base="BooleanWithNA_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3614,7 +3614,7 @@
 	<xs:complexType name="VentilationRateUnits">
 		<xs:simpleContent>
 			<xs:extension base="VentilationRateUnits_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3628,7 +3628,7 @@
 	<xs:complexType name="VentilationFanThirdPartyCertification">
 		<xs:simpleContent>
 			<xs:extension base="VentilationFanThirdPartyCertification_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3642,7 +3642,7 @@
 	<xs:complexType name="Recommendation">
 		<xs:simpleContent>
 			<xs:extension base="Recommendation_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3659,7 +3659,7 @@
 	<xs:complexType name="SpotVentilationLocation">
 		<xs:simpleContent>
 			<xs:extension base="SpotVentilationLocation_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3673,7 +3673,7 @@
 	<xs:complexType name="SpotVentilationUnits">
 		<xs:simpleContent>
 			<xs:extension base="SpotVentilationUnits_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3690,7 +3690,7 @@
 	<xs:complexType name="VentilationFanType">
 		<xs:simpleContent>
 			<xs:extension base="VentilationFanType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3703,7 +3703,7 @@
 	<xs:complexType name="HoursPerDay">
 		<xs:simpleContent>
 			<xs:extension base="HoursPerDay_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3721,7 +3721,7 @@
 	<xs:complexType name="VentilationFanLocation">
 		<xs:simpleContent>
 			<xs:extension base="VentilationFanLocation_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3737,7 +3737,7 @@
 	<xs:complexType name="eGridRegions">
 		<xs:simpleContent>
 			<xs:extension base="eGridRegions_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3747,7 +3747,7 @@
 	<xs:complexType name="ProgramSponsor">
 		<xs:simpleContent>
 			<xs:extension base="ProgramSponsor_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3776,7 +3776,7 @@
 	<xs:complexType name="GreenBuildingVerificationType">
 		<xs:simpleContent>
 			<xs:extension base="GreenBuildingVerificationType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3797,7 +3797,7 @@
 	<xs:complexType name="GreenBuildingVerificationSource">
 		<xs:simpleContent>
 			<xs:extension base="GreenBuildingVerificationSource_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3810,7 +3810,7 @@
 	<xs:complexType name="GreenBuildingVerificationStatus">
 		<xs:simpleContent>
 			<xs:extension base="GreenBuildingVerificationStatus_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3823,7 +3823,7 @@
 	<xs:complexType name="BoilerType">
 		<xs:simpleContent>
 			<xs:extension base="BoilerType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3836,7 +3836,7 @@
 	<xs:complexType name="KnownOrEstimated">
 		<xs:simpleContent>
 			<xs:extension base="KnownOrEstimated_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3853,7 +3853,7 @@
 	<xs:complexType name="PoolType">
 		<xs:simpleContent>
 			<xs:extension base="PoolType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3866,7 +3866,7 @@
 	<xs:complexType name="MonthsPerYear">
 		<xs:simpleContent>
 			<xs:extension base="MonthsPerYear_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3883,7 +3883,7 @@
 	<xs:complexType name="PoolFilterType">
 		<xs:simpleContent>
 			<xs:extension base="PoolFilterType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3901,7 +3901,7 @@
 	<xs:complexType name="PoolPumpType">
 		<xs:simpleContent>
 			<xs:extension base="PoolPumpType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3920,7 +3920,7 @@
 	<xs:complexType name="PoolPump3rdPartyCertification">
 		<xs:simpleContent>
 			<xs:extension base="PoolPump3rdPartyCertification_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3937,7 +3937,7 @@
 	<xs:complexType name="PoolPumpSpeedSetting">
 		<xs:simpleContent>
 			<xs:extension base="PoolPumpSpeedSetting_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3949,7 +3949,7 @@
 	<xs:complexType name="Speed">
 		<xs:simpleContent>
 			<xs:extension base="Speed_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3961,7 +3961,7 @@
 	<xs:complexType name="FlowRate">
 		<xs:simpleContent>
 			<xs:extension base="FlowRate_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3979,7 +3979,7 @@
 	<xs:complexType name="PoolCleanerType">
 		<xs:simpleContent>
 			<xs:extension base="PoolCleanerType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -3997,7 +3997,7 @@
 	<xs:complexType name="PoolHeaterType">
 		<xs:simpleContent>
 			<xs:extension base="PoolHeaterType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4011,7 +4011,7 @@
 	<xs:complexType name="BPI2400CalibrationQualification">
 		<xs:simpleContent>
 			<xs:extension base="BPI2400CalibrationQualification_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4026,7 +4026,7 @@
 	<xs:complexType name="WeatherStationType">
 		<xs:simpleContent>
 			<xs:extension base="WeatherStationType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4039,7 +4039,7 @@
 	<xs:complexType name="DuctLeakageTotalOrToOutside">
 		<xs:simpleContent>
 			<xs:extension base="DuctLeakageTotalOrToOutside_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4056,7 +4056,7 @@
 	<xs:complexType name="WeatherStationUse">
 		<xs:simpleContent>
 			<xs:extension base="WeatherStationUse_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4070,7 +4070,7 @@
 	<xs:complexType name="WaterFixtureType">
 		<xs:simpleContent>
 			<xs:extension base="WaterFixtureType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4089,7 +4089,7 @@
 	<xs:complexType name="WaterFixtureThirdPartyCertification">
 		<xs:simpleContent>
 			<xs:extension base="WaterFixtureThirdPartyCertification_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4109,7 +4109,7 @@
 	<xs:complexType name="LightingFixtureThirdPartyCertification">
 		<xs:simpleContent>
 			<xs:extension base="LightingFixtureThirdPartyCertification_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4121,7 +4121,7 @@
 	<xs:complexType name="PeopleCount">
 		<xs:simpleContent>
 			<xs:extension base="PeopleCount_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4134,7 +4134,7 @@
 	<xs:complexType name="WindThirdPartyCertification">
 		<xs:simpleContent>
 			<xs:extension base="WindThirdPartyCertification_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4147,7 +4147,7 @@
 	<xs:complexType name="DrainWaterHeatRecoveryFacilitiesConnected">
 		<xs:simpleContent>
 			<xs:extension base="DrainWaterHeatRecoveryFacilitiesConnected_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4163,7 +4163,7 @@
 	<xs:complexType name="RecirculationControlType">
 		<xs:simpleContent>
 			<xs:extension base="RecirculationControlType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4176,7 +4176,7 @@
 	<xs:complexType name="MERV">
 		<xs:simpleContent>
 			<xs:extension base="MERV_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4189,7 +4189,7 @@
 	<xs:complexType name="SolarAbsorptance">
 		<xs:simpleContent>
 			<xs:extension base="SolarAbsorptance_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4202,7 +4202,7 @@
 	<xs:complexType name="Emittance">
 		<xs:simpleContent>
 			<xs:extension base="Emittance_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4216,7 +4216,7 @@
 	<xs:complexType name="AtticWallType">
 		<xs:simpleContent>
 			<xs:extension base="AtticWallType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4229,7 +4229,7 @@
 	<xs:complexType name="MinutesPerDay">
 		<xs:simpleContent>
 			<xs:extension base="MinutesPerDay_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4243,7 +4243,7 @@
 	<xs:complexType name="VentilationUnit">
 		<xs:simpleContent>
 			<xs:extension base="VentilationUnit_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4259,7 +4259,7 @@
 	<xs:complexType name="BatteryType">
 		<xs:simpleContent>
 			<xs:extension base="BatteryType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4271,7 +4271,7 @@
 	<xs:complexType name="BatteryCapacity">
 		<xs:simpleContent>
 			<xs:extension base="BatteryCapacity_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4285,7 +4285,7 @@
 	<xs:complexType name="BatteryCoolingStrategy">
 		<xs:simpleContent>
 			<xs:extension base="BatteryCoolingStrategy_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4317,7 +4317,7 @@
 	<xs:complexType name="BatteryLocation">
 		<xs:simpleContent>
 			<xs:extension base="BatteryLocation_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4331,7 +4331,7 @@
 	<xs:complexType name="DiameterDimension">
 		<xs:simpleContent>
 			<xs:extension base="DiameterDimension_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4350,7 +4350,7 @@
 	<xs:complexType name="ConnectedDeviceCommunicationProtocol">
 		<xs:simpleContent>
 			<xs:extension base="ConnectedDeviceCommunicationProtocol_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4363,7 +4363,7 @@
 	<xs:complexType name="DHWControllerTechnology">
 		<xs:simpleContent>
 			<xs:extension base="DHWControllerTechnology_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4376,7 +4376,7 @@
 	<xs:complexType name="DHWTemperatureControl">
 		<xs:simpleContent>
 			<xs:extension base="DHWTemperatureControl_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4390,7 +4390,7 @@
 	<xs:complexType name="ClothesDryerControlType">
 		<xs:simpleContent>
 			<xs:extension base="ClothesDryerControlType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4402,7 +4402,7 @@
 	<xs:complexType name="CollectorRatedThermalLosses">
 		<xs:simpleContent>
 			<xs:extension base="CollectorRatedThermalLosses_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4415,7 +4415,7 @@
 	<xs:complexType name="SolarFraction">
 		<xs:simpleContent>
 			<xs:extension base="SolarFraction_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4428,7 +4428,7 @@
 	<xs:complexType name="CollectorRatedOpticalEfficiency">
 		<xs:simpleContent>
 			<xs:extension base="CollectorRatedOpticalEfficiency_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4442,7 +4442,7 @@
 	<xs:complexType name="PVModuleType">
 		<xs:simpleContent>
 			<xs:extension base="PVModuleType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4457,7 +4457,7 @@
 	<xs:complexType name="PVTracking">
 		<xs:simpleContent>
 			<xs:extension base="PVTracking_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4471,7 +4471,7 @@
 	<xs:complexType name="FanSpeed">
 		<xs:simpleContent>
 			<xs:extension base="FanSpeed_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4484,7 +4484,7 @@
 	<xs:complexType name="SodiumLight_Pressure">
 		<xs:simpleContent>
 			<xs:extension base="SodiumLight_Pressure_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4497,7 +4497,7 @@
 	<xs:complexType name="HeatPumpBackupType">
 		<xs:simpleContent>
 			<xs:extension base="HeatPumpBackupType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4514,7 +4514,7 @@
 	<xs:complexType name="ExternalResourceType">
 		<xs:simpleContent>
 			<xs:extension base="ExternalResourceType_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4526,7 +4526,7 @@
 	<xs:complexType name="SolarThermalSystemEnergyFactor">
 		<xs:simpleContent>
 			<xs:extension base="SolarThermalSystemEnergyFactor_simple">
-				<xs:attribute ref="dataSource"/>
+				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -4387,23 +4387,51 @@
 			<xs:enumeration value="temperature"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="ClothesDryerControlType">
+		<xs:simpleContent>
+			<xs:extension base="ClothesDryerControlType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="CollectorRatedThermalLosses_simple">
 		<xs:restriction base="xs:double">
 			<xs:minExclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="CollectorRatedThermalLosses">
+		<xs:simpleContent>
+			<xs:extension base="CollectorRatedThermalLosses_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="SolarFraction_simple">
 		<xs:restriction base="xs:double">
 			<xs:minExclusive value="0"/>
 			<xs:maxInclusive value="1"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="SolarFraction">
+		<xs:simpleContent>
+			<xs:extension base="SolarFraction_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="CollectorRatedOpticalEfficiency_simple">
 		<xs:restriction base="xs:double">
 			<xs:minExclusive value="0"/>
 			<xs:maxExclusive value="1"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="CollectorRatedOpticalEfficiency">
+		<xs:simpleContent>
+			<xs:extension base="CollectorRatedOpticalEfficiency_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="PVModuleType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="standard"/>
@@ -4411,6 +4439,13 @@
 			<xs:enumeration value="thin film"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="PVModuleType">
+		<xs:simpleContent>
+			<xs:extension base="PVModuleType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="PVTracking_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="fixed"/>
@@ -4419,6 +4454,13 @@
 			<xs:enumeration value="2-axis"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="PVTracking">
+		<xs:simpleContent>
+			<xs:extension base="PVTracking_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="FanSpeed_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="low"/>
@@ -4426,18 +4468,39 @@
 			<xs:enumeration value="high"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="FanSpeed">
+		<xs:simpleContent>
+			<xs:extension base="FanSpeed_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="SodiumLight_Pressure_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="high"/>
 			<xs:enumeration value="low"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="SodiumLight_Pressure">
+		<xs:simpleContent>
+			<xs:extension base="SodiumLight_Pressure_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="HeatPumpBackupType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="integrated"/>
 			<xs:enumeration value="separate"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="HeatPumpBackupType">
+		<xs:simpleContent>
+			<xs:extension base="HeatPumpBackupType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="ExternalResourceType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="photo"/>
@@ -4448,9 +4511,23 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="ExternalResourceType">
+		<xs:simpleContent>
+			<xs:extension base="ExternalResourceType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="SolarThermalSystemEnergyFactor_simple">
 		<xs:restriction base="xs:double">
 			<xs:minExclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="SolarThermalSystemEnergyFactor">
+		<xs:simpleContent>
+			<xs:extension base="SolarThermalSystemEnergyFactor_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 </xs:schema>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -2,6 +2,13 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.0">
 	<!-- Value Lists -->
 	<!--Address Information Below-->
+	<xs:complexType name="HPXMLString">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="schemaVersionType">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="3.0"/>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1,7 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.0">
-	<!-- Value Lists -->
-	<!--Address Information Below-->
 	<xs:complexType name="HPXMLString">
 		<xs:simpleContent>
 			<xs:extension base="xs:string">
@@ -9,36 +7,108 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+	<xs:complexType name="HPXMLDate">
+		<xs:simpleContent>
+			<xs:extension base="xs:date">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="HPXMLBoolean">
+		<xs:simpleContent>
+			<xs:extension base="xs:boolean">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="HPXMLDouble">
+		<xs:simpleContent>
+			<xs:extension base="xs:boolean">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="HPXMLDecimal">
+		<xs:simpleContent>
+			<xs:extension base="xs:boolean">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	
 	<xs:simpleType name="schemaVersionType">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="3.0"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="AddressTypeCode">
+	<!--Address Information Below-->
+	<xs:simpleType name="AddressTypeCode_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="street"/>
 			<xs:enumeration value="mailing"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="StateCode">
+	<xs:complexType name="AddressTypeCode">
+		<xs:simpleContent>
+			<xs:extension base="AddressTypeCode_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="StateCode_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="ZipCode">
+	<xs:complexType name="StateCode">
+		<xs:simpleContent>
+			<xs:extension base="StateCode_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ZipCode_simple">
 		<xs:restriction base="xs:string">
 			<xs:pattern value="[0-9]{5}(-[0-9]{4})?"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="USPSBarCode">
+	<xs:complexType name="ZipCode">
+		<xs:simpleContent>
+			<xs:extension base="ZipCode_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="USPSBarCode_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
+	<xs:complexType name="USPSBarCode">
+		<xs:simpleContent>
+			<xs:extension base="USPSBarCode_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Name Information Below-->
-	<xs:simpleType name="PrefixName">
+	<xs:simpleType name="PrefixName_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="SuffixName">
+	<xs:complexType name="PrefixName">
+		<xs:simpleContent>
+			<xs:extension base="PrefixName_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="SuffixName_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="IndividualType">
+	<xs:complexType name="SuffixName">
+		<xs:simpleContent>
+			<xs:extension base="SuffixName_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="IndividualType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="owner-occupant"/>
 			<xs:enumeration value="owner-non-occupant"/>
@@ -48,65 +118,163 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="BusinessCertification">
+	<xs:complexType name="IndividualType">
+		<xs:simpleContent>
+			<xs:extension base="IndividualType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="BusinessCertification_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="BPI"/>
 			<xs:enumeration value="RESNET"/>
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="BusinessCertification">
+		<xs:simpleContent>
+			<xs:extension base="BusinessCertification_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Telephone Information Below-->
-	<xs:simpleType name="TelephoneTypeCode">
+	<xs:simpleType name="TelephoneTypeCode_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="day"/>
 			<xs:enumeration value="evening"/>
 			<xs:enumeration value="mobile"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="TelephoneNumber">
+	<xs:complexType name="TelephoneTypeCode">
+		<xs:simpleContent>
+			<xs:extension base="TelephoneTypeCode_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="TelephoneNumber_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="TelephoneExtension">
+	<xs:complexType name="TelephoneNumber">
+		<xs:simpleContent>
+			<xs:extension base="TelephoneNumber_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="TelephoneExtension_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
+	<xs:complexType name="TelephoneExtension">
+		<xs:simpleContent>
+			<xs:extension base="TelephoneExtension_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Email Information Below-->
-	<xs:simpleType name="EmailTypeCode">
+	<xs:simpleType name="EmailTypeCode_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="personal"/>
 			<xs:enumeration value="work"/>
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="EmailAddress">
+	<xs:complexType name="EmailTypeCode">
+		<xs:simpleContent>
+			<xs:extension base="EmailTypeCode_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="EmailAddress_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
+	<xs:complexType name="EmailAddress">
+		<xs:simpleContent>
+			<xs:extension base="EmailAddress_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--System Identifiers Below-->
-	<xs:simpleType name="SendingSystemIdentifierType">
+	<xs:simpleType name="SendingSystemIdentifierType_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="SendingSystemIdentifierValue">
+	<xs:complexType name="SendingSystemIdentifierType">
+		<xs:simpleContent>
+			<xs:extension base="SendingSystemIdentifierType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="SendingSystemIdentifierValue_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="ReceivingSystemIdentifierType">
+	<xs:complexType name="SendingSystemIdentifierValue">
+		<xs:simpleContent>
+			<xs:extension base="SendingSystemIdentifierValue_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ReceivingSystemIdentifierType_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="ReceivingSystemIdentifierValue">
+	<xs:complexType name="ReceivingSystemIdentifierType">
+		<xs:simpleContent>
+			<xs:extension base="ReceivingSystemIdentifierType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ReceivingSystemIdentifierValue_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
+	<xs:complexType name="ReceivingSystemIdentifierValue">
+		<xs:simpleContent>
+			<xs:extension base="ReceivingSystemIdentifierValue_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--XMLTransaction Header Information Below-->
-	<xs:simpleType name="XMLType">
+	<xs:simpleType name="XMLType_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="XMLGeneratedBy">
+	<xs:complexType name="XMLType">
+		<xs:simpleContent>
+			<xs:extension base="XMLType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="XMLGeneratedBy_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="CreatedDateAndTime">
+	<xs:complexType name="XMLGeneratedBy">
+		<xs:simpleContent>
+			<xs:extension base="XMLGeneratedBy_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="CreatedDateAndTime_simple">
 		<xs:restriction base="xs:dateTime"/>
 	</xs:simpleType>
+	<xs:complexType name="CreatedDateAndTime">
+		<xs:simpleContent>
+			<xs:extension base="CreatedDateAndTime_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Utility Information Below-->
 	<!--Misc Data Fields Below-->
 	<!--Air Infiltration Below-->
-	<xs:simpleType name="BuildingLeakiness">
+	<xs:simpleType name="BuildingLeakiness_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="very tight"/>
 			<xs:enumeration value="tight"/>
@@ -115,18 +283,39 @@
 			<xs:enumeration value="very leaky"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="WindConditions">
+	<xs:complexType name="BuildingLeakiness">
+		<xs:simpleContent>
+			<xs:extension base="BuildingLeakiness_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="WindConditions_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="windy"/>
 			<xs:enumeration value="normal"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="BuildingAirLeakage">
+	<xs:complexType name="WindConditions">
+		<xs:simpleContent>
+			<xs:extension base="WindConditions_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="BuildingAirLeakage_simple">
 		<xs:restriction base="xs:double">
 			<xs:minExclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="BuildingAirLeakageUnit">
+	<xs:complexType name="BuildingAirLeakage">
+		<xs:simpleContent>
+			<xs:extension base="BuildingAirLeakage_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="BuildingAirLeakageUnit_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="CFM"/>
 			<xs:enumeration value="CFMnatural"/>
@@ -134,37 +323,86 @@
 			<xs:enumeration value="ACHnatural"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="FanPressure">
+	<xs:complexType name="BuildingAirLeakageUnit">
+		<xs:simpleContent>
+			<xs:extension base="BuildingAirLeakageUnit_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="FanPressure_simple">
 		<xs:restriction base="xs:double"/>
 	</xs:simpleType>
-	<xs:simpleType name="FanRingUsed">
+	<xs:complexType name="FanPressure">
+		<xs:simpleContent>
+			<xs:extension base="FanPressure_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="FanRingUsed_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="open"/>
 			<xs:enumeration value="A"/>
 			<xs:enumeration value="B"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="TestDate">
+	<xs:complexType name="FanRingUsed">
+		<xs:simpleContent>
+			<xs:extension base="FanRingUsed_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="TestDate_simple">
 		<xs:restriction base="xs:dateTime"/>
 	</xs:simpleType>
-	<xs:simpleType name="TestInorOut">
+	<xs:complexType name="TestDate">
+		<xs:simpleContent>
+			<xs:extension base="TestDate_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="TestInorOut_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="test in"/>
 			<xs:enumeration value="test out"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="TypeofBlowerDoorTest">
+	<xs:complexType name="TestInorOut">
+		<xs:simpleContent>
+			<xs:extension base="TestInorOut_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="TypeofBlowerDoorTest_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="pressurization"/>
 			<xs:enumeration value="depressurization"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="HousePressure">
+	<xs:complexType name="TypeofBlowerDoorTest">
+		<xs:simpleContent>
+			<xs:extension base="TypeofBlowerDoorTest_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="HousePressure_simple">
 		<xs:restriction base="xs:double">
 			<xs:minExclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="TypeofInfiltrationMeasurement">
+	<xs:complexType name="HousePressure">
+		<xs:simpleContent>
+			<xs:extension base="HousePressure_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="TypeofInfiltrationMeasurement_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="blower door"/>
 			<xs:enumeration value="tracer gas"/>
@@ -172,8 +410,15 @@
 			<xs:enumeration value="checklist"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="TypeofInfiltrationMeasurement">
+		<xs:simpleContent>
+			<xs:extension base="TypeofInfiltrationMeasurement_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Climate and Risk Zones-->
-	<xs:simpleType name="ClimateZoneDOE">
+	<xs:simpleType name="ClimateZoneDOE_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="subarctic"/>
 			<xs:enumeration value="marine"/>
@@ -185,7 +430,14 @@
 			<xs:enumeration value="very cold"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="IECCYear">
+	<xs:complexType name="ClimateZoneDOE">
+		<xs:simpleContent>
+			<xs:extension base="ClimateZoneDOE_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="IECCYear_simple">
 		<xs:restriction base="xs:integer">
 			<xs:enumeration value="2012"/>
 			<xs:enumeration value="2009"/>
@@ -193,7 +445,14 @@
 			<xs:enumeration value="2003"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="ClimateZoneIECC">
+	<xs:complexType name="IECCYear">
+		<xs:simpleContent>
+			<xs:extension base="IECCYear_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ClimateZoneIECC_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="1A"/>
 			<xs:enumeration value="1B"/>
@@ -217,16 +476,37 @@
 			<xs:enumeration value="8"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="EarthquakeZone">
+	<xs:complexType name="ClimateZoneIECC">
+		<xs:simpleContent>
+			<xs:extension base="ClimateZoneIECC_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="EarthquakeZone_simple">
 		<xs:restriction base="xs:boolean"/>
 	</xs:simpleType>
-	<xs:simpleType name="RadonZone">
+	<xs:complexType name="EarthquakeZone">
+		<xs:simpleContent>
+			<xs:extension base="EarthquakeZone_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="RadonZone_simple">
 		<xs:restriction base="xs:integer">
 			<xs:minInclusive value="1"/>
 			<xs:maxInclusive value="3"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="TermiteZone">
+	<xs:complexType name="RadonZone">
+		<xs:simpleContent>
+			<xs:extension base="RadonZone_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="TermiteZone_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="none to slight"/>
 			<xs:enumeration value="slight to moderate"/>
@@ -234,8 +514,15 @@
 			<xs:enumeration value="very heavy"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="TermiteZone">
+		<xs:simpleContent>
+			<xs:extension base="TermiteZone_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Construction Below-->
-	<xs:simpleType name="ResidentialFacilityType">
+	<xs:simpleType name="ResidentialFacilityType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="single-family detached"/>
 			<xs:enumeration value="single-family attached"/>
@@ -251,7 +538,14 @@
 			<xs:enumeration value="unknown"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="EducationLevels">
+	<xs:complexType name="ResidentialFacilityType">
+		<xs:simpleContent>
+			<xs:extension base="ResidentialFacilityType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="EducationLevels_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="no high school"/>
 			<xs:enumeration value="some high school"/>
@@ -265,7 +559,14 @@
 			<xs:enumeration value="doctoral degree"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="FootprintShape">
+	<xs:complexType name="EducationLevels">
+		<xs:simpleContent>
+			<xs:extension base="EducationLevels_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="FootprintShape_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="rectangular"/>
 			<xs:enumeration value="square"/>
@@ -277,7 +578,14 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="OrientationType">
+	<xs:complexType name="FootprintShape">
+		<xs:simpleContent>
+			<xs:extension base="FootprintShape_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="OrientationType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="north"/>
 			<xs:enumeration value="northwest"/>
@@ -289,29 +597,64 @@
 			<xs:enumeration value="northeast"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="NumberOfFloorsType">
+	<xs:complexType name="OrientationType">
+		<xs:simpleContent>
+			<xs:extension base="OrientationType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="NumberOfFloorsType_simple">
 		<xs:restriction base="xs:double">
 			<xs:minInclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="IntegerGreaterThanZero">
+	<xs:complexType name="NumberOfFloorsType">
+		<xs:simpleContent>
+			<xs:extension base="NumberOfFloorsType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="IntegerGreaterThanZero_simple">
 		<xs:restriction base="xs:integer">
 			<xs:minExclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="IntegerGreaterThanOrEqualToZero">
+	<xs:complexType name="IntegerGreaterThanZero">
+		<xs:simpleContent>
+			<xs:extension base="IntegerGreaterThanZero_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="IntegerGreaterThanOrEqualToZero_simple">
 		<xs:restriction base="xs:integer">
 			<xs:minInclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="SiteType">
+	<xs:complexType name="IntegerGreaterThanOrEqualToZero">
+		<xs:simpleContent>
+			<xs:extension base="IntegerGreaterThanOrEqualToZero_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="SiteType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="rural"/>
 			<xs:enumeration value="suburban"/>
 			<xs:enumeration value="urban"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="Surroundings">
+	<xs:complexType name="SiteType">
+		<xs:simpleContent>
+			<xs:extension base="SiteType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="Surroundings_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="stand-alone"/>
 			<xs:enumeration value="attached on one side"/>
@@ -319,7 +662,14 @@
 			<xs:enumeration value="attached on three sides"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="VerticalSurroundings">
+	<xs:complexType name="Surroundings">
+		<xs:simpleContent>
+			<xs:extension base="Surroundings_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="VerticalSurroundings_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="unit above"/>
 			<xs:enumeration value="unit below"/>
@@ -327,28 +677,56 @@
 			<xs:enumeration value="no units above or below"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="ShieldingofHome">
+	<xs:complexType name="VerticalSurroundings">
+		<xs:simpleContent>
+			<xs:extension base="VerticalSurroundings_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ShieldingofHome_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="well-shielded"/>
 			<xs:enumeration value="normal"/>
 			<xs:enumeration value="exposed"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="GarageLocation">
+	<xs:complexType name="ShieldingofHome">
+		<xs:simpleContent>
+			<xs:extension base="ShieldingofHome_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="GarageLocation_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="basement"/>
 			<xs:enumeration value="first floor"/>
 			<xs:enumeration value="detached"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="SpaceAboveGarage">
+	<xs:complexType name="GarageLocation">
+		<xs:simpleContent>
+			<xs:extension base="GarageLocation_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="SpaceAboveGarage_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="conditioned area"/>
 			<xs:enumeration value="unconditioned attic"/>
 			<xs:enumeration value="crawlspace"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="HouseholdType">
+	<xs:complexType name="SpaceAboveGarage">
+		<xs:simpleContent>
+			<xs:extension base="SpaceAboveGarage_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="HouseholdType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="family household"/>
 			<xs:enumeration value="married couple, no children"/>
@@ -360,7 +738,14 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="ResidentPopulationType">
+	<xs:complexType name="HouseholdType">
+		<xs:simpleContent>
+			<xs:extension base="HouseholdType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ResidentPopulationType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="no specific resident population"/>
 			<xs:enumeration value="student"/>
@@ -372,7 +757,14 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="Occupancy">
+	<xs:complexType name="ResidentPopulationType">
+		<xs:simpleContent>
+			<xs:extension base="ResidentPopulationType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="Occupancy_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="owner-occupied"/>
 			<xs:enumeration value="renter-occupied"/>
@@ -380,7 +772,14 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="OccupantIncomeRangeUnits">
+	<xs:complexType name="Occupancy">
+		<xs:simpleContent>
+			<xs:extension base="Occupancy_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="OccupantIncomeRangeUnits_simple">
 		<xs:annotation>
 			<xs:documentation>AMI = Area Median Income; FPL = Federal Poverty Level</xs:documentation>
 		</xs:annotation>
@@ -389,11 +788,25 @@
 			<xs:enumeration value="% federal poverty level"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="Year">
+	<xs:complexType name="OccupantIncomeRangeUnits">
+		<xs:simpleContent>
+			<xs:extension base="OccupantIncomeRangeUnits_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="Year_simple">
 		<xs:restriction base="xs:integer"/>
 	</xs:simpleType>
+	<xs:complexType name="Year">
+		<xs:simpleContent>
+			<xs:extension base="Year_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!-- Make sure to update FuelType with changes to this list as well. -->
-	<xs:simpleType name="ConsumptionType">
+	<xs:simpleType name="ConsumptionType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="electricity"/>
 			<xs:enumeration value="renewable electricity"/>
@@ -421,14 +834,28 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="MeteringConfiguration">
+	<xs:complexType name="ConsumptionType">
+		<xs:simpleContent>
+			<xs:extension base="ConsumptionType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="MeteringConfiguration_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="direct metering"/>
 			<xs:enumeration value="master meter without sub-metering"/>
 			<xs:enumeration value="master meter with sub-metering"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="EmissionType">
+	<xs:complexType name="MeteringConfiguration">
+		<xs:simpleContent>
+			<xs:extension base="MeteringConfiguration_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="EmissionType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="CO2"/>
 			<xs:enumeration value="methane"/>
@@ -436,7 +863,14 @@
 			<xs:enumeration value="CO2 equivalent"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="EmissionUnits">
+	<xs:complexType name="EmissionType">
+		<xs:simpleContent>
+			<xs:extension base="EmissionType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="EmissionUnits_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="kg"/>
 			<xs:enumeration value="ton"/>
@@ -444,21 +878,42 @@
 			<xs:enumeration value="pound"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="FuelInterruptibility">
+	<xs:complexType name="EmissionUnits">
+		<xs:simpleContent>
+			<xs:extension base="EmissionUnits_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="FuelInterruptibility_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="interruptible"/>
 			<xs:enumeration value="firm"/>
 			<xs:enumeration value="na"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="SharedEnergySystem">
+	<xs:complexType name="FuelInterruptibility">
+		<xs:simpleContent>
+			<xs:extension base="FuelInterruptibility_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="SharedEnergySystem_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="yes"/>
 			<xs:enumeration value="no"/>
 			<xs:enumeration value="common meter"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="IntervalType">
+	<xs:complexType name="SharedEnergySystem">
+		<xs:simpleContent>
+			<xs:extension base="SharedEnergySystem_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="IntervalType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="15-minute"/>
 			<xs:enumeration value="hourly"/>
@@ -467,16 +922,37 @@
 			<xs:enumeration value="annual"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="PeakSeason">
+	<xs:complexType name="IntervalType">
+		<xs:simpleContent>
+			<xs:extension base="IntervalType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="PeakSeason_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="summer"/>
 			<xs:enumeration value="winter"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="COReading">
+	<xs:complexType name="PeakSeason">
+		<xs:simpleContent>
+			<xs:extension base="PeakSeason_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="COReading_simple">
 		<xs:restriction base="xs:double"/>
 	</xs:simpleType>
-	<xs:simpleType name="RadonTestTypes">
+	<xs:complexType name="COReading">
+		<xs:simpleContent>
+			<xs:extension base="COReading_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="RadonTestTypes_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="activated charcoal absorption"/>
 			<xs:enumeration value="alpha-track detectors"/>
@@ -486,7 +962,14 @@
 			<xs:enumeration value="continuous radon monitoring"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="RadonTestLocation">
+	<xs:complexType name="RadonTestTypes">
+		<xs:simpleContent>
+			<xs:extension base="RadonTestTypes_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="RadonTestLocation_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="kitchen"/>
 			<xs:enumeration value="crawlspace"/>
@@ -496,8 +979,15 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="RadonTestLocation">
+		<xs:simpleContent>
+			<xs:extension base="RadonTestLocation_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!-- Make sure to update ConsumptionType with changes to this list as well. -->
-	<xs:simpleType name="FuelType">
+	<xs:simpleType name="FuelType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="electricity"/>
 			<xs:enumeration value="renewable electricity"/>
@@ -525,9 +1015,16 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="FuelType">
+		<xs:simpleContent>
+			<xs:extension base="FuelType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Other Health and Safety Below-->
 	<!--Standard Measure Fields Below-->
-	<xs:simpleType name="EventType">
+	<xs:simpleType name="EventType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="audit"/>
 			<xs:enumeration value="proposed workscope"/>
@@ -538,9 +1035,16 @@
 			<xs:enumeration value="preconstruction"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="EventType">
+		<xs:simpleContent>
+			<xs:extension base="EventType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Air Sealing Below-->
 	<!--Doors Below-->
-	<xs:simpleType name="AtticComponentsAirSealed">
+	<xs:simpleType name="AtticComponentsAirSealed_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="attic floor"/>
 			<xs:enumeration value="top plates"/>
@@ -555,7 +1059,14 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="BasementCrawlspaceComponentsAirSealed">
+	<xs:complexType name="AtticComponentsAirSealed">
+		<xs:simpleContent>
+			<xs:extension base="AtticComponentsAirSealed_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="BasementCrawlspaceComponentsAirSealed_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="plumbing penetrations"/>
 			<xs:enumeration value="access"/>
@@ -569,7 +1080,14 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="LivingSpaceComponentsAirSealed">
+	<xs:complexType name="BasementCrawlspaceComponentsAirSealed">
+		<xs:simpleContent>
+			<xs:extension base="BasementCrawlspaceComponentsAirSealed_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="LivingSpaceComponentsAirSealed_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="home-garage connection"/>
 			<xs:enumeration value="rim joists"/>
@@ -582,7 +1100,14 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="FoundationWallType">
+	<xs:complexType name="LivingSpaceComponentsAirSealed">
+		<xs:simpleContent>
+			<xs:extension base="LivingSpaceComponentsAirSealed_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="FoundationWallType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="solid concrete"/>
 			<xs:enumeration value="concrete block"/>
@@ -592,7 +1117,14 @@
 			<xs:enumeration value="wood"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="AdjacentTo">
+	<xs:complexType name="FoundationWallType">
+		<xs:simpleContent>
+			<xs:extension base="FoundationWallType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="AdjacentTo_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="attic"/>
 			<xs:enumeration value="attic - conditioned"/>
@@ -620,7 +1152,14 @@
 			<xs:enumeration value="unconditioned space"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="StudSize">
+	<xs:complexType name="AdjacentTo">
+		<xs:simpleContent>
+			<xs:extension base="AdjacentTo_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="StudSize_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="2x2"/>
 			<xs:enumeration value="2x3"/>
@@ -634,13 +1173,27 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="StudMaterial">
+	<xs:complexType name="StudSize">
+		<xs:simpleContent>
+			<xs:extension base="StudSize_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="StudMaterial_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="wood"/>
 			<xs:enumeration value="metal"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="DoorMaterial">
+	<xs:complexType name="StudMaterial">
+		<xs:simpleContent>
+			<xs:extension base="StudMaterial_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="DoorMaterial_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="solid wood"/>
 			<xs:enumeration value="hollow wood"/>
@@ -650,26 +1203,54 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="DoorType">
+	<xs:complexType name="DoorMaterial">
+		<xs:simpleContent>
+			<xs:extension base="DoorMaterial_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="DoorType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="interior"/>
 			<xs:enumeration value="exterior"/>
 			<xs:enumeration value="storm"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="RValue">
+	<xs:complexType name="DoorType">
+		<xs:simpleContent>
+			<xs:extension base="DoorType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="RValue_simple">
 		<xs:restriction base="xs:double">
 			<xs:minInclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="RValue">
+		<xs:simpleContent>
+			<xs:extension base="RValue_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Insulation Below-->
-	<xs:simpleType name="DoorThirdPartyCertifications">
+	<xs:simpleType name="DoorThirdPartyCertifications_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Energy Star"/>
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="InstallationType">
+	<xs:complexType name="DoorThirdPartyCertifications">
+		<xs:simpleContent>
+			<xs:extension base="DoorThirdPartyCertifications_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="InstallationType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="cavity"/>
 			<xs:enumeration value="continuous"/>
@@ -677,7 +1258,14 @@
 			<xs:enumeration value="continuous - exterior"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="InsulationBattType">
+	<xs:complexType name="InstallationType">
+		<xs:simpleContent>
+			<xs:extension base="InstallationType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="InsulationBattType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="fiberglass"/>
 			<xs:enumeration value="rockwool"/>
@@ -685,7 +1273,14 @@
 			<xs:enumeration value="unknown"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="InsulationLooseFillType">
+	<xs:complexType name="InsulationBattType">
+		<xs:simpleContent>
+			<xs:extension base="InsulationBattType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="InsulationLooseFillType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="cellulose"/>
 			<xs:enumeration value="fiberglass"/>
@@ -694,7 +1289,14 @@
 			<xs:enumeration value="unknown"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="InsulationRigidType">
+	<xs:complexType name="InsulationLooseFillType">
+		<xs:simpleContent>
+			<xs:extension base="InsulationLooseFillType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="InsulationRigidType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="polyisocyanurate"/>
 			<xs:enumeration value="xps"/>
@@ -702,29 +1304,57 @@
 			<xs:enumeration value="unknown"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="InsulationSprayFoamType">
+	<xs:complexType name="InsulationRigidType">
+		<xs:simpleContent>
+			<xs:extension base="InsulationRigidType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="InsulationSprayFoamType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="open cell"/>
 			<xs:enumeration value="closed cell"/>
 			<xs:enumeration value="unknown"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="InsulationCondition">
+	<xs:complexType name="InsulationSprayFoamType">
+		<xs:simpleContent>
+			<xs:extension base="InsulationSprayFoamType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="InsulationCondition_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="good"/>
 			<xs:enumeration value="fair"/>
 			<xs:enumeration value="poor"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="InsulationCondition">
+		<xs:simpleContent>
+			<xs:extension base="InsulationCondition_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Lighting Below-->
 	<!--Lighting Controls Below-->
-	<xs:simpleType name="InsulationLocation">
+	<xs:simpleType name="InsulationLocation_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="interior"/>
 			<xs:enumeration value="exterior"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="LightingLocation">
+	<xs:complexType name="InsulationLocation">
+		<xs:simpleContent>
+			<xs:extension base="InsulationLocation_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="LightingLocation_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="interior"/>
 			<xs:enumeration value="exterior"/>
@@ -732,7 +1362,14 @@
 			<xs:enumeration value="common area"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="FluorescentTubeType">
+	<xs:complexType name="LightingLocation">
+		<xs:simpleContent>
+			<xs:extension base="LightingLocation_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="FluorescentTubeType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="T2"/>
 			<xs:enumeration value="T4"/>
@@ -745,7 +1382,14 @@
 			<xs:enumeration value="T17"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="FluorescentBallastType">
+	<xs:complexType name="FluorescentTubeType">
+		<xs:simpleContent>
+			<xs:extension base="FluorescentTubeType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="FluorescentBallastType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="electronic"/>
 			<xs:enumeration value="magnetic"/>
@@ -754,7 +1398,14 @@
 			<xs:enumeration value="programmed start"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="LightingThirdPartyCertification">
+	<xs:complexType name="FluorescentBallastType">
+		<xs:simpleContent>
+			<xs:extension base="FluorescentBallastType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="LightingThirdPartyCertification_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Energy Star"/>
 			<xs:enumeration value="Energy Star Most Efficient"/>
@@ -767,7 +1418,14 @@
 			<xs:enumeration value="unknown"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="LightingDailyHours">
+	<xs:complexType name="LightingThirdPartyCertification">
+		<xs:simpleContent>
+			<xs:extension base="LightingThirdPartyCertification_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="LightingDailyHours_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="1 to 4 hours per day"/>
 			<xs:enumeration value="4 to 12 hours per day"/>
@@ -775,7 +1433,14 @@
 			<xs:enumeration value="all day"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="LightingControls">
+	<xs:complexType name="LightingDailyHours">
+		<xs:simpleContent>
+			<xs:extension base="LightingDailyHours_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="LightingControls_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="daylight dimming"/>
 			<xs:enumeration value="occupancy sensors"/>
@@ -788,8 +1453,15 @@
 			<xs:enumeration value="part of emcs"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="LightingControls">
+		<xs:simpleContent>
+			<xs:extension base="LightingControls_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Moisture Control Below-->
-	<xs:simpleType name="ExteriorLocationsWaterIntrusionorDamage">
+	<xs:simpleType name="ExteriorLocationsWaterIntrusionorDamage_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="roof"/>
 			<xs:enumeration value="interior ceiling"/>
@@ -801,7 +1473,14 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="InteriorLocationsofWaterLeaksorDamage">
+	<xs:complexType name="ExteriorLocationsWaterIntrusionorDamage">
+		<xs:simpleContent>
+			<xs:extension base="ExteriorLocationsWaterIntrusionorDamage_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="InteriorLocationsofWaterLeaksorDamage_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="kitchen "/>
 			<xs:enumeration value="bathroom"/>
@@ -809,9 +1488,16 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="InteriorLocationsofWaterLeaksorDamage">
+		<xs:simpleContent>
+			<xs:extension base="InteriorLocationsofWaterLeaksorDamage_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Plug Load Controls Below-->
 	<!--Shading and Solar Reflectance Below-->
-	<xs:simpleType name="PlugLoadControlType">
+	<xs:simpleType name="PlugLoadControlType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="advanced power strip for AV"/>
 			<xs:enumeration value="advanced power strip for IT"/>
@@ -820,7 +1506,14 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="RadiantBarrierLocation">
+	<xs:complexType name="PlugLoadControlType">
+		<xs:simpleContent>
+			<xs:extension base="PlugLoadControlType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="RadiantBarrierLocation_simple">
 		<xs:annotation>
 			<xs:documentation>Enumerations from http://www.fsec.ucf.edu/en/publications/pdf/FSEC-DN-7-84.pdf</xs:documentation>
 		</xs:annotation>
@@ -832,9 +1525,16 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="RadiantBarrierLocation">
+		<xs:simpleContent>
+			<xs:extension base="RadiantBarrierLocation_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Ventilation Below-->
 	<!--Window Group Below-->
-	<xs:simpleType name="HVACThirdPartyCertification">
+	<xs:simpleType name="HVACThirdPartyCertification_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Energy Star"/>
 			<xs:enumeration value="Energy Star Most Efficient"/>
@@ -845,7 +1545,14 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="DHWThirdPartyCertification">
+	<xs:complexType name="HVACThirdPartyCertification">
+		<xs:simpleContent>
+			<xs:extension base="HVACThirdPartyCertification_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="DHWThirdPartyCertification_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Energy Star"/>
 			<xs:enumeration value="CEE Tier 1"/>
@@ -854,7 +1561,14 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="GlassLayers">
+	<xs:complexType name="DHWThirdPartyCertification">
+		<xs:simpleContent>
+			<xs:extension base="DHWThirdPartyCertification_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="GlassLayers_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="single-pane"/>
 			<xs:enumeration value="double-pane"/>
@@ -863,19 +1577,40 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="WindowThirdPartyCertification">
+	<xs:complexType name="GlassLayers">
+		<xs:simpleContent>
+			<xs:extension base="GlassLayers_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="WindowThirdPartyCertification_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Energy Star"/>
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="SHGC">
+	<xs:complexType name="WindowThirdPartyCertification">
+		<xs:simpleContent>
+			<xs:extension base="WindowThirdPartyCertification_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="SHGC_simple">
 		<xs:restriction base="xs:double">
 			<xs:minExclusive value="0"/>
 			<xs:maxExclusive value="1"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="InteriorShading">
+	<xs:complexType name="SHGC">
+		<xs:simpleContent>
+			<xs:extension base="SHGC_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="InteriorShading_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="light blinds"/>
 			<xs:enumeration value="dark blinds"/>
@@ -886,7 +1621,14 @@
 			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="ExteriorShading">
+	<xs:complexType name="InteriorShading">
+		<xs:simpleContent>
+			<xs:extension base="InteriorShading_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ExteriorShading_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="external overhangs"/>
 			<xs:enumeration value="awnings"/>
@@ -899,39 +1641,88 @@
 			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="UFactor">
+	<xs:complexType name="ExteriorShading">
+		<xs:simpleContent>
+			<xs:extension base="ExteriorShading_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="UFactor_simple">
 		<xs:restriction base="xs:double">
 			<xs:minExclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="UFactor">
+		<xs:simpleContent>
+			<xs:extension base="UFactor_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Combustion Applicance Tests Below-->
-	<xs:simpleType name="FlueCondition">
+	<xs:simpleType name="FlueCondition_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="pass"/>
 			<xs:enumeration value="fail"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="FlueCondition">
+		<xs:simpleContent>
+			<xs:extension base="FlueCondition_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Combustion Appliance Zone Test Below-->
-	<xs:simpleType name="CAZDepressurizationLimit">
+	<xs:simpleType name="CAZDepressurizationLimit_simple">
 		<xs:restriction base="xs:double"/>
 	</xs:simpleType>
-	<xs:simpleType name="OpenClosed">
+	<xs:complexType name="CAZDepressurizationLimit">
+		<xs:simpleContent>
+			<xs:extension base="CAZDepressurizationLimit_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="OpenClosed_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="open"/>
 			<xs:enumeration value="closed"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="DepressurizationFindingPoorCase">
+	<xs:complexType name="OpenClosed">
+		<xs:simpleContent>
+			<xs:extension base="OpenClosed_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="DepressurizationFindingPoorCase_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="pass"/>
 			<xs:enumeration value="fail"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="NetPressureChange">
+	<xs:complexType name="DepressurizationFindingPoorCase">
+		<xs:simpleContent>
+			<xs:extension base="DepressurizationFindingPoorCase_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="NetPressureChange_simple">
 		<xs:restriction base="xs:double"/>
 	</xs:simpleType>
+	<xs:complexType name="NetPressureChange">
+		<xs:simpleContent>
+			<xs:extension base="NetPressureChange_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Cooling System Information Below-->
-	<xs:simpleType name="CoolingSystemType">
+	<xs:simpleType name="CoolingSystemType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="central air conditioner"/>
 			<xs:enumeration value="mini-split"/>
@@ -940,7 +1731,14 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="CoolingEfficiencyUnits">
+	<xs:complexType name="CoolingSystemType">
+		<xs:simpleContent>
+			<xs:extension base="CoolingSystemType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="CoolingEfficiencyUnits_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="SEER"/>
 			<xs:enumeration value="EER"/>
@@ -948,7 +1746,14 @@
 			<xs:enumeration value="kW/ton"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="HeatingEfficiencyUnits">
+	<xs:complexType name="CoolingEfficiencyUnits">
+		<xs:simpleContent>
+			<xs:extension base="CoolingEfficiencyUnits_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="HeatingEfficiencyUnits_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="HSPF"/>
 			<xs:enumeration value="COP"/>
@@ -956,27 +1761,55 @@
 			<xs:enumeration value="Percent"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="DistrictSteamType">
+	<xs:complexType name="HeatingEfficiencyUnits">
+		<xs:simpleContent>
+			<xs:extension base="HeatingEfficiencyUnits_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="DistrictSteamType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="1-pipe"/>
 			<xs:enumeration value="2-pipe"/>
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="Efficiency">
+	<xs:complexType name="DistrictSteamType">
+		<xs:simpleContent>
+			<xs:extension base="DistrictSteamType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="Efficiency_simple">
 		<xs:restriction base="xs:double">
 			<xs:minInclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="Efficiency">
+		<xs:simpleContent>
+			<xs:extension base="Efficiency_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Heat Pump Information Below-->
-	<xs:simpleType name="GeothermalLoop">
+	<xs:simpleType name="GeothermalLoop_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="open"/>
 			<xs:enumeration value="closed"/>
 			<xs:enumeration value="direct expansion"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="HeatPumpType">
+	<xs:complexType name="GeothermalLoop">
+		<xs:simpleContent>
+			<xs:extension base="GeothermalLoop_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="HeatPumpType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="water-to-air"/>
 			<xs:enumeration value="water-to-water"/>
@@ -987,7 +1820,14 @@
 			<xs:enumeration value="ground-to-water"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="VentSystem">
+	<xs:complexType name="HeatPumpType">
+		<xs:simpleContent>
+			<xs:extension base="HeatPumpType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="VentSystem_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="atmospheric"/>
 			<xs:enumeration value="induced draft"/>
@@ -997,46 +1837,102 @@
 			<xs:enumeration value="sealed combustion"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="VentSystem">
+		<xs:simpleContent>
+			<xs:extension base="VentSystem_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Heating System Information Below-->
-	<xs:simpleType name="AFUE">
+	<xs:simpleType name="AFUE_simple">
 		<xs:restriction base="xs:double">
 			<xs:minInclusive value="1"/>
 			<xs:maxInclusive value="100"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="COP">
+	<xs:complexType name="AFUE">
+		<xs:simpleContent>
+			<xs:extension base="AFUE_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="COP_simple">
 		<xs:restriction base="xs:double">
 			<xs:minExclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="COP">
+		<xs:simpleContent>
+			<xs:extension base="COP_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--HVAC Distribution Below-->
-	<xs:simpleType name="HSPF">
+	<xs:simpleType name="HSPF_simple">
 		<xs:restriction base="xs:double">
 			<xs:minInclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="SEER">
+	<xs:complexType name="HSPF">
+		<xs:simpleContent>
+			<xs:extension base="HSPF_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="SEER_simple">
 		<xs:restriction base="xs:double">
 			<xs:minInclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="EER">
+	<xs:complexType name="SEER">
+		<xs:simpleContent>
+			<xs:extension base="SEER_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="EER_simple">
 		<xs:restriction base="xs:double">
 			<xs:minInclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="kWperTon">
+	<xs:complexType name="EER">
+		<xs:simpleContent>
+			<xs:extension base="EER_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="kWperTon_simple">
 		<xs:restriction base="xs:double">
 			<xs:minInclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="DuctType">
+	<xs:complexType name="kWperTon">
+		<xs:simpleContent>
+			<xs:extension base="kWperTon_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="DuctType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="supply"/>
 			<xs:enumeration value="return"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="DuctMaterial">
+	<xs:complexType name="DuctType">
+		<xs:simpleContent>
+			<xs:extension base="DuctType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="DuctMaterial_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="duct board"/>
 			<xs:enumeration value="sheet metal"/>
@@ -1046,7 +1942,14 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="DuctLocation">
+	<xs:complexType name="DuctMaterial">
+		<xs:simpleContent>
+			<xs:extension base="DuctMaterial_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="DuctLocation_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="attic"/>
 			<xs:enumeration value="attic - conditioned"/>
@@ -1073,7 +1976,14 @@
 			<xs:enumeration value="under slab"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="DuctLeakageTestMethod">
+	<xs:complexType name="DuctLocation">
+		<xs:simpleContent>
+			<xs:extension base="DuctLocation_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="DuctLeakageTestMethod_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="duct leakage tester"/>
 			<xs:enumeration value="blower door subtract"/>
@@ -1081,7 +1991,14 @@
 			<xs:enumeration value="visual inspection"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="DuctLeakageTestUnitofMeasure">
+	<xs:complexType name="DuctLeakageTestMethod">
+		<xs:simpleContent>
+			<xs:extension base="DuctLeakageTestMethod_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="DuctLeakageTestUnitofMeasure_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="CFM50"/>
 			<xs:enumeration value="CFM25"/>
@@ -1089,7 +2006,14 @@
 			<xs:enumeration value="Percent"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="LeakinessObservedVisualInspection">
+	<xs:complexType name="DuctLeakageTestUnitofMeasure">
+		<xs:simpleContent>
+			<xs:extension base="DuctLeakageTestUnitofMeasure_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="LeakinessObservedVisualInspection_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="connections sealed w mastic"/>
 			<xs:enumeration value="no observable leaks"/>
@@ -1098,27 +2022,62 @@
 			<xs:enumeration value="catastrophic leaks"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="MeasuredDuctLeakage">
+	<xs:complexType name="LeakinessObservedVisualInspection">
+		<xs:simpleContent>
+			<xs:extension base="LeakinessObservedVisualInspection_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="MeasuredDuctLeakage_simple">
 		<xs:restriction base="xs:double"/>
 	</xs:simpleType>
+	<xs:complexType name="MeasuredDuctLeakage">
+		<xs:simpleContent>
+			<xs:extension base="MeasuredDuctLeakage_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--HVAC System Below-->
-	<xs:simpleType name="AirHandlerStaticPressureMeasurementLocation">
+	<xs:simpleType name="AirHandlerStaticPressureMeasurementLocation_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="in ducts"/>
 			<xs:enumeration value="at equipment"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="StaticPressureSource">
+	<xs:complexType name="AirHandlerStaticPressureMeasurementLocation">
+		<xs:simpleContent>
+			<xs:extension base="AirHandlerStaticPressureMeasurementLocation_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="StaticPressureSource_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="as measured"/>
 			<xs:enumeration value="per design report"/>
 			<xs:enumeration value="per OEM documentation"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="Capacity">
+	<xs:complexType name="StaticPressureSource">
+		<xs:simpleContent>
+			<xs:extension base="StaticPressureSource_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="Capacity_simple">
 		<xs:restriction base="xs:double"/>
 	</xs:simpleType>
-	<xs:simpleType name="HVACMaintenanceSchedule">
+	<xs:complexType name="Capacity">
+		<xs:simpleContent>
+			<xs:extension base="Capacity_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="HVACMaintenanceSchedule_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="none"/>
 			<xs:enumeration value="yes - unspecified"/>
@@ -1133,16 +2092,44 @@
 			<xs:enumeration value="annually"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="DispositionofExistingSystem">
+	<xs:complexType name="HVACMaintenanceSchedule">
+		<xs:simpleContent>
+			<xs:extension base="HVACMaintenanceSchedule_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="DispositionofExistingSystem_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="Manufacturer">
+	<xs:complexType name="DispositionofExistingSystem">
+		<xs:simpleContent>
+			<xs:extension base="DispositionofExistingSystem_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="Manufacturer_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="Model">
+	<xs:complexType name="Manufacturer">
+		<xs:simpleContent>
+			<xs:extension base="Manufacturer_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="Model_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="UnitLocation">
+	<xs:complexType name="Model">
+		<xs:simpleContent>
+			<xs:extension base="Model_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="UnitLocation_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="attic"/>
 			<xs:enumeration value="attic - conditioned"/>
@@ -1168,11 +2155,25 @@
 			<xs:enumeration value="unconditioned space"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="UnitLocation">
+		<xs:simpleContent>
+			<xs:extension base="UnitLocation_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Thermostats Below-->
-	<xs:simpleType name="Temperature">
+	<xs:simpleType name="Temperature_simple">
 		<xs:restriction base="xs:double"/>
 	</xs:simpleType>
-	<xs:simpleType name="ThermostatType">
+	<xs:complexType name="Temperature">
+		<xs:simpleContent>
+			<xs:extension base="Temperature_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ThermostatType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="programmable thermostat"/>
 			<xs:enumeration value="manual thermostat"/>
@@ -1182,49 +2183,112 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="HotWaterResetControl">
+	<xs:complexType name="ThermostatType">
+		<xs:simpleContent>
+			<xs:extension base="ThermostatType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="HotWaterResetControl_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="seasonal"/>
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="Hours">
+	<xs:complexType name="HotWaterResetControl">
+		<xs:simpleContent>
+			<xs:extension base="HotWaterResetControl_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="Hours_simple">
 		<xs:restriction base="xs:integer"/>
 	</xs:simpleType>
+	<xs:complexType name="Hours">
+		<xs:simpleContent>
+			<xs:extension base="Hours_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Water Heating System Below-->
-	<xs:simpleType name="EnergyFactor">
+	<xs:simpleType name="EnergyFactor_simple">
 		<xs:restriction base="xs:double">
 			<xs:minExclusive value="0"/>
 			<xs:maxInclusive value="5"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="PipeInsulated">
+	<xs:complexType name="EnergyFactor">
+		<xs:simpleContent>
+			<xs:extension base="EnergyFactor_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="PipeInsulated_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="RecoveryEfficiency">
+	<xs:complexType name="PipeInsulated">
+		<xs:simpleContent>
+			<xs:extension base="PipeInsulated_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="RecoveryEfficiency_simple">
 		<xs:restriction base="xs:double">
 			<xs:minExclusive value="0"/>
 			<xs:maxInclusive value="5"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="Volume">
+	<xs:complexType name="RecoveryEfficiency">
+		<xs:simpleContent>
+			<xs:extension base="RecoveryEfficiency_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="Volume_simple">
 		<xs:restriction base="xs:double">
 			<xs:minExclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="ThermalEfficiency">
+	<xs:complexType name="Volume">
+		<xs:simpleContent>
+			<xs:extension base="Volume_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ThermalEfficiency_simple">
 		<xs:restriction base="xs:double">
 			<xs:minExclusive value="0"/>
 			<xs:maxInclusive value="1"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="ProjectType">
+	<xs:complexType name="ThermalEfficiency">
+		<xs:simpleContent>
+			<xs:extension base="ThermalEfficiency_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ProjectType_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
+	<xs:complexType name="ProjectType">
+		<xs:simpleContent>
+			<xs:extension base="ProjectType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Appliances Below-->
 	<!--Clothes Dryers Below-->
 	<!--Clothes Washer Below-->
-	<xs:simpleType name="ApplianceThirdPartyCertifications">
+	<xs:simpleType name="ApplianceThirdPartyCertifications_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Energy Star"/>
 			<xs:enumeration value="Energy Star Most Efficient"/>
@@ -1233,8 +2297,15 @@
 			<xs:enumeration value="CEE Tier 3"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="ApplianceThirdPartyCertifications">
+		<xs:simpleContent>
+			<xs:extension base="ApplianceThirdPartyCertifications_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Dishwasher Below-->
-	<xs:simpleType name="DishwasherType">
+	<xs:simpleType name="DishwasherType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="uncategorized"/>
 			<xs:enumeration value="built-in under counter"/>
@@ -1244,27 +2315,62 @@
 			<xs:enumeration value="conveyor"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="RatedAnnualkWh">
+	<xs:complexType name="DishwasherType">
+		<xs:simpleContent>
+			<xs:extension base="DishwasherType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="RatedAnnualkWh_simple">
 		<xs:restriction base="xs:double">
 			<xs:minExclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="RatedWaterGalPerCycle">
+	<xs:complexType name="RatedAnnualkWh">
+		<xs:simpleContent>
+			<xs:extension base="RatedAnnualkWh_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="RatedWaterGalPerCycle_simple">
 		<xs:restriction base="xs:double">
 			<xs:minExclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="RatedWaterGalPerCycle">
+		<xs:simpleContent>
+			<xs:extension base="RatedWaterGalPerCycle_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Freezer Below-->
 	<!--Refrigerators Below-->
 	<!--Energy Savings Information Below-->
-	<xs:simpleType name="TotalCostHealthSafetyMeasures">
+	<xs:simpleType name="TotalCostHealthSafetyMeasures_simple">
 		<xs:restriction base="xs:double"/>
 	</xs:simpleType>
-	<xs:simpleType name="TotalCostQualEnergyMeasures">
+	<xs:complexType name="TotalCostHealthSafetyMeasures">
+		<xs:simpleContent>
+			<xs:extension base="TotalCostHealthSafetyMeasures_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="TotalCostQualEnergyMeasures_simple">
 		<xs:restriction base="xs:double"/>
 	</xs:simpleType>
+	<xs:complexType name="TotalCostQualEnergyMeasures">
+		<xs:simpleContent>
+			<xs:extension base="TotalCostQualEnergyMeasures_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Homeowner Questionaire Below-->
-	<xs:simpleType name="HomeownerQuestionaireScore">
+	<xs:simpleType name="HomeownerQuestionaireScore_simple">
 		<xs:annotation>
 			<xs:documentation>1-10 score of why they chose that option</xs:documentation>
 		</xs:annotation>
@@ -1273,15 +2379,36 @@
 			<xs:maxInclusive value="10"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="HomeownerQuestionaireScore">
+		<xs:simpleContent>
+			<xs:extension base="HomeownerQuestionaireScore_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Software Information Below-->
-	<xs:simpleType name="SoftwareProgramUsed">
+	<xs:simpleType name="SoftwareProgramUsed_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="SoftwareProgramVersion">
+	<xs:complexType name="SoftwareProgramUsed">
+		<xs:simpleContent>
+			<xs:extension base="SoftwareProgramUsed_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="SoftwareProgramVersion_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
+	<xs:complexType name="SoftwareProgramVersion">
+		<xs:simpleContent>
+			<xs:extension base="SoftwareProgramVersion_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--Contractor / Contracting Company Information Below-->
-	<xs:simpleType name="BusinessSpecialization">
+	<xs:simpleType name="BusinessSpecialization_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="energy audit"/>
 			<xs:enumeration value="hvac"/>
@@ -1293,7 +2420,14 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="BusinessType">
+	<xs:complexType name="BusinessSpecialization">
+		<xs:simpleContent>
+			<xs:extension base="BusinessSpecialization_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="BusinessType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="contractor"/>
 			<xs:enumeration value="auditor"/>
@@ -1301,7 +2435,14 @@
 			<xs:enumeration value="property manager"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="AuditorQualification">
+	<xs:complexType name="BusinessType">
+		<xs:simpleContent>
+			<xs:extension base="BusinessType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="AuditorQualification_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="PE"/>
 			<xs:enumeration value="CEM"/>
@@ -1311,7 +2452,14 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="ImplementerQualification">
+	<xs:complexType name="AuditorQualification">
+		<xs:simpleContent>
+			<xs:extension base="AuditorQualification_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ImplementerQualification_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="PE"/>
 			<xs:enumeration value="CEM"/>
@@ -1326,7 +2474,14 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="AzimuthType">
+	<xs:complexType name="ImplementerQualification">
+		<xs:simpleContent>
+			<xs:extension base="ImplementerQualification_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="AzimuthType_simple">
 		<xs:annotation>
 			<xs:documentation>Gives compass direction a surface (window, wall) is facing. Measured in degrees clockwise from North.</xs:documentation>
 		</xs:annotation>
@@ -1335,7 +2490,14 @@
 			<xs:maxExclusive value="360"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="energyUnitType">
+	<xs:complexType name="AzimuthType">
+		<xs:simpleContent>
+			<xs:extension base="AzimuthType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="energyUnitType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="cmh"/>
 			<xs:enumeration value="ccf"/>
@@ -1358,7 +2520,14 @@
 			<xs:enumeration value="ton hours"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="waterUnitType">
+	<xs:complexType name="energyUnitType">
+		<xs:simpleContent>
+			<xs:extension base="energyUnitType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="waterUnitType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="gal"/>
 			<xs:enumeration value="kgal"/>
@@ -1369,7 +2538,14 @@
 			<xs:enumeration value="Mcf"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="MeterReadingType">
+	<xs:complexType name="waterUnitType">
+		<xs:simpleContent>
+			<xs:extension base="waterUnitType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="MeterReadingType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="point"/>
 			<xs:enumeration value="median"/>
@@ -1379,7 +2555,14 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="WaterType">
+	<xs:complexType name="MeterReadingType">
+		<xs:simpleContent>
+			<xs:extension base="MeterReadingType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="WaterType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="indoor and outdoor water"/>
 			<xs:enumeration value="indoor water"/>
@@ -1387,13 +2570,27 @@
 			<xs:enumeration value="wastewater/sewer"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="WaterUseIntensityUnits">
+	<xs:complexType name="WaterType">
+		<xs:simpleContent>
+			<xs:extension base="WaterType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="WaterUseIntensityUnits_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="gal/sq.ft."/>
 			<xs:enumeration value="gal/day/person"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="endUseType">
+	<xs:complexType name="WaterUseIntensityUnits">
+		<xs:simpleContent>
+			<xs:extension base="WaterUseIntensityUnits_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="endUseType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Heating"/>
 			<xs:enumeration value="Cooling"/>
@@ -1405,46 +2602,102 @@
 			<xs:enumeration value="Other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="MeasuredOrEstimated">
+	<xs:complexType name="endUseType">
+		<xs:simpleContent>
+			<xs:extension base="endUseType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="MeasuredOrEstimated_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="estimated"/>
 			<xs:enumeration value="measured"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="GrossOrNet">
+	<xs:complexType name="MeasuredOrEstimated">
+		<xs:simpleContent>
+			<xs:extension base="MeasuredOrEstimated_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="GrossOrNet_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="gross"/>
 			<xs:enumeration value="net"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="SurfaceArea">
+	<xs:complexType name="GrossOrNet">
+		<xs:simpleContent>
+			<xs:extension base="GrossOrNet_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="SurfaceArea_simple">
 		<xs:restriction base="xs:double">
 			<xs:minExclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="TransactionType">
+	<xs:complexType name="SurfaceArea">
+		<xs:simpleContent>
+			<xs:extension base="SurfaceArea_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="TransactionType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="create"/>
 			<xs:enumeration value="update"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="AuditorRelationship">
+	<xs:complexType name="TransactionType">
+		<xs:simpleContent>
+			<xs:extension base="TransactionType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="AuditorRelationship_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="HVACInstallationStandard">
+	<xs:complexType name="AuditorRelationship">
+		<xs:simpleContent>
+			<xs:extension base="AuditorRelationship_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="HVACInstallationStandard_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="ACCA 5 QI HVAC"/>
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="HVACSizingCalcs">
+	<xs:complexType name="HVACInstallationStandard">
+		<xs:simpleContent>
+			<xs:extension base="HVACInstallationStandard_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="HVACSizingCalcs_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="manual j"/>
 			<xs:enumeration value="manual j and manual d"/>
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="HydronicDistributionType">
+	<xs:complexType name="HVACSizingCalcs">
+		<xs:simpleContent>
+			<xs:extension base="HVACSizingCalcs_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="HydronicDistributionType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="radiator"/>
 			<xs:enumeration value="baseboard"/>
@@ -1453,28 +2706,56 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="AirDistributionType">
+	<xs:complexType name="HydronicDistributionType">
+		<xs:simpleContent>
+			<xs:extension base="HydronicDistributionType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="AirDistributionType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="regular velocity"/>
 			<xs:enumeration value="high velocity"/>
 			<xs:enumeration value="gravity"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="ElectricDistributionType">
+	<xs:complexType name="AirDistributionType">
+		<xs:simpleContent>
+			<xs:extension base="AirDistributionType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ElectricDistributionType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="baseboard"/>
 			<xs:enumeration value="radiant floor"/>
 			<xs:enumeration value="radiant ceiling"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="AirHandlerMotorType">
+	<xs:complexType name="ElectricDistributionType">
+		<xs:simpleContent>
+			<xs:extension base="ElectricDistributionType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="AirHandlerMotorType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="PSC single-speed"/>
 			<xs:enumeration value="PSC multi-speed"/>
 			<xs:enumeration value="ECM"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="PlugLoadType">
+	<xs:complexType name="AirHandlerMotorType">
+		<xs:simpleContent>
+			<xs:extension base="AirHandlerMotorType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="PlugLoadType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="TV plasma"/>
 			<xs:enumeration value="TV CRT"/>
@@ -1489,33 +2770,68 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="PlugLoadLocation">
+	<xs:complexType name="PlugLoadType">
+		<xs:simpleContent>
+			<xs:extension base="PlugLoadType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="PlugLoadLocation_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="interior"/>
 			<xs:enumeration value="exterior"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="PlugLoadUnits">
+	<xs:complexType name="PlugLoadLocation">
+		<xs:simpleContent>
+			<xs:extension base="PlugLoadLocation_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="PlugLoadUnits_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="kWh/year"/>
 			<xs:enumeration value="W"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="WindowCondition">
+	<xs:complexType name="PlugLoadUnits">
+		<xs:simpleContent>
+			<xs:extension base="PlugLoadUnits_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="WindowCondition_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="good"/>
 			<xs:enumeration value="moderate"/>
 			<xs:enumeration value="poor"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="GasFill">
+	<xs:complexType name="WindowCondition">
+		<xs:simpleContent>
+			<xs:extension base="WindowCondition_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="GasFill_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="air"/>
 			<xs:enumeration value="argon"/>
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="GlassType">
+	<xs:complexType name="GasFill">
+		<xs:simpleContent>
+			<xs:extension base="GasFill_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="GlassType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="low-e"/>
 			<xs:enumeration value="tinted"/>
@@ -1524,7 +2840,14 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="ClothesWasherType">
+	<xs:complexType name="GlassType">
+		<xs:simpleContent>
+			<xs:extension base="GlassType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ClothesWasherType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="top loader"/>
 			<xs:enumeration value="front loader"/>
@@ -1532,14 +2855,28 @@
 			<xs:enumeration value="unitized/stacked washer-dryer pair"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="ClothesDryerType">
+	<xs:complexType name="ClothesWasherType">
+		<xs:simpleContent>
+			<xs:extension base="ClothesWasherType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ClothesDryerType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="dryer"/>
 			<xs:enumeration value="all-in-one combination washer/dryer"/>
 			<xs:enumeration value="unitized/stacked washer-dryer pair"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="LaundryMachineLocation">
+	<xs:complexType name="ClothesDryerType">
+		<xs:simpleContent>
+			<xs:extension base="ClothesDryerType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="LaundryMachineLocation_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="basement"/>
 			<xs:enumeration value="basement - conditioned"/>
@@ -1553,7 +2890,14 @@
 			<xs:enumeration value="unconditioned space"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="FreezerStyle">
+	<xs:complexType name="LaundryMachineLocation">
+		<xs:simpleContent>
+			<xs:extension base="LaundryMachineLocation_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="FreezerStyle_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="uncategorized"/>
 			<xs:enumeration value="manual defrost"/>
@@ -1562,7 +2906,14 @@
 			<xs:enumeration value="case"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="RefrigeratorStyle">
+	<xs:complexType name="FreezerStyle">
+		<xs:simpleContent>
+			<xs:extension base="FreezerStyle_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="RefrigeratorStyle_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="side-by-side"/>
 			<xs:enumeration value="top freezer"/>
@@ -1578,7 +2929,14 @@
 			<xs:enumeration value="uncategorized"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="RefrigeratorLocation">
+	<xs:complexType name="RefrigeratorStyle">
+		<xs:simpleContent>
+			<xs:extension base="RefrigeratorStyle_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="RefrigeratorLocation_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="basement"/>
 			<xs:enumeration value="basement - conditioned"/>
@@ -1592,14 +2950,28 @@
 			<xs:enumeration value="unconditioned space"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="DehumidifierLocation">
+	<xs:complexType name="RefrigeratorLocation">
+		<xs:simpleContent>
+			<xs:extension base="RefrigeratorLocation_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="DehumidifierLocation_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="living space"/>
 			<xs:enumeration value="basement"/>
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="WaterHeaterType">
+	<xs:complexType name="DehumidifierLocation">
+		<xs:simpleContent>
+			<xs:extension base="DehumidifierLocation_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="WaterHeaterType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="storage water heater"/>
 			<xs:enumeration value="dedicated boiler with storage tank"/>
@@ -1609,7 +2981,14 @@
 			<xs:enumeration value="space-heating boiler with tankless coil"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="SolarThermalSystemType">
+	<xs:complexType name="WaterHeaterType">
+		<xs:simpleContent>
+			<xs:extension base="WaterHeaterType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="SolarThermalSystemType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="hot water"/>
 			<xs:enumeration value="hot water and space heating"/>
@@ -1617,7 +2996,14 @@
 			<xs:enumeration value="hybrid system"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="SolarThermalCollectorLoopType">
+	<xs:complexType name="SolarThermalSystemType">
+		<xs:simpleContent>
+			<xs:extension base="SolarThermalSystemType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="SolarThermalCollectorLoopType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="air direct"/>
 			<xs:enumeration value="air indirect"/>
@@ -1626,7 +3012,14 @@
 			<xs:enumeration value="passive thermosyphon"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="SolarThermalCollectorType">
+	<xs:complexType name="SolarThermalCollectorLoopType">
+		<xs:simpleContent>
+			<xs:extension base="SolarThermalCollectorLoopType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="SolarThermalCollectorType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="single glazing black"/>
 			<xs:enumeration value="single glazing selective"/>
@@ -1636,67 +3029,214 @@
 			<xs:enumeration value="integrated collector storage"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="ResourceTypeCode">
+	<xs:complexType name="SolarThermalCollectorType">
+		<xs:simpleContent>
+			<xs:extension base="SolarThermalCollectorType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ResourceTypeCode_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="Quantity">
+	<xs:complexType name="ResourceTypeCode">
+		<xs:simpleContent>
+			<xs:extension base="ResourceTypeCode_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="Quantity_simple">
 		<xs:restriction base="xs:decimal"/>
 	</xs:simpleType>
-	<xs:simpleType name="ProgramName">
+	<xs:complexType name="Quantity">
+		<xs:simpleContent>
+			<xs:extension base="Quantity_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ProgramName_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="Title">
+	<xs:complexType name="ProgramName">
+		<xs:simpleContent>
+			<xs:extension base="ProgramName_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="Title_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="StartDate">
+	<xs:complexType name="Title">
+		<xs:simpleContent>
+			<xs:extension base="Title_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="StartDate_simple">
 		<xs:restriction base="xs:date"/>
 	</xs:simpleType>
-	<xs:simpleType name="CompleteDateEstimated">
+	<xs:complexType name="StartDate">
+		<xs:simpleContent>
+			<xs:extension base="StartDate_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="CompleteDateEstimated_simple">
 		<xs:restriction base="xs:date"/>
 	</xs:simpleType>
-	<xs:simpleType name="CompleteDateActual">
+	<xs:complexType name="CompleteDateEstimated">
+		<xs:simpleContent>
+			<xs:extension base="CompleteDateEstimated_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="CompleteDateActual_simple">
 		<xs:restriction base="xs:date"/>
 	</xs:simpleType>
-	<xs:simpleType name="Notes">
+	<xs:complexType name="CompleteDateActual">
+		<xs:simpleContent>
+			<xs:extension base="CompleteDateActual_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="Notes_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="MeasureCode">
+	<xs:complexType name="Notes">
+		<xs:simpleContent>
+			<xs:extension base="Notes_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="MeasureCode_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="MeasureDescription">
+	<xs:complexType name="MeasureCode">
+		<xs:simpleContent>
+			<xs:extension base="MeasureCode_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="MeasureDescription_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="EstimatedLife">
+	<xs:complexType name="MeasureDescription">
+		<xs:simpleContent>
+			<xs:extension base="MeasureDescription_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="EstimatedLife_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="InstallationDate">
+	<xs:complexType name="EstimatedLife">
+		<xs:simpleContent>
+			<xs:extension base="EstimatedLife_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="InstallationDate_simple">
 		<xs:restriction base="xs:date"/>
 	</xs:simpleType>
-	<xs:simpleType name="Cost">
+	<xs:complexType name="InstallationDate">
+		<xs:simpleContent>
+			<xs:extension base="InstallationDate_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="Cost_simple">
 		<xs:restriction base="xs:decimal"/>
 	</xs:simpleType>
-	<xs:simpleType name="FundingSourceCode">
+	<xs:complexType name="Cost">
+		<xs:simpleContent>
+			<xs:extension base="Cost_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="FundingSourceCode_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="TotalAmount">
+	<xs:complexType name="FundingSourceCode">
+		<xs:simpleContent>
+			<xs:extension base="FundingSourceCode_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="TotalAmount_simple">
 		<xs:restriction base="xs:decimal"/>
 	</xs:simpleType>
-	<xs:simpleType name="FundingSourceName">
+	<xs:complexType name="TotalAmount">
+		<xs:simpleContent>
+			<xs:extension base="TotalAmount_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="FundingSourceName_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="IncentiveAmount">
+	<xs:complexType name="FundingSourceName">
+		<xs:simpleContent>
+			<xs:extension base="FundingSourceName_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="IncentiveAmount_simple">
 		<xs:restriction base="xs:decimal"/>
 	</xs:simpleType>
-	<xs:simpleType name="LoadProfile">
+	<xs:complexType name="IncentiveAmount">
+		<xs:simpleContent>
+			<xs:extension base="IncentiveAmount_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="LoadProfile_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="AnnualAmount">
+	<xs:complexType name="LoadProfile">
+		<xs:simpleContent>
+			<xs:extension base="LoadProfile_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="AnnualAmount_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="JobRole">
+	<xs:complexType name="AnnualAmount">
+		<xs:simpleContent>
+			<xs:extension base="AnnualAmount_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="JobRole_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="Fraction">
+	<xs:complexType name="JobRole">
+		<xs:simpleContent>
+			<xs:extension base="JobRole_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="Fraction_simple">
 		<xs:annotation>
 			<xs:documentation>A fraction that has to be between 0 and 1 inclusive</xs:documentation>
 		</xs:annotation>
@@ -1705,7 +3245,14 @@
 			<xs:maxInclusive value="1"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="FractionGreaterThanOne">
+	<xs:complexType name="Fraction">
+		<xs:simpleContent>
+			<xs:extension base="Fraction_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="FractionGreaterThanOne_simple">
 		<xs:annotation>
 			<xs:documentation>A fraction that can be greater than one (ie 110%)</xs:documentation>
 		</xs:annotation>
@@ -1713,27 +3260,55 @@
 			<xs:minInclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="ImprovementStatusType">
+	<xs:complexType name="FractionGreaterThanOne">
+		<xs:simpleContent>
+			<xs:extension base="FractionGreaterThanOne_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ImprovementStatusType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Installed"/>
 			<xs:enumeration value="NotInstalled"/>
 			<xs:enumeration value="Recommended"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="TestResultType">
+	<xs:complexType name="ImprovementStatusType">
+		<xs:simpleContent>
+			<xs:extension base="ImprovementStatusType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="TestResultType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="passed"/>
 			<xs:enumeration value="failed"/>
 			<xs:enumeration value="not tested"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="FoundationThermalBoundary">
+	<xs:complexType name="TestResultType">
+		<xs:simpleContent>
+			<xs:extension base="TestResultType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="FoundationThermalBoundary_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="frame floor"/>
 			<xs:enumeration value="foundation wall"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="WallAndRoofColor">
+	<xs:complexType name="FoundationThermalBoundary">
+		<xs:simpleContent>
+			<xs:extension base="FoundationThermalBoundary_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="WallAndRoofColor_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="light"/>
 			<xs:enumeration value="medium"/>
@@ -1742,7 +3317,14 @@
 			<xs:enumeration value="reflective"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="RoofType">
+	<xs:complexType name="WallAndRoofColor">
+		<xs:simpleContent>
+			<xs:extension base="WallAndRoofColor_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="RoofType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="shingles"/>
 			<xs:enumeration value="slate or tile shingles"/>
@@ -1758,7 +3340,14 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="DeckType">
+	<xs:complexType name="RoofType">
+		<xs:simpleContent>
+			<xs:extension base="RoofType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="DeckType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="concrete"/>
 			<xs:enumeration value="metal"/>
@@ -1766,7 +3355,14 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="Siding">
+	<xs:complexType name="DeckType">
+		<xs:simpleContent>
+			<xs:extension base="DeckType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="Siding_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="wood siding"/>
 			<xs:enumeration value="stucco"/>
@@ -1781,18 +3377,39 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="LengthMeasurement">
+	<xs:complexType name="Siding">
+		<xs:simpleContent>
+			<xs:extension base="Siding_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="LengthMeasurement_simple">
 		<xs:restriction base="xs:double">
 			<xs:minInclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="InsulationGrade">
+	<xs:complexType name="LengthMeasurement">
+		<xs:simpleContent>
+			<xs:extension base="LengthMeasurement_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="InsulationGrade_simple">
 		<xs:restriction base="xs:integer">
 			<xs:minInclusive value="1"/>
 			<xs:maxInclusive value="3"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="FloorCovering">
+	<xs:complexType name="InsulationGrade">
+		<xs:simpleContent>
+			<xs:extension base="InsulationGrade_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="FloorCovering_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="carpet"/>
 			<xs:enumeration value="tile"/>
@@ -1801,25 +3418,53 @@
 			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="Pitch">
+	<xs:complexType name="FloorCovering">
+		<xs:simpleContent>
+			<xs:extension base="FloorCovering_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="Pitch_simple">
 		<xs:restriction base="xs:double">
 			<xs:minInclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="Tilt">
+	<xs:complexType name="Pitch">
+		<xs:simpleContent>
+			<xs:extension base="Pitch_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="Tilt_simple">
 		<xs:restriction base="xs:double">
 			<xs:minInclusive value="0"/>
 			<xs:maxInclusive value="90"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="PVSystemLocation">
+	<xs:complexType name="Tilt">
+		<xs:simpleContent>
+			<xs:extension base="Tilt_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="PVSystemLocation_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="roof"/>
 			<xs:enumeration value="ground"/>
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="PVSystemOwnership">
+	<xs:complexType name="PVSystemLocation">
+		<xs:simpleContent>
+			<xs:extension base="PVSystemLocation_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="PVSystemOwnership_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="leased"/>
 			<xs:enumeration value="owned"/>
@@ -1828,13 +3473,27 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="EVChargingLevel">
+	<xs:complexType name="PVSystemOwnership">
+		<xs:simpleContent>
+			<xs:extension base="PVSystemOwnership_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="EVChargingLevel_simple">
 		<xs:restriction base="xs:integer">
 			<xs:minInclusive value="1"/>
 			<xs:maxInclusive value="3"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="EVChargingConnector">
+	<xs:complexType name="EVChargingLevel">
+		<xs:simpleContent>
+			<xs:extension base="EVChargingLevel_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="EVChargingConnector_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="SAE J1772"/>
 			<xs:enumeration value="CHAdeMO"/>
@@ -1842,28 +3501,63 @@
 			<xs:enumeration value="Combined Charging System"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="Current">
+	<xs:complexType name="EVChargingConnector">
+		<xs:simpleContent>
+			<xs:extension base="EVChargingConnector_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="Current_simple">
 		<xs:restriction base="xs:decimal">
 			<xs:minInclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="Voltage">
+	<xs:complexType name="Current">
+		<xs:simpleContent>
+			<xs:extension base="Current_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="Voltage_simple">
 		<xs:restriction base="xs:decimal">
 			<xs:minInclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="Power">
+	<xs:complexType name="Voltage">
+		<xs:simpleContent>
+			<xs:extension base="Voltage_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="Power_simple">
 		<xs:restriction base="xs:double">
 			<xs:minInclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="ZoneType">
+	<xs:complexType name="Power">
+		<xs:simpleContent>
+			<xs:extension base="Power_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ZoneType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="conditioned"/>
 			<xs:enumeration value="unconditioned"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="WholeBldgVentilationRequirementMethod">
+	<xs:complexType name="ZoneType">
+		<xs:simpleContent>
+			<xs:extension base="ZoneType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="WholeBldgVentilationRequirementMethod_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="ASHRAE 62.2-1989"/>
 			<xs:enumeration value="ASHRAE 62.2-2007"/>
@@ -1871,34 +3565,69 @@
 			<xs:enumeration value="ASHRAE 62.2-2013"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="BooleanWithNA">
+	<xs:complexType name="WholeBldgVentilationRequirementMethod">
+		<xs:simpleContent>
+			<xs:extension base="WholeBldgVentilationRequirementMethod_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="BooleanWithNA_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="true"/>
 			<xs:enumeration value="false"/>
 			<xs:enumeration value="na"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="VentilationRateUnits">
+	<xs:complexType name="BooleanWithNA">
+		<xs:simpleContent>
+			<xs:extension base="BooleanWithNA_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="VentilationRateUnits_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="ACH"/>
 			<xs:enumeration value="CFMnat"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="VentilationFanThirdPartyCertification">
+	<xs:complexType name="VentilationRateUnits">
+		<xs:simpleContent>
+			<xs:extension base="VentilationRateUnits_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="VentilationFanThirdPartyCertification_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Energy Star"/>
 			<xs:enumeration value="Home Ventilation Institute"/>
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="Recommendation">
+	<xs:complexType name="VentilationFanThirdPartyCertification">
+		<xs:simpleContent>
+			<xs:extension base="VentilationFanThirdPartyCertification_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="Recommendation_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="require"/>
 			<xs:enumeration value="recommend"/>
 			<xs:enumeration value="no recommendation"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="SpotVentilationLocation">
+	<xs:complexType name="Recommendation">
+		<xs:simpleContent>
+			<xs:extension base="Recommendation_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="SpotVentilationLocation_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="bath"/>
 			<xs:enumeration value="garage"/>
@@ -1908,14 +3637,28 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="SpotVentilationUnits">
+	<xs:complexType name="SpotVentilationLocation">
+		<xs:simpleContent>
+			<xs:extension base="SpotVentilationLocation_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="SpotVentilationUnits_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="CFM"/>
 			<xs:enumeration value="ACH"/>
 			<xs:enumeration value="L/s"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="VentilationFanType">
+	<xs:complexType name="SpotVentilationUnits">
+		<xs:simpleContent>
+			<xs:extension base="SpotVentilationUnits_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="VentilationFanType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="exhaust only"/>
 			<xs:enumeration value="supply only"/>
@@ -1925,13 +3668,27 @@
 			<xs:enumeration value="central fan integrated supply"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="HoursPerDay">
+	<xs:complexType name="VentilationFanType">
+		<xs:simpleContent>
+			<xs:extension base="VentilationFanType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="HoursPerDay_simple">
 		<xs:restriction base="xs:double">
 			<xs:minInclusive value="0"/>
 			<xs:maxInclusive value="24"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="VentilationFanLocation">
+	<xs:complexType name="HoursPerDay">
+		<xs:simpleContent>
+			<xs:extension base="HoursPerDay_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="VentilationFanLocation_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="bath"/>
 			<xs:enumeration value="garage"/>
@@ -1942,7 +3699,14 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="eGridRegions">
+	<xs:complexType name="VentilationFanLocation">
+		<xs:simpleContent>
+			<xs:extension base="VentilationFanLocation_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="eGridRegions_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Alaska"/>
 			<xs:enumeration value="Eastern"/>
@@ -1951,10 +3715,24 @@
 			<xs:enumeration value="Western"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="ProgramSponsor">
+	<xs:complexType name="eGridRegions">
+		<xs:simpleContent>
+			<xs:extension base="eGridRegions_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ProgramSponsor_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="GreenBuildingVerificationType">
+	<xs:complexType name="ProgramSponsor">
+		<xs:simpleContent>
+			<xs:extension base="ProgramSponsor_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="GreenBuildingVerificationType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="BPI-2101-compliant Certificate of Residential Energy Efficiency Features and Performance"/>
 			<xs:enumeration value="Certified Passive House"/>
@@ -1976,7 +3754,14 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="GreenBuildingVerificationSource">
+	<xs:complexType name="GreenBuildingVerificationType">
+		<xs:simpleContent>
+			<xs:extension base="GreenBuildingVerificationType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="GreenBuildingVerificationSource_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Administrator"/>
 			<xs:enumeration value="Assessor"/>
@@ -1990,27 +3775,53 @@
 			<xs:enumeration value="See Remarks"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="GreenBuildingVerificationStatus">
+	<xs:complexType name="GreenBuildingVerificationSource">
+		<xs:simpleContent>
+			<xs:extension base="GreenBuildingVerificationSource_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="GreenBuildingVerificationStatus_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="complete"/>
 			<xs:enumeration value="in process"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="BoilerType">
+	<xs:complexType name="GreenBuildingVerificationStatus">
+		<xs:simpleContent>
+			<xs:extension base="GreenBuildingVerificationStatus_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="BoilerType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="hot water"/>
 			<xs:enumeration value="steam"/>
 		</xs:restriction>
 	</xs:simpleType>
-
-
-	<xs:simpleType name="KnownOrEstimated">
+	<xs:complexType name="BoilerType">
+		<xs:simpleContent>
+			<xs:extension base="BoilerType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="KnownOrEstimated_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="known"/>
 			<xs:enumeration value="estimated"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="PoolType">
+	<xs:complexType name="KnownOrEstimated">
+		<xs:simpleContent>
+			<xs:extension base="KnownOrEstimated_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="PoolType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="in ground"/>
 			<xs:enumeration value="on ground"/>
@@ -2020,13 +3831,27 @@
 			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="MonthsPerYear">
+	<xs:complexType name="PoolType">
+		<xs:simpleContent>
+			<xs:extension base="PoolType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="MonthsPerYear_simple">
 		<xs:restriction base="xs:integer">
 			<xs:minInclusive value="0"/>
 			<xs:maxInclusive value="12"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="PoolFilterType">
+	<xs:complexType name="MonthsPerYear">
+		<xs:simpleContent>
+			<xs:extension base="MonthsPerYear_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="PoolFilterType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="sand"/>
 			<xs:enumeration value="diatomaceous earth"/>
@@ -2036,7 +3861,14 @@
 			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="PoolPumpType">
+	<xs:complexType name="PoolFilterType">
+		<xs:simpleContent>
+			<xs:extension base="PoolFilterType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="PoolPumpType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="single speed"/>
 			<xs:enumeration value="multi speed"/>
@@ -2047,7 +3879,14 @@
 			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="PoolPump3rdPartyCertification">
+	<xs:complexType name="PoolPumpType">
+		<xs:simpleContent>
+			<xs:extension base="PoolPumpType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="PoolPump3rdPartyCertification_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="ENERGY STAR"/>
 			<xs:enumeration value="ENERGY STAR Most Efficient"/>
@@ -2059,7 +3898,14 @@
 			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="PoolPumpSpeedSetting">
+	<xs:complexType name="PoolPump3rdPartyCertification">
+		<xs:simpleContent>
+			<xs:extension base="PoolPump3rdPartyCertification_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="PoolPumpSpeedSetting_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="low"/>
 			<xs:enumeration value="high"/>
@@ -2069,17 +3915,38 @@
 			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="Speed">
+	<xs:complexType name="PoolPumpSpeedSetting">
+		<xs:simpleContent>
+			<xs:extension base="PoolPumpSpeedSetting_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="Speed_simple">
 		<xs:restriction base="xs:double">
 			<xs:minInclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="FlowRate">
+	<xs:complexType name="Speed">
+		<xs:simpleContent>
+			<xs:extension base="Speed_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="FlowRate_simple">
 		<xs:restriction base="xs:double">
 			<xs:minInclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="PoolCleanerType">
+	<xs:complexType name="FlowRate">
+		<xs:simpleContent>
+			<xs:extension base="FlowRate_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="PoolCleanerType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="robotic"/>
 			<xs:enumeration value="suction side"/>
@@ -2090,7 +3957,14 @@
 			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="PoolHeaterType">
+	<xs:complexType name="PoolCleanerType">
+		<xs:simpleContent>
+			<xs:extension base="PoolCleanerType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="PoolHeaterType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="gas fired"/>
 			<xs:enumeration value="electric resistance"/>
@@ -2101,14 +3975,28 @@
 			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="BPI2400CalibrationQualification">
+	<xs:complexType name="PoolHeaterType">
+		<xs:simpleContent>
+			<xs:extension base="PoolHeaterType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="BPI2400CalibrationQualification_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="none"/>
 			<xs:enumeration value="detailed"/>
 			<xs:enumeration value="simple"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="WeatherStationType">
+	<xs:complexType name="BPI2400CalibrationQualification">
+		<xs:simpleContent>
+			<xs:extension base="BPI2400CalibrationQualification_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="WeatherStationType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="TMY"/>
 			<xs:enumeration value="TMY2"/>
@@ -2116,13 +4004,27 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="DuctLeakageTotalOrToOutside">
+	<xs:complexType name="WeatherStationType">
+		<xs:simpleContent>
+			<xs:extension base="WeatherStationType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="DuctLeakageTotalOrToOutside_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="to outside"/>
 			<xs:enumeration value="total"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="WeatherStationUse">
+	<xs:complexType name="DuctLeakageTotalOrToOutside">
+		<xs:simpleContent>
+			<xs:extension base="DuctLeakageTotalOrToOutside_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="WeatherStationUse_simple">
 		<xs:annotation>
 			<xs:documentation>By leaving this field empty, the weather station is assumed used for all functions such as utility bill regression analysis and energy model simulations. If different
 				weather stations are used for the different functions, use this field to specify the usage of each weather station.</xs:documentation>
@@ -2132,14 +4034,28 @@
 			<xs:enumeration value="energy modeling"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="WaterFixtureType">
+	<xs:complexType name="WeatherStationUse">
+		<xs:simpleContent>
+			<xs:extension base="WeatherStationUse_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="WaterFixtureType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="faucet"/>
 			<xs:enumeration value="shower head"/>
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="WaterFixtureThirdPartyCertification">
+	<xs:complexType name="WaterFixtureType">
+		<xs:simpleContent>
+			<xs:extension base="WaterFixtureType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="WaterFixtureThirdPartyCertification_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Energy Star"/>
 			<xs:enumeration value="Energy Star Most Efficient"/>
@@ -2151,7 +4067,14 @@
 			<xs:enumeration value="unknown"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="LightingFixtureThirdPartyCertification">
+	<xs:complexType name="WaterFixtureThirdPartyCertification">
+		<xs:simpleContent>
+			<xs:extension base="WaterFixtureThirdPartyCertification_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="LightingFixtureThirdPartyCertification_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Energy Star"/>
 			<xs:enumeration value="Energy Star Most Efficient"/>
@@ -2164,24 +4087,52 @@
 			<xs:enumeration value="unknown"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="PeopleCount">
+	<xs:complexType name="LightingFixtureThirdPartyCertification">
+		<xs:simpleContent>
+			<xs:extension base="LightingFixtureThirdPartyCertification_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="PeopleCount_simple">
 		<xs:restriction base="xs:double">
 			<xs:minInclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="WindThirdPartyCertification">
+	<xs:complexType name="PeopleCount">
+		<xs:simpleContent>
+			<xs:extension base="PeopleCount_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="WindThirdPartyCertification_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="AWEA 9.1-2009"/>
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="DrainWaterHeatRecoveryFacilitiesConnected">
+	<xs:complexType name="WindThirdPartyCertification">
+		<xs:simpleContent>
+			<xs:extension base="WindThirdPartyCertification_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="DrainWaterHeatRecoveryFacilitiesConnected_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="one"/>
 			<xs:enumeration value="all"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="RecirculationControlType">
+	<xs:complexType name="DrainWaterHeatRecoveryFacilitiesConnected">
+		<xs:simpleContent>
+			<xs:extension base="DrainWaterHeatRecoveryFacilitiesConnected_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="RecirculationControlType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="no control"/>
 			<xs:enumeration value="timer"/>
@@ -2190,45 +4141,94 @@
 			<xs:enumeration value="manual demand control"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="MERV">
+	<xs:complexType name="RecirculationControlType">
+		<xs:simpleContent>
+			<xs:extension base="RecirculationControlType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="MERV_simple">
 		<xs:restriction base="xs:int">
 			<xs:minInclusive value="1"/>
 			<xs:maxInclusive value="20"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="SolarAbsorptance">
+	<xs:complexType name="MERV">
+		<xs:simpleContent>
+			<xs:extension base="MERV_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="SolarAbsorptance_simple">
 		<xs:restriction base="xs:double">
 			<xs:minInclusive value="0"/>
 			<xs:maxInclusive value="1"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="Emittance">
+	<xs:complexType name="SolarAbsorptance">
+		<xs:simpleContent>
+			<xs:extension base="SolarAbsorptance_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="Emittance_simple">
 		<xs:restriction base="xs:double">
 			<xs:minInclusive value="0"/>
 			<xs:maxInclusive value="1"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="AtticWallType">
+	<xs:complexType name="Emittance">
+		<xs:simpleContent>
+			<xs:extension base="Emittance_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="AtticWallType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="gable"/>
 			<xs:enumeration value="knee wall"/>
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="MinutesPerDay">
+	<xs:complexType name="AtticWallType">
+		<xs:simpleContent>
+			<xs:extension base="AtticWallType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="MinutesPerDay_simple">
 		<xs:restriction base="xs:double">
 			<xs:minInclusive value="0"/>
 			<xs:maxInclusive value="1440"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="VentilationUnit">
+	<xs:complexType name="MinutesPerDay">
+		<xs:simpleContent>
+			<xs:extension base="MinutesPerDay_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="VentilationUnit_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="SLA"/>
 			<xs:enumeration value="ACHnatural"/>
 			<xs:enumeration value="CFM per sq.ft."/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="BatteryType">
+	<xs:complexType name="VentilationUnit">
+		<xs:simpleContent>
+			<xs:extension base="VentilationUnit_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="BatteryType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Li-ion"/>
 			<xs:enumeration value="lead acid"/>
@@ -2237,19 +4237,40 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="BatteryCapacity">
+	<xs:complexType name="BatteryType">
+		<xs:simpleContent>
+			<xs:extension base="BatteryType_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="BatteryCapacity_simple">
 		<xs:restriction base="xs:decimal">
 			<xs:minInclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="BatteryCoolingStrategy">
+	<xs:complexType name="BatteryCapacity">
+		<xs:simpleContent>
+			<xs:extension base="BatteryCapacity_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="BatteryCoolingStrategy_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="passive"/>
 			<xs:enumeration value="active air cooling"/>
 			<xs:enumeration value="liquid cooling"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="BatteryLocation">
+	<xs:complexType name="BatteryCoolingStrategy">
+		<xs:simpleContent>
+			<xs:extension base="BatteryCoolingStrategy_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="BatteryLocation_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="attic"/>
 			<xs:enumeration value="attic - conditioned"/>
@@ -2274,14 +4295,28 @@
 			<xs:enumeration value="unconditioned space"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="DiameterDimension">
+	<xs:complexType name="BatteryLocation">
+		<xs:simpleContent>
+			<xs:extension base="BatteryLocation_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="DiameterDimension_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="inner"/>
 			<xs:enumeration value="outer"/>
 			<xs:enumeration value="nominal"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="ConnectedDeviceCommunicationProtocol">
+	<xs:complexType name="DiameterDimension">
+		<xs:simpleContent>
+			<xs:extension base="DiameterDimension_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ConnectedDeviceCommunicationProtocol_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Wi-Fi"/>
 			<xs:enumeration value="Zigbee"/>
@@ -2293,18 +4328,39 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="DHWControllerTechnology">
+	<xs:complexType name="ConnectedDeviceCommunicationProtocol">
+		<xs:simpleContent>
+			<xs:extension base="ConnectedDeviceCommunicationProtocol_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="DHWControllerTechnology_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="smart"/>
 			<xs:enumeration value="timer"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="DHWTemperatureControl">
+	<xs:complexType name="DHWControllerTechnology">
+		<xs:simpleContent>
+			<xs:extension base="DHWControllerTechnology_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="DHWTemperatureControl_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="fixed"/>
 			<xs:enumeration value="variable"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="DHWTemperatureControl">
+		<xs:simpleContent>
+			<xs:extension base="DHWTemperatureControl_simple">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="DataSource">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="user"/>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1,5 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.0">
+	<xs:simpleType name="DataSource">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="user"/>
+			<xs:enumeration value="software"/>
+		</xs:restriction>
+	</xs:simpleType>
 	<xs:complexType name="HPXMLString">
 		<xs:simpleContent>
 			<xs:extension base="xs:string">
@@ -4374,10 +4380,77 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="DataSource">
+	<xs:simpleType name="ClothesDryerControlType_simple">
 		<xs:restriction base="xs:string">
-			<xs:enumeration value="user"/>
-			<xs:enumeration value="software"/>
+			<xs:enumeration value="timer"/>
+			<xs:enumeration value="moisture"/>
+			<xs:enumeration value="temperature"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CollectorRatedThermalLosses_simple">
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SolarFraction_simple">
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+			<xs:maxInclusive value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CollectorRatedOpticalEfficiency_simple">
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+			<xs:maxExclusive value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PVModuleType_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="standard"/>
+			<xs:enumeration value="premium"/>
+			<xs:enumeration value="thin film"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PVTracking_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="fixed"/>
+			<xs:enumeration value="1-axis"/>
+			<xs:enumeration value="1-axis backtracked"/>
+			<xs:enumeration value="2-axis"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FanSpeed_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="low"/>
+			<xs:enumeration value="medium"/>
+			<xs:enumeration value="high"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SodiumLight_Pressure_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="high"/>
+			<xs:enumeration value="low"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="HeatPumpBackupType_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="integrated"/>
+			<xs:enumeration value="separate"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalResourceType_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="photo"/>
+			<xs:enumeration value="illustration"/>
+			<xs:enumeration value="document"/>
+			<xs:enumeration value="spreadsheet"/>
+			<xs:enumeration value="website"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SolarThermalSystemEnergyFactor_simple">
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
 </xs:schema>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -14,6 +14,13 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+	<xs:complexType name="HPXMLDateTime">
+		<xs:simpleContent>
+			<xs:extension base="xs:dateTime">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:complexType name="HPXMLBoolean">
 		<xs:simpleContent>
 			<xs:extension base="xs:boolean">
@@ -35,7 +42,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	
 	<xs:simpleType name="schemaVersionType">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="3.0"/>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -2185,8 +2185,6 @@
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="user"/>
 			<xs:enumeration value="software"/>
-			<xs:enumeration value="software default"/>
-			<xs:enumeration value="imputed"/>
 		</xs:restriction>
 	</xs:simpleType>
 </xs:schema>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -2181,4 +2181,12 @@
 			<xs:enumeration value="CFM per sq.ft."/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:simpleType name="DataSource">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="user"/>
+			<xs:enumeration value="software"/>
+			<xs:enumeration value="software default"/>
+			<xs:enumeration value="imputed"/>
+		</xs:restriction>
+	</xs:simpleType>
 </xs:schema>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -30,14 +30,21 @@
 	</xs:complexType>
 	<xs:complexType name="HPXMLDouble">
 		<xs:simpleContent>
-			<xs:extension base="xs:boolean">
+			<xs:extension base="xs:double">
 				<xs:attribute ref="dataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
 	<xs:complexType name="HPXMLDecimal">
 		<xs:simpleContent>
-			<xs:extension base="xs:boolean">
+			<xs:extension base="xs:decimal">
+				<xs:attribute ref="dataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="HPXMLInteger">
+		<xs:simpleContent>
+			<xs:extension base="xs:integer">
 				<xs:attribute ref="dataSource"/>
 			</xs:extension>
 		</xs:simpleContent>


### PR DESCRIPTION
This adds a `dataSource` attribute with the following enumerations

- user
- software
- ~~software default~~
- ~~imputed~~

The next big question we need to answer is _which_ elements need this attribute? Some examples to stir up discussion:

- Orientation / Azimuth 👍 
- WalkingScore 👎 
- NumberofAdults / NumberofChildren 🤷‍♂ 
- Occupancy (owner vs renter) 🤷‍♂ 
- FoundationType 👎 
- VentilationRate 👍 
- WallType 🤷‍♂ 
- Wall/Area 👍 
- Wall/Color 👀 ❓ 
- FloorJoists/Size 👀 
- FloorJoists/Spacing 👍 
- Insulation/InsulationGrade 👍
- HVAC system types 👎  (should be observable, right?)

And there's more. It's going to be pretty disruptive to put these on _everything_. Almost every line of the schema will change. 