### PR TITLE
DHW Controllers

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -1397,6 +1397,7 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
+									<xs:element ref="ConnectedDevice"/>
 									<xs:element minOccurs="0" name="Model" type="xs:string"/>
 									<xs:element minOccurs="0" name="Manufacturer" type="xs:string"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="xs:string"/>
@@ -4755,10 +4756,8 @@ https://hpxml.nrel.gov/wiki/WallTypes</xs:documentation>
 			<xs:sequence>
 				<xs:group ref="SystemInfo"/>
 				<xs:element name="IsConnected" type="xs:boolean"/>
-				<xs:element maxOccurs="unbounded" minOccurs="0" name="CommunicatesWith"
-					type="LocalReference"/>
-				<xs:element minOccurs="0" name="CommunicationProtocol"
-					type="ConnectedDeviceCommunicationProtocol" maxOccurs="unbounded"/>
+				<xs:element maxOccurs="unbounded" minOccurs="0" name="CommunicatesWith" type="LocalReference"/>
+				<xs:element minOccurs="0" name="CommunicationProtocol" type="ConnectedDeviceCommunicationProtocol" maxOccurs="unbounded"/>
 				<xs:element minOccurs="0" name="DemandResponseCapability" type="xs:boolean"/>
 				<xs:element minOccurs="0" name="OccupancySensor" type="xs:boolean"/>
 				<xs:element minOccurs="0" ref="extension"/>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10"
-	targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.0">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.0">
 	<xs:include schemaLocation="HPXMLDataTypes.xsd"/>
 	<xs:element name="XMLTransactionHeaderInformation">
 		<xs:annotation>
@@ -36,14 +35,10 @@
 			<xs:documentation>System identifiers contain type codes and an identifier for both a sending and a receiving system.  These fields are needed to be able to transmit data between two systems, and have it identified in the two systems. Also, there is an id attribute to define a local id to be used internally. </xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType"
-				minOccurs="0"/>
-			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue"
-				minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType"
-				minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue"
-				minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType" minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue" minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType" minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="id" type="xs:ID" use="required">
 			<xs:annotation>
@@ -64,14 +59,10 @@
 			<xs:documentation>Use the id attribute if the element being referenced is available locally in the current xml transaction. Use the Sending/Receiving System Identifiers to identify elements in other xml transactions.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType"
-				minOccurs="0"/>
-			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue"
-				minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType"
-				minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue"
-				minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType" minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue" minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType" minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="id" type="xs:IDREF">
 			<xs:annotation>
@@ -124,8 +115,7 @@
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="IndividualType" type="IndividualType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="Telephone"
-				type="TelephoneInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="Telephone" type="TelephoneInfoType"/>
 			<xs:element minOccurs="0" maxOccurs="unbounded" name="Email" type="EmailInfoType"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
@@ -141,11 +131,9 @@
 				<xs:element minOccurs="0" name="MeterNumber" type="xs:string"/>
 				<xs:element name="UtilityAccountNumber" type="xs:string" minOccurs="0"/>
 				<xs:element minOccurs="0" name="Permission" type="xs:boolean"/>
-				<xs:element name="UtilityServiceTypeProvided" type="ConsumptionType" minOccurs="0"
-					maxOccurs="unbounded"/>
+				<xs:element name="UtilityServiceTypeProvided" type="ConsumptionType" minOccurs="0" maxOccurs="unbounded"/>
 				<xs:element minOccurs="0" name="BusinessInfo" type="BusinessInfoType"/>
-				<xs:element maxOccurs="unbounded" minOccurs="0" name="BusinessContactInfo"
-					type="BusinessContactInfoType"/>
+				<xs:element maxOccurs="unbounded" minOccurs="0" name="BusinessContactInfo" type="BusinessContactInfoType"/>
 				<xs:element ref="extension" minOccurs="0"/>
 			</xs:sequence>
 		</xs:complexType>
@@ -195,8 +183,7 @@
 				<xs:complexType>
 					<xs:sequence maxOccurs="1">
 						<xs:element name="InstallationType" type="InstallationType" minOccurs="0"/>
-						<xs:element name="InsulationMaterial" type="InsulationMaterial"
-							minOccurs="0"/>
+						<xs:element name="InsulationMaterial" type="InsulationMaterial" minOccurs="0"/>
 						<xs:element name="NominalRValue" type="RValue" minOccurs="0"/>
 						<xs:element name="Thickness" type="LengthMeasurement" minOccurs="0">
 							<xs:annotation>
@@ -223,8 +210,7 @@
 			<xs:element minOccurs="0" name="AHRINumber" type="xs:string"/>
 			<xs:element minOccurs="0" name="SerialNumber" type="xs:string"/>
 			<xs:element name="ModelYear" type="Year" minOccurs="0"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification"
-				type="ApplianceThirdPartyCertifications"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="ApplianceThirdPartyCertifications"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="ClothesDryerInfoType">
@@ -334,14 +320,11 @@
 					<xs:element minOccurs="0" name="Type" type="DishwasherType"/>
 					<xs:element minOccurs="0" name="Fuel" type="FuelType"/>
 					<xs:element name="HeatDryDefaultOff" type="xs:boolean" minOccurs="0"/>
-					<xs:element name="AuxillaryWaterHeaterDefaultOff" type="xs:boolean"
-						minOccurs="0"/>
+					<xs:element name="AuxillaryWaterHeaterDefaultOff" type="xs:boolean" minOccurs="0"/>
 					<xs:element minOccurs="0" name="RatedAnnualkWh" type="RatedAnnualkWh"/>
 					<xs:element minOccurs="0" name="EnergyFactor" type="EnergyFactor"/>
-					<xs:element minOccurs="0" name="RatedWaterGalPerCycle"
-						type="RatedWaterGalPerCycle"/>
-					<xs:element minOccurs="0" name="PlaceSettingCapacity"
-						type="IntegerGreaterThanZero"/>
+					<xs:element minOccurs="0" name="RatedWaterGalPerCycle" type="RatedWaterGalPerCycle"/>
+					<xs:element minOccurs="0" name="PlaceSettingCapacity" type="IntegerGreaterThanZero"/>
 					<xs:element minOccurs="0" name="Usage" type="xs:double">
 						<xs:annotation>
 							<xs:documentation>loads/week</xs:documentation>
@@ -442,8 +425,7 @@
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element name="SoftwareProgramUsed" type="SoftwareProgramUsed" minOccurs="0"/>
-				<xs:element name="SoftwareProgramVersion" type="SoftwareProgramVersion"
-					minOccurs="0"/>
+				<xs:element name="SoftwareProgramVersion" type="SoftwareProgramVersion" minOccurs="0"/>
 				<xs:element ref="extension" minOccurs="0"/>
 			</xs:sequence>
 		</xs:complexType>
@@ -460,12 +442,9 @@
 			<xs:element name="Auditor">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="Qualification" type="AuditorQualification"
-							maxOccurs="unbounded"/>
-						<xs:element minOccurs="0" name="StateWhereQualificationHeld"
-							type="StateCode"/>
-						<xs:element minOccurs="0" name="YearsExperience"
-							type="IntegerGreaterThanOrEqualToZero"/>
+						<xs:element minOccurs="0" name="Qualification" type="AuditorQualification" maxOccurs="unbounded"/>
+						<xs:element minOccurs="0" name="StateWhereQualificationHeld" type="StateCode"/>
+						<xs:element minOccurs="0" name="YearsExperience" type="IntegerGreaterThanOrEqualToZero"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -473,10 +452,8 @@
 			<xs:element name="Implementer">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" minOccurs="0" name="Qualification"
-							type="ImplementerQualification"/>
-						<xs:element minOccurs="0" name="StateWhereQualificationHeld"
-							type="StateCode"/>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="Qualification" type="ImplementerQualification"/>
+						<xs:element minOccurs="0" name="StateWhereQualificationHeld" type="StateCode"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -495,8 +472,7 @@
 		<xs:sequence>
 			<xs:group maxOccurs="unbounded" ref="SystemInfo"/>
 			<xs:element name="BusinessInfo" type="BusinessInfoType"/>
-			<xs:element name="SubContractor" type="ContractorType" minOccurs="0"
-				maxOccurs="unbounded"/>
+			<xs:element name="SubContractor" type="ContractorType" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 	</xs:complexType>
@@ -509,8 +485,7 @@
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element name="SpaceName" type="xs:string" minOccurs="0"/>
-						<xs:element minOccurs="0" name="NumberOfBedrooms"
-							type="IntegerGreaterThanOrEqualToZero"/>
+						<xs:element minOccurs="0" name="NumberOfBedrooms" type="IntegerGreaterThanOrEqualToZero"/>
 						<xs:element minOccurs="0" name="FloorArea" type="SurfaceArea">
 							<xs:annotation>
 								<xs:documentation>[sq.ft.]</xs:documentation>
@@ -552,8 +527,7 @@
 			<xs:element name="AirInfiltration" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="AirInfiltrationMeasurement"
-							type="AirInfiltrationMeasurementType" maxOccurs="unbounded"> </xs:element>
+						<xs:element minOccurs="0" name="AirInfiltrationMeasurement" type="AirInfiltrationMeasurementType" maxOccurs="unbounded"> </xs:element>
 						<xs:element minOccurs="0" name="AirSealing" maxOccurs="unbounded">
 							<xs:complexType>
 								<xs:sequence>
@@ -562,14 +536,9 @@
 									<xs:element minOccurs="0" name="ComponentsAirSealed">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element maxOccurs="unbounded" minOccurs="0"
-												name="Attic" type="AtticComponentsAirSealed"/>
-												<xs:element maxOccurs="unbounded" minOccurs="0"
-												name="BasementCrawlspace"
-												type="BasementCrawlspaceComponentsAirSealed"/>
-												<xs:element maxOccurs="unbounded" minOccurs="0"
-												name="LivingSpace"
-												type="LivingSpaceComponentsAirSealed"/>
+												<xs:element maxOccurs="unbounded" minOccurs="0" name="Attic" type="AtticComponentsAirSealed"/>
+												<xs:element maxOccurs="unbounded" minOccurs="0" name="BasementCrawlspace" type="BasementCrawlspaceComponentsAirSealed"/>
+												<xs:element maxOccurs="unbounded" minOccurs="0" name="LivingSpace" type="LivingSpaceComponentsAirSealed"/>
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
@@ -603,19 +572,14 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="1" name="AtticType" type="AtticType"/>
-									<xs:element minOccurs="0" name="VentilationRate"
-										type="VentilationType"/>
-									<xs:element minOccurs="0" name="AttachedToRoof"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToWall"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFrameFloor"
-										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="VentilationRate" type="VentilationType"/>
+									<xs:element minOccurs="0" name="AttachedToRoof" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFrameFloor" type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo"
-												type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
@@ -638,25 +602,17 @@
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
 									<xs:element name="FoundationType" type="FoundationType"/>
-									<xs:element minOccurs="0" name="VentilationRate"
-										type="VentilationType"/>
-									<xs:element minOccurs="0" name="ThermalBoundary"
-										type="FoundationThermalBoundary"/>
-									<xs:element minOccurs="0" name="AttachedToRimJoist"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToWall"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFoundationWall"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFrameFloor"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToSlab"
-										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="VentilationRate" type="VentilationType"/>
+									<xs:element minOccurs="0" name="ThermalBoundary" type="FoundationThermalBoundary"/>
+									<xs:element minOccurs="0" name="AttachedToRimJoist" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFoundationWall" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFrameFloor" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToSlab" type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo"
-												type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
@@ -685,31 +641,22 @@
 									<xs:element minOccurs="1" name="GarageType">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="AttachedtoHouse"
-												type="xs:boolean"/>
-												<xs:element minOccurs="0" name="Vented"
-												type="xs:boolean"/>
-												<xs:element minOccurs="0" name="Conditioned"
-												type="xs:boolean"/>
+												<xs:element minOccurs="0" name="AttachedtoHouse" type="xs:boolean"/>
+												<xs:element minOccurs="0" name="Vented" type="xs:boolean"/>
+												<xs:element minOccurs="0" name="Conditioned" type="xs:boolean"/>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="AttachedToRoof"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToWall"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFoundationWall"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFrameFloor"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToSlab"
-										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToRoof" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFoundationWall" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFrameFloor" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToSlab" type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo"
-												type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
@@ -731,25 +678,21 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo"
-										type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Surface area of the roof itself</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation"
-										type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
 									<xs:element name="Azimuth" type="AzimuthType" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="RoofType" type="RoofType"/>
-									<xs:element minOccurs="0" name="RoofColor"
-										type="WallAndRoofColor"/>
-									<xs:element minOccurs="0" name="SolarAbsorptance"
-										type="SolarAbsorptance"/>
+									<xs:element minOccurs="0" name="RoofColor" type="WallAndRoofColor"/>
+									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
 									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
 									<xs:element minOccurs="0" name="Rafters" type="StudProperties"/>
 									<xs:element minOccurs="0" name="DeckType" type="DeckType"/>
@@ -758,12 +701,9 @@
 											<xs:documentation>Pitch of roof ?/12</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="RadiantBarrier" type="xs:boolean"
-										minOccurs="0"/>
-									<xs:element name="RadiantBarrierLocation"
-										type="RadiantBarrierLocation" minOccurs="0"/>
-									<xs:element minOccurs="0" name="Insulation"
-										type="InsulationInfo"/>
+									<xs:element name="RadiantBarrier" type="xs:boolean" minOccurs="0"/>
+									<xs:element name="RadiantBarrierLocation" type="RadiantBarrierLocation" minOccurs="0"/>
+									<xs:element minOccurs="0" name="Insulation" type="InsulationInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 							</xs:complexType>
@@ -779,40 +719,32 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element minOccurs="0" name="ExteriorAdjacentTo"
-										type="AdjacentTo"/>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo"
-										type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="ExteriorAdjacentTo" type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation"
-										type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
 									<xs:element name="Azimuth" type="AzimuthType" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Perimeter"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Perimeter" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="SolarAbsorptance"
-										type="SolarAbsorptance"/>
+									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
 									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
-									<xs:element minOccurs="0" name="Insulation"
-										type="InsulationInfo"/>
-									<xs:element minOccurs="0" name="FloorJoists"
-										type="StudProperties"/>
+									<xs:element minOccurs="0" name="Insulation" type="InsulationInfo"/>
+									<xs:element minOccurs="0" name="FloorJoists" type="StudProperties"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo"
-												type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
@@ -831,15 +763,11 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo"
-										minOccurs="0"> </xs:element>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo"
-										type="AdjacentTo"/>
-									<xs:element minOccurs="0" name="AtticWallType"
-										type="AtticWallType"/>
+									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo" minOccurs="0"> </xs:element>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="AtticWallType" type="AtticWallType"/>
 									<xs:element name="WallType" type="WallType" minOccurs="0"> </xs:element>
-									<xs:element minOccurs="0" name="Thickness"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[in] Thickness of the wall assembly</xs:documentation>
 										</xs:annotation>
@@ -849,8 +777,7 @@
 											<xs:documentation>[sq.ft.] Gross wall area</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation"
-										type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
 									<xs:element name="Azimuth" type="AzimuthType" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
@@ -859,16 +786,13 @@
 									<xs:element minOccurs="0" name="Studs" type="StudProperties"/>
 									<xs:element minOccurs="0" name="Siding" type="Siding"/>
 									<xs:element minOccurs="0" name="Color" type="WallAndRoofColor"/>
-									<xs:element minOccurs="0" name="SolarAbsorptance"
-										type="SolarAbsorptance"/>
+									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
 									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
-									<xs:element minOccurs="0" maxOccurs="1" name="Insulation"
-										type="InsulationInfo"/>
+									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo"
-												type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
@@ -887,10 +811,8 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo"
-										minOccurs="0"> </xs:element>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo"
-										type="AdjacentTo"/>
+									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo" minOccurs="0"> </xs:element>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="Type" type="FoundationWallType"/>
 									<xs:element minOccurs="0" name="Length" type="LengthMeasurement">
 										<xs:annotation>
@@ -907,47 +829,39 @@
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation"
-										type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
 									<xs:element name="Azimuth" type="AzimuthType" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Thickness"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[in] Thickness of foundation wall excluding interior framing.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="DepthBelowGrade"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="DepthBelowGrade" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Depth below grade of foundation wall</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AdjacentToFoundation"
-										type="LocalReference">
+									<xs:element minOccurs="0" name="AdjacentToFoundation" type="LocalReference">
 										<xs:annotation>
 											<xs:documentation>If this foundation wall is adjacent to another foundation, use this reference to indicate which one.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="InteriorStuds"
-										type="StudProperties"/>
-									<xs:element minOccurs="0" name="DistanceToTopOfInsulation"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="InteriorStuds" type="StudProperties"/>
+									<xs:element minOccurs="0" name="DistanceToTopOfInsulation" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Vertical distance from top of foundation wall to top of insulation.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="DistanceToBottomOfInsulation"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="DistanceToBottomOfInsulation" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Vertical distance from top of foundation wall to bottom of insulation.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element maxOccurs="1" minOccurs="0" name="Insulation"
-										type="InsulationInfo"/>
+									<xs:element maxOccurs="1" minOccurs="0" name="Insulation" type="InsulationInfo"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 							</xs:complexType>
@@ -966,23 +880,17 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo"
-										minOccurs="0"> </xs:element>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo"
-										type="AdjacentTo"/>
-									<xs:element minOccurs="0" name="FloorJoists"
-										type="StudProperties"/>
-									<xs:element minOccurs="0" name="FloorTrusses"
-										type="StudProperties"/>
-									<xs:element minOccurs="0" name="FloorCovering"
-										type="FloorCovering"/>
+									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo" minOccurs="0"> </xs:element>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="FloorJoists" type="StudProperties"/>
+									<xs:element minOccurs="0" name="FloorTrusses" type="StudProperties"/>
+									<xs:element minOccurs="0" name="FloorCovering" type="FloorCovering"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" maxOccurs="1" name="Insulation"
-										type="InsulationInfo"> </xs:element>
+									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"> </xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 							</xs:complexType>
@@ -1001,63 +909,51 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo"
-										type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Area of the slab</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Thickness"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[in] Thickness of foundation slab.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Perimeter"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Perimeter" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Length of slab perimeter.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="ExposedPerimeter"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="ExposedPerimeter" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Perimeter of the slab exposed to ambient conditions</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="PerimeterInsulationDepth"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="PerimeterInsulationDepth" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Depth from grade to bottom of vertical slab perimeter insulation</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="UnderSlabInsulationWidth"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="UnderSlabInsulationWidth" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Width from slab edge inward of horizontal under-slab insulation</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0"
-										name="UnderSlabInsulationSpansEntireSlab" type="xs:boolean"/>
-									<xs:element minOccurs="0" name="OnGradeExposedPerimeter"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="UnderSlabInsulationSpansEntireSlab" type="xs:boolean"/>
+									<xs:element minOccurs="0" name="OnGradeExposedPerimeter" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Perimeter of slab measured in feet that is on-grade (2 ft. below grade or less) and exposed to ambient conditions.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="DepthBelowGrade"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="DepthBelowGrade" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Depth from the top of the slab surface to grade</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FloorCovering"
-										type="FloorCovering"/>
-									<xs:element maxOccurs="1" minOccurs="0"
-										name="PerimeterInsulation" type="InsulationInfo"/>
-									<xs:element minOccurs="0" name="UnderSlabInsulation"
-										type="InsulationInfo"/>
+									<xs:element minOccurs="0" name="FloorCovering" type="FloorCovering"/>
+									<xs:element maxOccurs="1" minOccurs="0" name="PerimeterInsulation" type="InsulationInfo"/>
+									<xs:element minOccurs="0" name="UnderSlabInsulation" type="InsulationInfo"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 							</xs:complexType>
@@ -1075,15 +971,12 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="WindowInfo"/>
-									<xs:element minOccurs="0" name="WindowtoWallRatio"
-										type="Fraction"/>
-									<xs:element minOccurs="0" name="AttachedToWall"
-										type="LocalReference"/>
+									<xs:element minOccurs="0" name="WindowtoWallRatio" type="Fraction"/>
+									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo"
-												type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
@@ -1110,13 +1003,11 @@
 											<xs:documentation>Pitch of skylight ?/12</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AttachedToRoof"
-										type="LocalReference"/>
+									<xs:element minOccurs="0" name="AttachedToRoof" type="LocalReference"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo"
-												type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
@@ -1134,10 +1025,8 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="AttachedToWall"
-										type="LocalReference"/>
-									<xs:element minOccurs="0" name="Quantity"
-										type="IntegerGreaterThanZero"/>
+									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference"/>
+									<xs:element minOccurs="0" name="Quantity" type="IntegerGreaterThanZero"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Total door surface area for this group of doors</xs:documentation>
@@ -1148,25 +1037,18 @@
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation"
-										type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
 									<xs:element minOccurs="0" name="DoorType" type="DoorType"/>
-									<xs:element name="DoorMaterial" type="DoorMaterial"
-										minOccurs="0"/>
-									<xs:element minOccurs="0" name="WeatherStripping"
-										type="xs:boolean"/>
+									<xs:element name="DoorMaterial" type="DoorMaterial" minOccurs="0"/>
+									<xs:element minOccurs="0" name="WeatherStripping" type="xs:boolean"/>
 									<xs:element name="StormDoor" type="xs:boolean" minOccurs="0"/>
 									<xs:element name="RValue" type="RValue" minOccurs="0"/>
-									<xs:element minOccurs="0" name="LeakinessDescription"
-										type="BuildingLeakiness"/>
-									<xs:element maxOccurs="unbounded" minOccurs="0"
-										name="ThirdPartyCertification"
-										type="DoorThirdPartyCertifications"/>
+									<xs:element minOccurs="0" name="LeakinessDescription" type="BuildingLeakiness"/>
+									<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="DoorThirdPartyCertifications"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo"
-												type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
@@ -1194,26 +1076,19 @@
 										</xs:annotation>
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0"
-												name="PrimaryHeatingSystem" type="LocalReference"/>
-												<xs:element minOccurs="0"
-												name="PrimaryCoolingSystem" type="LocalReference"
-												/>
+												<xs:element minOccurs="0" name="PrimaryHeatingSystem" type="LocalReference"/>
+												<xs:element minOccurs="0" name="PrimaryCoolingSystem" type="LocalReference"/>
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" maxOccurs="unbounded"
-										name="HeatingSystem" type="HeatingSystemInfoType"/>
-									<xs:element minOccurs="0" maxOccurs="unbounded"
-										name="CoolingSystem" type="CoolingSystemInfoType"/>
-									<xs:element minOccurs="0" maxOccurs="unbounded" name="HeatPump"
-										type="HeatPumpInfoType"/>
+									<xs:element minOccurs="0" maxOccurs="unbounded" name="HeatingSystem" type="HeatingSystemInfoType"/>
+									<xs:element minOccurs="0" maxOccurs="unbounded" name="CoolingSystem" type="CoolingSystemInfoType"/>
+									<xs:element minOccurs="0" maxOccurs="unbounded" name="HeatPump" type="HeatPumpInfoType"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
-						<xs:element maxOccurs="unbounded" minOccurs="0" name="HVACControl"
-							type="HVACControlType"> </xs:element>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="HVACControl" type="HVACControlType"> </xs:element>
 						<xs:element maxOccurs="unbounded" minOccurs="0" name="HVACDistribution">
 							<xs:complexType>
 								<xs:sequence>
@@ -1222,40 +1097,32 @@
 									<xs:element minOccurs="0" name="DistributionSystemType">
 										<xs:complexType>
 											<xs:choice>
-												<xs:element name="AirDistribution"
-												type="AirDistributionInfo"/>
-												<xs:element name="HydronicDistribution"
-												type="HydronicDistributionInfo"/>
+												<xs:element name="AirDistribution" type="AirDistributionInfo"/>
+												<xs:element name="HydronicDistribution" type="HydronicDistributionInfo"/>
 												<xs:element name="Other" type="xs:string">
-												<xs:annotation>
-												<xs:documentation>describe</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>describe</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 											</xs:choice>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="ConditionedFloorAreaServed"
-										type="SurfaceArea">
+									<xs:element minOccurs="0" name="ConditionedFloorAreaServed" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Conditioned floor area that this distribution system serves.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0"
-										name="AnnualHeatingDistributionSystemEfficiency"
-										type="xs:double">
+									<xs:element minOccurs="0" name="AnnualHeatingDistributionSystemEfficiency" type="xs:double">
 										<xs:annotation>
 											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for heating, the DSE may be approximated by equation 3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use History.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0"
-										name="AnnualCoolingDistributionSystemEfficiency"
-										type="xs:double">
+									<xs:element minOccurs="0" name="AnnualCoolingDistributionSystemEfficiency" type="xs:double">
 										<xs:annotation>
 											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for cooling, the DSE may be approximated by equation 3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use History.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HVACDistributionImprovement"
-										type="HVACDistributionImprovementInfo"/>
+									<xs:element minOccurs="0" name="HVACDistributionImprovement" type="HVACDistributionImprovementInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 							</xs:complexType>
@@ -1263,10 +1130,8 @@
 						<xs:element minOccurs="0" name="Maintenance">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element minOccurs="0" name="Schedule"
-										type="HVACMaintenanceSchedule"/>
-									<xs:element minOccurs="0" name="ACReplacedinLastTenYears"
-										type="xs:boolean"/>
+									<xs:element minOccurs="0" name="Schedule" type="HVACMaintenanceSchedule"/>
+									<xs:element minOccurs="0" name="ACReplacedinLastTenYears" type="xs:boolean"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 							</xs:complexType>
@@ -1274,8 +1139,7 @@
 						<xs:element name="AnnualEnergyUse" minOccurs="0">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"
-										maxOccurs="unbounded"/>
+									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType" maxOccurs="unbounded"/>
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
@@ -1293,111 +1157,81 @@
 										<xs:complexType>
 											<xs:sequence>
 												<xs:group ref="SystemInfo"/>
-												<xs:element minOccurs="0" name="Manufacturer"
-												type="xs:string"/>
-												<xs:element minOccurs="0" name="SerialNumber"
-												type="xs:string"/>
-												<xs:element minOccurs="0" name="FanType"
-												type="VentilationFanType"/>
-												<xs:element minOccurs="0" name="RatedFlowRate"
-												type="xs:double">
-												<xs:annotation>
-												<xs:documentation>[CFM] as rated by manufacturer</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="Manufacturer" type="xs:string"/>
+												<xs:element minOccurs="0" name="SerialNumber" type="xs:string"/>
+												<xs:element minOccurs="0" name="FanType" type="VentilationFanType"/>
+												<xs:element minOccurs="0" name="RatedFlowRate" type="xs:double">
+													<xs:annotation>
+														<xs:documentation>[CFM] as rated by manufacturer</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="CalculatedFlowRate"
-												type="xs:double">
-												<xs:annotation>
-												<xs:documentation>[CFM] as calculated using duct size, prescriptive approach</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="CalculatedFlowRate" type="xs:double">
+													<xs:annotation>
+														<xs:documentation>[CFM] as calculated using duct size, prescriptive approach</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="TestedFlowRate"
-												type="xs:double">
-												<xs:annotation>
-												<xs:documentation>[CFM] as tested by assessor/auditor/inspector</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="TestedFlowRate" type="xs:double">
+													<xs:annotation>
+														<xs:documentation>[CFM] as tested by assessor/auditor/inspector</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="HoursInOperation"
-												type="HoursPerDay">
-												<xs:annotation>
-												<xs:documentation>24 = continuous, less than 24 = intermittent</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="HoursInOperation" type="HoursPerDay">
+													<xs:annotation>
+														<xs:documentation>24 = continuous, less than 24 = intermittent</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="DeliveredVentilation" type="xs:double">
-												<xs:annotation>
-												<xs:documentation>[CFM]</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="DeliveredVentilation" type="xs:double">
+													<xs:annotation>
+														<xs:documentation>[CFM]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="FanControlProperlyLabeled"
-												type="BooleanWithNA"/>
-												<xs:element minOccurs="0" name="ProperlyVented"
-												type="BooleanWithNA"/>
-												<xs:element minOccurs="0" name="FanLocation"
-												type="VentilationFanLocation"/>
-												<xs:element minOccurs="0"
-												name="UsedForLocalVentilation" type="xs:boolean"/>
-												<xs:element minOccurs="0"
-												name="UsedForWholeBuildingVentilation"
-												type="xs:boolean"/>
-												<xs:element minOccurs="0"
-												name="UsedForSeasonalCoolingLoadReduction"
-												type="xs:boolean"/>
-												<xs:element minOccurs="0"
-												name="UsedForGarageVentilation" type="xs:boolean"/>
-												<xs:element minOccurs="0" name="RatedNoise"
-												type="xs:double">
-												<xs:annotation>
-												<xs:documentation>[sones] from manufacturer's info</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="FanControlProperlyLabeled" type="BooleanWithNA"/>
+												<xs:element minOccurs="0" name="ProperlyVented" type="BooleanWithNA"/>
+												<xs:element minOccurs="0" name="FanLocation" type="VentilationFanLocation"/>
+												<xs:element minOccurs="0" name="UsedForLocalVentilation" type="xs:boolean"/>
+												<xs:element minOccurs="0" name="UsedForWholeBuildingVentilation" type="xs:boolean"/>
+												<xs:element minOccurs="0" name="UsedForSeasonalCoolingLoadReduction" type="xs:boolean"/>
+												<xs:element minOccurs="0" name="UsedForGarageVentilation" type="xs:boolean"/>
+												<xs:element minOccurs="0" name="RatedNoise" type="xs:double">
+													<xs:annotation>
+														<xs:documentation>[sones] from manufacturer's info</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="TestedNoise"
-												type="xs:double">
-												<xs:annotation>
-												<xs:documentation>[sones] as tested in field</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="TestedNoise" type="xs:double">
+													<xs:annotation>
+														<xs:documentation>[sones] as tested in field</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="TotalRecoveryEfficiency" type="Fraction">
-												<xs:annotation>
-												<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by electric consumption, case heat loss or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential total energy that could be recovered plus the exhaust fan energy. Values for some products can be found at the Home Ventilating Institute (hvi.org).</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="TotalRecoveryEfficiency" type="Fraction">
+													<xs:annotation>
+														<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by electric consumption, case heat loss or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential total energy that could be recovered plus the exhaust fan energy. Values for some products can be found at the Home Ventilating Institute (hvi.org).</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="SensibleRecoveryEfficiency" type="Fraction">
-												<xs:annotation>
-												<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by electric consumption, case heat loss or heat gain, air leakage, airflow mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test), as a percent of the potential sensible energy that could be recovered plus the exhaust fan energy. Values for some products can be found at the Home Ventilating Institute (hvi.org).</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="SensibleRecoveryEfficiency" type="Fraction">
+													<xs:annotation>
+														<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by electric consumption, case heat loss or heat gain, air leakage, airflow mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test), as a percent of the potential sensible energy that could be recovered plus the exhaust fan energy. Values for some products can be found at the Home Ventilating Institute (hvi.org).</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="AdjustedTotalRecoveryEfficiency"
-												type="Fraction">
-												<xs:annotation>
-												<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by case heat loss or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential total energy that could be recovered. This value is used to predict and compare Cooling Season Performance for the HRV/ERV unit. This value should be used for energy modeling when wattage for air movement is separately accounted for in the energy model. Values for some products can be found at the Home Ventilating Institute (hvi.org).</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="AdjustedTotalRecoveryEfficiency" type="Fraction">
+													<xs:annotation>
+														<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by case heat loss or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential total energy that could be recovered. This value is used to predict and compare Cooling Season Performance for the HRV/ERV unit. This value should be used for energy modeling when wattage for air movement is separately accounted for in the energy model. Values for some products can be found at the Home Ventilating Institute (hvi.org).</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="AdjustedSensibleRecoveryEfficiency"
-												type="Fraction">
-												<xs:annotation>
-												<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by case heat loss or heat gain, air leakage, airflow mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test), as a percent of the potential sensible energy that could be recovered. This value should be used for energy modeling when wattage for air movement is separately accounted for in the energy model. Values for some products can be found at the Home Ventilating Institute (hvi.org).</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="AdjustedSensibleRecoveryEfficiency" type="Fraction">
+													<xs:annotation>
+														<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by case heat loss or heat gain, air leakage, airflow mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test), as a percent of the potential sensible energy that could be recovered. This value should be used for energy modeling when wattage for air movement is separately accounted for in the energy model. Values for some products can be found at the Home Ventilating Institute (hvi.org).</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="FanPower"
-												type="xs:double">
-												<xs:annotation>
-												<xs:documentation>[W]</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="FanPower" type="xs:double">
+													<xs:annotation>
+														<xs:documentation>[W]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element maxOccurs="unbounded" minOccurs="0"
-												name="ThirdPartyCertification"
-												type="VentilationFanThirdPartyCertification"/>
-												<xs:element name="AttachedToHVACDistributionSystem"
-												type="LocalReference" minOccurs="0" maxOccurs="1">
-												<xs:annotation>
-												<xs:documentation>For central fan integrated supply mechanical ventilation, specifies the HVAC distribution system it is attached to.</xs:documentation>
-												</xs:annotation>
+												<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="VentilationFanThirdPartyCertification"/>
+												<xs:element name="AttachedToHVACDistributionSystem" type="LocalReference" minOccurs="0" maxOccurs="1">
+													<xs:annotation>
+														<xs:documentation>For central fan integrated supply mechanical ventilation, specifies the HVAC distribution system it is attached to.</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -1417,8 +1251,7 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="VentSystemType"
-										type="VentSystem"/>
+									<xs:element minOccurs="0" name="VentSystemType" type="VentSystem"/>
 									<xs:element minOccurs="0" ref="AttachedToZone"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
@@ -1435,43 +1268,35 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToZone"/>
-									<xs:element minOccurs="0" name="AttachedToCAZ"
-										type="LocalReference"/>
+									<xs:element minOccurs="0" name="AttachedToCAZ" type="LocalReference"/>
 									<xs:element name="FuelType" type="FuelType" minOccurs="0"/>
-									<xs:element name="WaterHeaterType" type="WaterHeaterType"
-										minOccurs="0"/>
+									<xs:element name="WaterHeaterType" type="WaterHeaterType" minOccurs="0"/>
 									<xs:element name="Location" type="UnitLocation" minOccurs="0"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
 									<xs:element name="ModelYear" type="Year" minOccurs="0"/>
-									<xs:element name="Manufacturer" type="Manufacturer"
-										minOccurs="0"/>
+									<xs:element name="Manufacturer" type="Manufacturer" minOccurs="0"/>
 									<xs:element name="ModelNumber" type="Model" minOccurs="0"/>
 									<xs:element minOccurs="0" name="AHRINumber" type="xs:string"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="xs:string"/>
-									<xs:element minOccurs="0" name="PerformanceAdjustment"
-										type="Fraction"/>
-									<xs:element minOccurs="0" name="ThirdPartyCertification"
-										type="DHWThirdPartyCertification" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction"/>
+									<xs:element minOccurs="0" name="ThirdPartyCertification" type="DHWThirdPartyCertification" maxOccurs="unbounded"/>
 									<xs:element name="TankVolume" type="Volume" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[gal]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FractionDHWLoadServed"
-										type="Fraction"/>
+									<xs:element minOccurs="0" name="FractionDHWLoadServed" type="Fraction"/>
 									<xs:element name="HeatingCapacity" type="Capacity" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[Btuh]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="EnergyFactor" type="EnergyFactor"
-										minOccurs="0">
+									<xs:element name="EnergyFactor" type="EnergyFactor" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>The amount of energy delivered as heated water in a day divided by the total daily energy consumption of a residential water heater, as determined following standardized DOE testing procedure.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="UniformEnergyFactor" type="EnergyFactor"
-										minOccurs="0">
+									<xs:element name="UniformEnergyFactor" type="EnergyFactor" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>DOE’s new metric for communicating the energy efficiency of a residential water heater, which replaces the Energy Factor (EF) metric. More efficient water heaters have a higher Uniform Energy Factor (UEF). UEF is determined by the Department of Energy’s test method outlined in 10 CFR Part 430, Subpart B, Appendix E.</xs:documentation>
 										</xs:annotation>
@@ -1486,86 +1311,68 @@
 											<xs:documentation>[gal per minute] The amount of gallons per minute of hot water that can be supplied by an instantaneous water heater while maintaining a nominal temperature rise of 77°F during steady state operation.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="RecoveryEfficiency" type="RecoveryEfficiency"
-										minOccurs="0">
+									<xs:element name="RecoveryEfficiency" type="RecoveryEfficiency" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>The ratio of energy delivered to heat cold water compared to the energy consumed by the water heater, as determined following standardized DOE testing procedure.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ThermalEfficiency" type="ThermalEfficiency"
-										minOccurs="0"/>
+									<xs:element name="ThermalEfficiency" type="ThermalEfficiency" minOccurs="0"/>
 									<xs:element minOccurs="0" name="WaterHeaterInsulation">
 										<xs:complexType>
 											<xs:sequence>
 												<xs:element minOccurs="0" name="Jacket">
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element minOccurs="0"
-												name="InsulationMaterial"
-												type="InsulationMaterial"/>
-												<xs:element name="JacketRValue" type="RValue"
-												minOccurs="0"/>
-												<xs:element minOccurs="0" name="Thickness"
-												type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>[in]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												</xs:complexType>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element minOccurs="0" name="InsulationMaterial" type="InsulationMaterial"/>
+															<xs:element name="JacketRValue" type="RValue" minOccurs="0"/>
+															<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+																<xs:annotation>
+																	<xs:documentation>[in]</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+													</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="TankWall">
-												<xs:annotation>
-												<xs:documentation>Refers to the insulation in the tank wall itself. This information is sometimes vailable on the water heater's name plate or the units specification sheet, or can be estimated by removing the water heater's access plate.</xs:documentation>
-												</xs:annotation>
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element minOccurs="0"
-												name="InsulationMaterial"
-												type="InsulationMaterial"/>
-												<xs:element name="TankWallRValue" type="RValue"
-												minOccurs="0"/>
-												<xs:element minOccurs="0" name="Thickness"
-												type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>[in]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												</xs:complexType>
+													<xs:annotation>
+														<xs:documentation>Refers to the insulation in the tank wall itself. This information is sometimes vailable on the water heater's name plate or the units specification sheet, or can be estimated by removing the water heater's access plate.</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element minOccurs="0" name="InsulationMaterial" type="InsulationMaterial"/>
+															<xs:element name="TankWallRValue" type="RValue" minOccurs="0"/>
+															<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+																<xs:annotation>
+																	<xs:documentation>[in]</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+													</xs:complexType>
 												</xs:element>
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
-									<xs:element name="MeetsACCA5QIHVACSpecification"
-										type="xs:boolean" minOccurs="0"/>
-									<xs:element name="HotWaterTemperature" type="Temperature"
-										minOccurs="0">
+									<xs:element name="MeetsACCA5QIHVACSpecification" type="xs:boolean" minOccurs="0"/>
+									<xs:element name="HotWaterTemperature" type="Temperature" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg F]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="UsesDesuperheater"
-										type="xs:boolean">
+									<xs:element minOccurs="0" name="HasMixingValve" type="xs:boolean"/>
+									<xs:element minOccurs="0" name="UsesDesuperheater" type="xs:boolean">
 										<xs:annotation>
 											<xs:documentation>Indicates whether this water heater uses a desuperheater. The attached heat pump or air conditioner can be referenced in the RelatedHVACSystem element.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HasSharedCombustionVentilation"
-										type="xs:boolean"/>
-									<xs:element minOccurs="0" name="CombustionVentilationOrphaned"
-										type="xs:boolean"/>
-									<xs:element name="CombustionVentingSystem" minOccurs="0"
-										type="LocalReference"> </xs:element>
-									<xs:element minOccurs="0" name="AutomaticVentDamper"
-										type="xs:boolean"/>
+									<xs:element minOccurs="0" name="HasSharedCombustionVentilation" type="xs:boolean"/>
+									<xs:element minOccurs="0" name="CombustionVentilationOrphaned" type="xs:boolean"/>
+									<xs:element name="CombustionVentingSystem" minOccurs="0" type="LocalReference"> </xs:element>
+									<xs:element minOccurs="0" name="AutomaticVentDamper" type="xs:boolean"/>
 									<xs:element minOccurs="0" name="PilotLight" type="xs:boolean"/>
-									<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
-										type="xs:boolean"/>
-									<xs:element name="RelatedHVACSystem" type="LocalReference"
-										minOccurs="0">
+									<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="xs:boolean"/>
+									<xs:element name="RelatedHVACSystem" type="LocalReference" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>Reference a HeatingSystem, HeatPump, or CoolingSystem.</xs:documentation>
 										</xs:annotation>
@@ -1573,15 +1380,26 @@
 									<xs:element minOccurs="0" name="Installation">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="Standard"
-												type="HVACInstallationStandard"/>
+												<xs:element minOccurs="0" name="Standard" type="HVACInstallationStandard"/>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="WaterHeaterImprovement"
-										type="WaterHeaterImprovementInfo"/>
+									<xs:element minOccurs="0" name="WaterHeaterImprovement" type="WaterHeaterImprovementInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="WaterHeatingControl">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="SystemInfo"/>
+									<xs:element minOccurs="0" name="Model" type="xs:string"/>
+									<xs:element minOccurs="0" name="Manufacturer" type="xs:string"/>
+									<xs:element minOccurs="0" name="SerialNumber" type="xs:string"/>
+									<xs:element minOccurs="0" name="ControlTechnology" type="DHWControllerTechnology"/>
+									<xs:element minOccurs="0" name="TemperatureControl" type="DHWTemperatureControl"/>
+									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
@@ -1589,8 +1407,7 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="AttachedToWaterHeatingSystem"
-										type="LocalReference">
+									<xs:element minOccurs="0" name="AttachedToWaterHeatingSystem" type="LocalReference">
 										<xs:annotation>
 											<xs:documentation>The water heating system that this distribution system serves.</xs:documentation>
 										</xs:annotation>
@@ -1599,64 +1416,53 @@
 										<xs:complexType>
 											<xs:choice>
 												<xs:element name="Standard">
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element minOccurs="0" name="PipingLength"
-												type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>Measured length of hot water piping from the hot water heater to the farthest hot water fixture, measured longitudinally from plans, assuming the hot water piping does not run diagonally, plus 10 feet of piping for each floor level, plus 5 feet of piping for unconditioned basements. [ft]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												</xs:complexType>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element minOccurs="0" name="PipingLength" type="LengthMeasurement">
+																<xs:annotation>
+																	<xs:documentation>Measured length of hot water piping from the hot water heater to the farthest hot water fixture, measured longitudinally from plans, assuming the hot water piping does not run diagonally, plus 10 feet of piping for each floor level, plus 5 feet of piping for unconditioned basements. [ft]</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+													</xs:complexType>
 												</xs:element>
 												<xs:element name="Recirculation">
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element minOccurs="0" name="ControlType"
-												type="RecirculationControlType"/>
-												<xs:element minOccurs="0"
-												name="RecirculationPipingLoopLength"
-												type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>Hot water recirculation loop piping length including both supply and return sides of the loop, measured longitudinally from plans, assuming the hot water piping does not run diagonally. [ft]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0"
-												name="BranchPipingLoopLength"
-												type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>Length of the branch hot water piping from the recirculation loop to the farthest hot water fixture from the recirculation loop, measured longitudinally from plans, assuming the branch hot water piping does not run diagonally, plus 20 feet of piping for each floor level greater than one plus 10 feet of piping for unconditioned basements. [ft]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" name="PumpPower"
-												type="Power">
-												<xs:annotation>
-												<xs:documentation>[W]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												</xs:complexType>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element minOccurs="0" name="ControlType" type="RecirculationControlType"/>
+															<xs:element minOccurs="0" name="RecirculationPipingLoopLength" type="LengthMeasurement">
+																<xs:annotation>
+																	<xs:documentation>Hot water recirculation loop piping length including both supply and return sides of the loop, measured longitudinally from plans, assuming the hot water piping does not run diagonally. [ft]</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" name="BranchPipingLoopLength" type="LengthMeasurement">
+																<xs:annotation>
+																	<xs:documentation>Length of the branch hot water piping from the recirculation loop to the farthest hot water fixture from the recirculation loop, measured longitudinally from plans, assuming the branch hot water piping does not run diagonally, plus 20 feet of piping for each floor level greater than one plus 10 feet of piping for unconditioned basements. [ft]</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" name="PumpPower" type="Power">
+																<xs:annotation>
+																	<xs:documentation>[W]</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+													</xs:complexType>
 												</xs:element>
 											</xs:choice>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="PipeInsulation"
-										type="PipeInsulationType"/>
+									<xs:element minOccurs="0" name="PipeInsulation" type="PipeInsulationType"/>
 									<xs:element minOccurs="0" name="DrainWaterHeatRecovery">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="FacilitiesConnected"
-												type="DrainWaterHeatRecoveryFacilitiesConnected"/>
-												<xs:element minOccurs="0" name="EqualFlow"
-												type="xs:boolean"/>
-												<xs:element minOccurs="0" name="Efficiency"
-												type="Fraction">
-												<xs:annotation>
-												<xs:documentation>Efficiency percent expressed as a fraction from 0-1.</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="FacilitiesConnected" type="DrainWaterHeatRecoveryFacilitiesConnected"/>
+												<xs:element minOccurs="0" name="EqualFlow" type="xs:boolean"/>
+												<xs:element minOccurs="0" name="Efficiency" type="Fraction">
+													<xs:annotation>
+														<xs:documentation>Efficiency percent expressed as a fraction from 0-1.</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -1671,15 +1477,11 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:choice minOccurs="0">
-										<xs:element name="AttachedToWaterHeatingSystem"
-											type="LocalReference"/>
-										<xs:element name="AttachedToHotWaterDistribution"
-											type="LocalReference"/>
+										<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference"/>
+										<xs:element name="AttachedToHotWaterDistribution" type="LocalReference"/>
 									</xs:choice>
-									<xs:element minOccurs="1" name="WaterFixtureType"
-										type="WaterFixtureType"/>
-									<xs:element minOccurs="0" name="Quantity"
-										type="IntegerGreaterThanZero">
+									<xs:element minOccurs="1" name="WaterFixtureType" type="WaterFixtureType"/>
+									<xs:element minOccurs="0" name="Quantity" type="IntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Number of similar water fixtures.</xs:documentation>
 										</xs:annotation>
@@ -1699,22 +1501,17 @@
 											<xs:documentation>Does this faucet have an aerator?</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="MinutesPerDay"
-										type="MinutesPerDay">
+									<xs:element minOccurs="0" name="MinutesPerDay" type="MinutesPerDay">
 										<xs:annotation>
 											<xs:documentation>[minutes] Number of minutes per day a water fixture operates.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0"
-										name="TemperatureInitiatedShowerFlowRestrictionValve"
-										type="xs:boolean">
+									<xs:element minOccurs="0" name="TemperatureInitiatedShowerFlowRestrictionValve" type="xs:boolean">
 										<xs:annotation>
 											<xs:documentation>Does the shower have a device that restricts the flow of water automatically once it has reached temperature?</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element maxOccurs="unbounded" minOccurs="0"
-										name="ThirdPartyCertification"
-										type="WaterFixtureThirdPartyCertification">
+									<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="WaterFixtureThirdPartyCertification">
 										<xs:annotation>
 											<xs:documentation>Independent organization has verified that product or appliance meets or exceeds the standard in question.</xs:documentation>
 										</xs:annotation>
@@ -1743,22 +1540,16 @@
 									<xs:element minOccurs="0" name="Manufacturer" type="xs:string"/>
 									<xs:element minOccurs="0" name="ModelNumber" type="xs:string"/>
 									<xs:element minOccurs="0" ref="AttachedToZone"/>
-									<xs:element name="SystemType" minOccurs="0"
-										type="SolarThermalSystemType"/>
-									<xs:element name="CollectorArea" type="SurfaceArea"
-										minOccurs="0">
+									<xs:element name="SystemType" minOccurs="0" type="SolarThermalSystemType"/>
+									<xs:element name="CollectorArea" type="SurfaceArea" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorLoopType"
-										type="SolarThermalCollectorLoopType"/>
-									<xs:element minOccurs="0" name="CollectorType"
-										type="SolarThermalCollectorType"/>
-									<xs:element minOccurs="0" name="CollectorOrientation"
-										type="OrientationType"/>
-									<xs:element minOccurs="0" name="CollectorAzimuth"
-										type="AzimuthType"/>
+									<xs:element minOccurs="0" name="CollectorLoopType" type="SolarThermalCollectorLoopType"/>
+									<xs:element minOccurs="0" name="CollectorType" type="SolarThermalCollectorType"/>
+									<xs:element minOccurs="0" name="CollectorOrientation" type="OrientationType"/>
+									<xs:element minOccurs="0" name="CollectorAzimuth" type="AzimuthType"/>
 									<xs:element minOccurs="0" name="CollectorTilt" type="Tilt">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
@@ -1790,8 +1581,7 @@
 											<xs:documentation>[gal]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="ConnectedTo"
-										type="LocalReference"/>
+									<xs:element minOccurs="0" name="ConnectedTo" type="LocalReference"/>
 									<xs:element minOccurs="0" name="SolarFraction">
 										<xs:annotation>
 											<xs:documentation>The Solar Fraction is the portion of the total conventional hot water heating load (delivered energy and tank standby losses). The higher the solar fraction, the greater the solar contribution to water heating, which reduces the energy required by the backup water heater. This value can be found in the OG-300 SRCC Certified Solar Water Heating System Directory.</xs:documentation>
@@ -1827,10 +1617,8 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="Location"
-										type="PVSystemLocation"/>
-									<xs:element minOccurs="0" name="Ownership"
-										type="PVSystemOwnership"/>
+									<xs:element minOccurs="0" name="Location" type="PVSystemLocation"/>
+									<xs:element minOccurs="0" name="Ownership" type="PVSystemOwnership"/>
 									<xs:element minOccurs="0" name="ModuleType">
 										<xs:simpleType>
 											<xs:restriction base="xs:string">
@@ -1850,8 +1638,7 @@
 											</xs:restriction>
 										</xs:simpleType>
 									</xs:element>
-									<xs:element minOccurs="0" name="ArrayOrientation"
-										type="OrientationType"/>
+									<xs:element minOccurs="0" name="ArrayOrientation" type="OrientationType"/>
 									<xs:element minOccurs="0" name="ArrayAzimuth" type="AzimuthType">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
@@ -1867,35 +1654,27 @@
 											<xs:documentation>[DC Watts] Peak power as supplied by the manufacturer</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorArea"
-										type="SurfaceArea">
+									<xs:element minOccurs="0" name="CollectorArea" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberOfPanels"
-										type="IntegerGreaterThanZero"/>
-									<xs:element minOccurs="0" name="InverterEfficiency"
-										type="Efficiency"/>
-									<xs:element minOccurs="0" name="SystemLossesFraction"
-										type="Fraction">
+									<xs:element minOccurs="0" name="NumberOfPanels" type="IntegerGreaterThanZero"/>
+									<xs:element minOccurs="0" name="InverterEfficiency" type="Efficiency"/>
+									<xs:element minOccurs="0" name="SystemLossesFraction" type="Fraction">
 										<xs:annotation>
 											<xs:documentation>System losses can be due to soiling, shading, snow, mismatch, wiring, electrical connections, light-induced degradation, nameplate rating inaccuracies, age, and availability.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="YearInverterManufactured"
-										type="Year"/>
-									<xs:element minOccurs="0" name="YearModulesManufactured"
-										type="Year"/>
+									<xs:element minOccurs="0" name="YearInverterManufactured" type="Year"/>
+									<xs:element minOccurs="0" name="YearModulesManufactured" type="Year"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
-									<xs:element minOccurs="0" name="AnnualOutput"
-										type="RatedAnnualkWh">
+									<xs:element minOccurs="0" name="AnnualOutput" type="RatedAnnualkWh">
 										<xs:annotation>
 											<xs:documentation>[kWh] Projected Annual Output for a typical meteorological year as determined by PVWatts or similar. </xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="LevelizedCostOfElectricity"
-										type="Cost">
+									<xs:element minOccurs="0" name="LevelizedCostOfElectricity" type="Cost">
 										<xs:annotation>
 											<xs:documentation>[$] The LCOE is the total cost of installing and operating a project expressed in dollars per kilowatt-hour of electricity generated by the system over its life. Can be calculated with System Advisor Model, a similar software, or through a simplified calculation at http://www.nrel.gov/analysis/tech_lcoe.html.</xs:documentation>
 										</xs:annotation>
@@ -1916,16 +1695,13 @@
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" name="Model" type="xs:string"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
-									<xs:element minOccurs="0" name="ThirdPartyCertification"
-										maxOccurs="unbounded" type="WindThirdPartyCertification"/>
-									<xs:element minOccurs="0" name="AWEARatedAnnualEnergy"
-										type="RatedAnnualkWh">
+									<xs:element minOccurs="0" name="ThirdPartyCertification" maxOccurs="unbounded" type="WindThirdPartyCertification"/>
+									<xs:element minOccurs="0" name="AWEARatedAnnualEnergy" type="RatedAnnualkWh">
 										<xs:annotation>
 											<xs:documentation>[kWh] the calculated total energy that would be produced during a one-year period with an average wind speed of 5 m/s (11.2 mph)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AWEARatedSoundLevel"
-										type="xs:double">
+									<xs:element minOccurs="0" name="AWEARatedSoundLevel" type="xs:double">
 										<xs:annotation>
 											<xs:documentation>[dBA] the sound pressure level not exceeded by the wind turbine 95% of the time at a distance of 60 meters from the rotor with an average wind speed of 5 m/s (11.2 mph).
 </xs:documentation>
@@ -1941,20 +1717,17 @@
 											<xs:documentation>[kW] the highest point on the certified power curve.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RotorDiameter"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="RotorDiameter" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HubHeight"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="HubHeight" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="LevelizedCostOfElectricity"
-										type="Cost">
+									<xs:element minOccurs="0" name="LevelizedCostOfElectricity" type="Cost">
 										<xs:annotation>
 											<xs:documentation>[$] The LCOE is the total cost of installing and operating a project expressed in dollars per kilowatt-hour of electricity generated by the system over its life. Can be calculated with System Advisor Model, a similar software, or through a simplified calculation at http://www.nrel.gov/analysis/tech_lcoe.html.</xs:documentation>
 										</xs:annotation>
@@ -1971,19 +1744,13 @@
 	</xs:complexType>
 	<xs:complexType name="Appliances">
 		<xs:sequence>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="ClothesWasher"
-				type="ClothesWasherInfoType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="ClothesDryer"
-				type="ClothesDryerInfoType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="Dishwasher"
-				type="DishwasherInfoType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="Refrigerator"
-				type="RefrigeratorInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="ClothesWasher" type="ClothesWasherInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="ClothesDryer" type="ClothesDryerInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="Dishwasher" type="DishwasherInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="Refrigerator" type="RefrigeratorInfoType"/>
 			<xs:element minOccurs="0" maxOccurs="unbounded" name="Freezer" type="FreezerInfoType"/>
-			<xs:element name="Dehumidifier" maxOccurs="unbounded" minOccurs="0"
-				type="DehumidifierInfoType"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="CookingRange"
-				type="CookingRangeInfoType"/>
+			<xs:element name="Dehumidifier" maxOccurs="unbounded" minOccurs="0" type="DehumidifierInfoType"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="CookingRange" type="CookingRangeInfoType"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="Oven" type="OvenInfoType"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
@@ -2021,15 +1788,13 @@
 								<xs:documentation>[W] per unit</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element maxOccurs="unbounded" minOccurs="0"
-							name="ThirdPartyCertification" type="LightingThirdPartyCertification"/>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="LightingThirdPartyCertification"/>
 						<xs:element name="AverageHoursPerDay" type="HoursPerDay" minOccurs="0">
 							<xs:annotation>
 								<xs:documentation>[h]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="LightingDailyHours"
-							type="LightingDailyHours">
+						<xs:element minOccurs="0" name="LightingDailyHours" type="LightingDailyHours">
 							<xs:annotation>
 								<xs:documentation>[h]</xs:documentation>
 							</xs:annotation>
@@ -2047,9 +1812,7 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
-						<xs:element maxOccurs="unbounded" minOccurs="0"
-							name="ThirdPartyCertification"
-							type="LightingFixtureThirdPartyCertification"/>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="LightingFixtureThirdPartyCertification"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -2058,12 +1821,9 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
-						<xs:element minOccurs="0" name="AttachedToLightingGroup"
-							type="LocalReference"/>
-						<xs:element name="LightingControlType" type="LightingControls" minOccurs="0"
-							> </xs:element>
-						<xs:element name="NumberofLightingControls"
-							type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+						<xs:element minOccurs="0" name="AttachedToLightingGroup" type="LocalReference"/>
+						<xs:element name="LightingControlType" type="LightingControls" minOccurs="0"> </xs:element>
+						<xs:element name="NumberofLightingControls" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
 						<xs:element name="Location" type="LightingLocation" minOccurs="0"> </xs:element>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
@@ -2101,8 +1861,7 @@
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
-						<xs:element minOccurs="0" name="ThirdPartyCertification"
-							type="ApplianceThirdPartyCertifications" maxOccurs="unbounded"/>
+						<xs:element minOccurs="0" name="ThirdPartyCertification" type="ApplianceThirdPartyCertifications" maxOccurs="unbounded"/>
 						<xs:element minOccurs="0" name="Quantity" type="IntegerGreaterThanZero">
 							<xs:annotation>
 								<xs:documentation>Number of similar ceiling fans.</xs:documentation>
@@ -2159,12 +1918,12 @@
 										<xs:complexType>
 											<xs:sequence>
 												<xs:element minOccurs="0" name="Pressure">
-												<xs:simpleType>
-												<xs:restriction base="xs:string">
-												<xs:enumeration value="high"/>
-												<xs:enumeration value="low"/>
-												</xs:restriction>
-												</xs:simpleType>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:enumeration value="high"/>
+															<xs:enumeration value="low"/>
+														</xs:restriction>
+													</xs:simpleType>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -2204,8 +1963,7 @@
 								<xs:documentation>[gal] Volume of pool.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="MonthsPerYearofOperation"
-							type="MonthsPerYear">
+						<xs:element minOccurs="0" name="MonthsPerYearofOperation" type="MonthsPerYear">
 							<xs:annotation>
 								<xs:documentation>Months per year pool is in operation.</xs:documentation>
 							</xs:annotation>
@@ -2215,8 +1973,7 @@
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="SuctionPipeDiameter"
-							type="LengthMeasurement">
+						<xs:element minOccurs="0" name="SuctionPipeDiameter" type="LengthMeasurement">
 							<xs:annotation>
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
@@ -2236,95 +1993,78 @@
 										<xs:complexType>
 											<xs:sequence>
 												<xs:group ref="SystemInfo"/>
-												<xs:element minOccurs="0" name="Type"
-												type="PoolPumpType"/>
-												<xs:element minOccurs="0" name="Manufacturer"
-												type="xs:string">
-												<xs:annotation>
-												<xs:documentation>Manufacturer of pool pump.</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="Type" type="PoolPumpType"/>
+												<xs:element minOccurs="0" name="Manufacturer" type="xs:string">
+													<xs:annotation>
+														<xs:documentation>Manufacturer of pool pump.</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="SerialNumber"
-												type="xs:string">
-												<xs:annotation>
-												<xs:documentation>Serial number of pool pump.</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="SerialNumber" type="xs:string">
+													<xs:annotation>
+														<xs:documentation>Serial number of pool pump.</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="ModelNumber"
-												type="xs:string">
-												<xs:annotation>
-												<xs:documentation>Model number of pool pump.</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="ModelNumber" type="xs:string">
+													<xs:annotation>
+														<xs:documentation>Model number of pool pump.</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="ThirdPartyCertification"
-												type="PoolPump3rdPartyCertification"
-												maxOccurs="unbounded">
-												<xs:annotation>
-												<xs:documentation>Independent organization has verified that product or appliance meets or exceeds the standard in question (ENERGY STAR, CEE, or other)</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="ThirdPartyCertification" type="PoolPump3rdPartyCertification" maxOccurs="unbounded">
+													<xs:annotation>
+														<xs:documentation>Independent organization has verified that product or appliance meets or exceeds the standard in question (ENERGY STAR, CEE, or other)</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="EnergyFactor"
-												type="Efficiency">
-												<xs:annotation>
-												<xs:documentation>[gal/Wh] The measure of overall pool filter pump efficiency in units of gallons per watt-hour, as determined using the applicable test method in Section 4.1.2. Energy factor is analogous to other energy factors such as miles per gallon. Energy factor (EF) is calculated as: EF (gal/Wh) = flow rate (gpm) * 60 ÷ power (watts) (ANSI/APSP/ICC-15 2011).</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="EnergyFactor" type="Efficiency">
+													<xs:annotation>
+														<xs:documentation>[gal/Wh] The measure of overall pool filter pump efficiency in units of gallons per watt-hour, as determined using the applicable test method in Section 4.1.2. Energy factor is analogous to other energy factors such as miles per gallon. Energy factor (EF) is calculated as: EF (gal/Wh) = flow rate (gpm) * 60 ÷ power (watts) (ANSI/APSP/ICC-15 2011).</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="SpeedSetting"
-												type="PoolPumpSpeedSetting">
-												<xs:annotation>
-												<xs:documentation>The speed setting at which the Energy Factor was measured (ENERGY STAR, 2013).</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="SpeedSetting" type="PoolPumpSpeedSetting">
+													<xs:annotation>
+														<xs:documentation>The speed setting at which the Energy Factor was measured (ENERGY STAR, 2013).</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="RatedHorsepower"
-												type="Power">
-												<xs:annotation>
-												<xs:documentation>The motor power output designed by the manufacturer for a rated RPM, voltage and frequency. May be less than total horsepower where the service factor is greater than 1.0, or equal to total horsepower where the service factor = 1.0 (ANSI/APSP/ICC-15 2011).</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="RatedHorsepower" type="Power">
+													<xs:annotation>
+														<xs:documentation>The motor power output designed by the manufacturer for a rated RPM, voltage and frequency. May be less than total horsepower where the service factor is greater than 1.0, or equal to total horsepower where the service factor = 1.0 (ANSI/APSP/ICC-15 2011).</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="TotalHorsepower"
-												type="Power">
-												<xs:annotation>
-												<xs:documentation>The total horsepower, or product of the rated horsepower and the service factor of a motor used on a pool pump (also known as SFHP) based on the maximum continuous duty motor power output rating allowable for the nameplate ambient rating and motor insulation class (e.g., total horsepower = rated horsepower * service factor) (ANSI/APSP/ICC-15 2011).</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="TotalHorsepower" type="Power">
+													<xs:annotation>
+														<xs:documentation>The total horsepower, or product of the rated horsepower and the service factor of a motor used on a pool pump (also known as SFHP) based on the maximum continuous duty motor power output rating allowable for the nameplate ambient rating and motor insulation class (e.g., total horsepower = rated horsepower * service factor) (ANSI/APSP/ICC-15 2011).</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="ServiceFactor"
-												type="xs:double">
-												<xs:annotation>
-												<xs:documentation>A multiplier applied to the rated horsepower of a pump motor to indicate the percent above nameplate horsepower at which the motor can operate continuously without exceeding its allowable insulation class temperature limit, provided that other design parameters, such rated voltage, frequency and ambient temperature, are within limits. A 1.5 hp pump with a 1.65 service factor produces 2.475 hp (total horsepower) at the maximum service factor point (ANSI/APSP/ICC-15 2011).</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="ServiceFactor" type="xs:double">
+													<xs:annotation>
+														<xs:documentation>A multiplier applied to the rated horsepower of a pump motor to indicate the percent above nameplate horsepower at which the motor can operate continuously without exceeding its allowable insulation class temperature limit, provided that other design parameters, such rated voltage, frequency and ambient temperature, are within limits. A 1.5 hp pump with a 1.65 service factor produces 2.475 hp (total horsepower) at the maximum service factor point (ANSI/APSP/ICC-15 2011).</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element maxOccurs="unbounded" minOccurs="0"
-												name="PumpSpeed">
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element minOccurs="0" name="Power"
-												type="Power">
-												<xs:annotation>
-												<xs:documentation>[W]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" name="MotorNominalSpeed"
-												type="Speed">
-												<xs:annotation>
-												<xs:documentation>[Rev/min] The number of revolutions of the motor shaft in a given unit of time, expressed as revolutions per minute (RPM) (ENERGY STAR, 2013).</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" name="FlowRate"
-												type="FlowRate">
-												<xs:annotation>
-												<xs:documentation>[gal/min] The volume of water flowing through the filtration system in a given time, usually measured in gallons per minute (gpm) (ANSI/APSP/ICC-15 2011).</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" name="HoursPerDay"
-												type="HoursPerDay">
-												<xs:annotation>
-												<xs:documentation>[hours] Number of hours per day a pool pump operates at a particular speed setting.</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												</xs:complexType>
+												<xs:element maxOccurs="unbounded" minOccurs="0" name="PumpSpeed">
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element minOccurs="0" name="Power" type="Power">
+																<xs:annotation>
+																	<xs:documentation>[W]</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" name="MotorNominalSpeed" type="Speed">
+																<xs:annotation>
+																	<xs:documentation>[Rev/min] The number of revolutions of the motor shaft in a given unit of time, expressed as revolutions per minute (RPM) (ENERGY STAR, 2013).</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" name="FlowRate" type="FlowRate">
+																<xs:annotation>
+																	<xs:documentation>[gal/min] The volume of water flowing through the filtration system in a given time, usually measured in gallons per minute (gpm) (ANSI/APSP/ICC-15 2011).</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" name="HoursPerDay" type="HoursPerDay">
+																<xs:annotation>
+																	<xs:documentation>[hours] Number of hours per day a pool pump operates at a particular speed setting.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+													</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -2380,10 +2120,8 @@
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element minOccurs="0" ref="AttachedToSpace"/>
-						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero"
-							minOccurs="0"/>
-						<xs:element name="PlugLoadControlType" minOccurs="0"
-							type="PlugLoadControlType"/>
+						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+						<xs:element name="PlugLoadControlType" minOccurs="0" type="PlugLoadControlType"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -2395,8 +2133,7 @@
 						<xs:element minOccurs="0" ref="AttachedToSpace"/>
 						<xs:element name="PlugLoadType" type="PlugLoadType" minOccurs="0"/>
 						<xs:element minOccurs="0" name="Location" type="PlugLoadLocation"/>
-						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero"
-							minOccurs="0"/>
+						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
 						<xs:element minOccurs="0" name="Load">
 							<xs:complexType>
 								<xs:sequence>
@@ -2425,14 +2162,10 @@
 			<xs:element name="Ventilation" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="WholeBuildingVentilationDesign"
-							type="WholeBldgVentDesignInfo"/>
-						<xs:element minOccurs="0" name="SpotVentilationDesign"
-							type="SpotVentDesignInfo"/>
-						<xs:element minOccurs="0" name="OtherVentilationIssues"
-							type="OtherVentIssues"/>
-						<xs:element minOccurs="0" name="VentilationImprovement"
-							type="VentilationImprovementInfo"/>
+						<xs:element minOccurs="0" name="WholeBuildingVentilationDesign" type="WholeBldgVentDesignInfo"/>
+						<xs:element minOccurs="0" name="SpotVentilationDesign" type="SpotVentDesignInfo"/>
+						<xs:element minOccurs="0" name="OtherVentilationIssues" type="OtherVentIssues"/>
+						<xs:element minOccurs="0" name="VentilationImprovement" type="VentilationImprovementInfo"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -2440,10 +2173,8 @@
 			<xs:element name="MoistureControl" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="MoistureControlInfo"
-							type="MoistureControlInfoType"> </xs:element>
-						<xs:element minOccurs="0" name="MoistureControlImprovement"
-							type="MoistureControlImprovementInfo"/>
+						<xs:element maxOccurs="unbounded" name="MoistureControlInfo" type="MoistureControlInfoType"> </xs:element>
+						<xs:element minOccurs="0" name="MoistureControlImprovement" type="MoistureControlImprovementInfo"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -2451,144 +2182,120 @@
 			<xs:element minOccurs="0" name="CombustionAppliances">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="CombustionApplianceZone"
-							maxOccurs="unbounded">
+						<xs:element minOccurs="0" name="CombustionApplianceZone" maxOccurs="unbounded">
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element name="CAZDepressurizationLimit"
-										type="CAZDepressurizationLimit" minOccurs="0">
+									<xs:element name="CAZDepressurizationLimit" type="CAZDepressurizationLimit" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>Pulled from industry standards by users (e.g. BPI Gold Sheet) or via software program</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="BaselineTest" type="CAZTestConfiguration"
-										minOccurs="0">
+									<xs:element name="BaselineTest" type="CAZTestConfiguration" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>Baseline pressure is read under the following conditions: no items running, all fans off, all exterior doors closed, and all interior doors are opened.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="PoorCaseTest"
-										type="CAZTestConfiguration">
+									<xs:element minOccurs="0" name="PoorCaseTest" type="CAZTestConfiguration">
 										<xs:annotation>
 											<xs:documentation>The poor case CAZ depressurization test is configured by determining the largest combustion appliance zone depressurization attainable at the time of testing due to the combined effects of door position, exhaust appliance operation, and air handler fan operation. A base pressure must be measured with all fans off and doors open. The poor case CAZ depressurization measurement is the pressure difference between the largest depressurization attained at the time of testing and the base pressure.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="NetPressureChange" type="NetPressureChange"
-										minOccurs="0">
+									<xs:element name="NetPressureChange" type="NetPressureChange" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>With respect to the baseline pressure (e.g. no fans running, all exterior doors closed, and all interior doors opened)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="DepressurizationFindingPoorCase"
-										type="DepressurizationFindingPoorCase" minOccurs="0"/>
-									<xs:element name="AmountAmbientCOinCAZduringTesting"
-										type="xs:double" minOccurs="0">
+									<xs:element name="DepressurizationFindingPoorCase" type="DepressurizationFindingPoorCase" minOccurs="0"/>
+									<xs:element name="AmountAmbientCOinCAZduringTesting" type="xs:double" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>parts per million (ppm)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="AmbientCOinCAZExceeded35ppmduringTesting"
-										type="xs:boolean" minOccurs="0"/>
-									<xs:element minOccurs="0" name="CombustionApplianceTest"
-										maxOccurs="unbounded">
+									<xs:element name="AmbientCOinCAZExceeded35ppmduringTesting" type="xs:boolean" minOccurs="0"/>
+									<xs:element minOccurs="0" name="CombustionApplianceTest" maxOccurs="unbounded">
 										<xs:complexType>
 											<xs:sequence minOccurs="0">
-												<xs:element name="CAZAppliance"
-												type="RemoteReference">
-												<xs:annotation>
-												<xs:documentation>The ID of the system tested</xs:documentation>
-												</xs:annotation>
+												<xs:element name="CAZAppliance" type="RemoteReference">
+													<xs:annotation>
+														<xs:documentation>The ID of the system tested</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="CombustionVentingSystem"
-												type="RemoteReference"/>
-												<xs:element name="FlueVisualCondition"
-												type="FlueCondition" minOccurs="0"/>
-												<xs:element minOccurs="0" name="FlueConditionNotes"
-												type="xs:string"/>
-												<xs:element name="OutsideTemperatureFlueDraftTest"
-												type="Temperature" minOccurs="0">
-												<xs:annotation>
-												<xs:documentation>[deg F]</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="CombustionVentingSystem" type="RemoteReference"/>
+												<xs:element name="FlueVisualCondition" type="FlueCondition" minOccurs="0"/>
+												<xs:element minOccurs="0" name="FlueConditionNotes" type="xs:string"/>
+												<xs:element name="OutsideTemperatureFlueDraftTest" type="Temperature" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>[deg F]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="FlueDraftTest">
-												<xs:annotation>
-												<xs:documentation>[Pa]</xs:documentation>
-												</xs:annotation>
-												<xs:complexType>
-												<xs:complexContent>
-												<xs:extension base="CAZApplianceReading">
-												<xs:sequence>
-												<xs:element ref="extension" minOccurs="0"/>
-												</xs:sequence>
-												</xs:extension>
-												</xs:complexContent>
-												</xs:complexType>
+													<xs:annotation>
+														<xs:documentation>[Pa]</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:complexContent>
+															<xs:extension base="CAZApplianceReading">
+																<xs:sequence>
+																	<xs:element ref="extension" minOccurs="0"/>
+																</xs:sequence>
+															</xs:extension>
+														</xs:complexContent>
+													</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="SpillageTest">
-												<xs:annotation>
-												<xs:documentation>[seconds]</xs:documentation>
-												</xs:annotation>
-												<xs:complexType>
-												<xs:complexContent>
-												<xs:extension base="CAZApplianceReading">
-												<xs:sequence>
-												<xs:element ref="extension" minOccurs="0"/>
-												</xs:sequence>
-												</xs:extension>
-												</xs:complexContent>
-												</xs:complexType>
+													<xs:annotation>
+														<xs:documentation>[seconds]</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:complexContent>
+															<xs:extension base="CAZApplianceReading">
+																<xs:sequence>
+																	<xs:element ref="extension" minOccurs="0"/>
+																</xs:sequence>
+															</xs:extension>
+														</xs:complexContent>
+													</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="CarbonMonoxideTest">
-												<xs:annotation>
-												<xs:documentation>[ppm]</xs:documentation>
-												</xs:annotation>
-												<xs:complexType>
-												<xs:complexContent>
-												<xs:extension base="CAZApplianceReading">
-												<xs:sequence>
-												<xs:element
-												name="MaxAmbientCOinLivingSpaceDuringAudit"
-												minOccurs="0" type="xs:double">
-												<xs:annotation>
-												<xs:documentation>Monitored throughout assessment, not just appliance testing</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>[ppm]</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:complexContent>
+															<xs:extension base="CAZApplianceReading">
+																<xs:sequence>
+																	<xs:element name="MaxAmbientCOinLivingSpaceDuringAudit" minOccurs="0" type="xs:double">
+																		<xs:annotation>
+																			<xs:documentation>Monitored throughout assessment, not just appliance testing</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element minOccurs="0" name="AmbientCOActionDuringCAZTesting" type="xs:string">
+																		<xs:annotation>
+																			<xs:documentation>BPI Gold Sheet is one example that shows action levels based upon decision logic</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element minOccurs="0" ref="extension"/>
+																</xs:sequence>
+															</xs:extension>
+														</xs:complexContent>
+													</xs:complexType>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="AmbientCOActionDuringCAZTesting"
-												type="xs:string">
-												<xs:annotation>
-												<xs:documentation>BPI Gold Sheet is one example that shows action levels based upon decision logic</xs:documentation>
-												</xs:annotation>
+												<xs:element name="StackTemperature" type="Temperature" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>[deg F] after 10 minutes run time</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												</xs:extension>
-												</xs:complexContent>
-												</xs:complexType>
-												</xs:element>
-												<xs:element name="StackTemperature"
-												type="Temperature" minOccurs="0">
-												<xs:annotation>
-												<xs:documentation>[deg F] after 10 minutes run time</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element name="FuelLeaks" minOccurs="0"
-												maxOccurs="unbounded">
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element name="FuelType" type="FuelType"/>
-												<xs:element name="LeaksIdentified"
-												type="xs:boolean"/>
-												<xs:element name="LeaksAddressed"
-												type="xs:boolean"/>
-												<xs:element minOccurs="0" name="Notes"
-												type="xs:string"/>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												</xs:complexType>
+												<xs:element name="FuelLeaks" minOccurs="0" maxOccurs="unbounded">
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="FuelType" type="FuelType"/>
+															<xs:element name="LeaksIdentified" type="xs:boolean"/>
+															<xs:element name="LeaksAddressed" type="xs:boolean"/>
+															<xs:element minOccurs="0" name="Notes" type="xs:string"/>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+													</xs:complexType>
 												</xs:element>
 												<xs:element ref="extension" minOccurs="0"/>
 											</xs:sequence>
@@ -2607,8 +2314,7 @@
 					<xs:sequence>
 						<xs:element name="StoveID" type="SystemIdentifiersInfoType"/>
 						<xs:element minOccurs="0" name="StoveFuel" type="FuelType"/>
-						<xs:element name="HeatingStoveProperlyVented" type="xs:boolean"
-							minOccurs="0"/>
+						<xs:element name="HeatingStoveProperlyVented" type="xs:boolean" minOccurs="0"/>
 						<xs:element name="COReading" type="COReading" minOccurs="0"/>
 						<xs:element minOccurs="0" name="TimeofCOReading" type="xs:dateTime"/>
 						<xs:element name="GasLeaksIdentified" type="xs:boolean" minOccurs="0"/>
@@ -2636,8 +2342,7 @@
 								<xs:documentation>Did the contracted scope of work include window replacement?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="LeadSafeCertificationNumber"
-							type="xs:string">
+						<xs:element minOccurs="0" name="LeadSafeCertificationNumber" type="xs:string">
 							<xs:annotation>
 								<xs:documentation>Certification Number of the EPA Lead-Safe Certified firm that performed the work.</xs:documentation>
 							</xs:annotation>
@@ -2654,19 +2359,15 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="StartDateTime"
-										type="xs:dateTime"/>
+									<xs:element minOccurs="0" name="StartDateTime" type="xs:dateTime"/>
 									<xs:element minOccurs="0" name="EndDateTime" type="xs:dateTime"/>
-									<xs:element minOccurs="0" name="TestLocation"
-										type="RadonTestLocation"/>
-									<xs:element name="RadonTestResults" type="xs:double"
-										minOccurs="0">
+									<xs:element minOccurs="0" name="TestLocation" type="RadonTestLocation"/>
+									<xs:element name="RadonTestResults" type="xs:double" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>in pCi/L</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RadonTestMethod"
-										type="RadonTestTypes"/>
+									<xs:element minOccurs="0" name="RadonTestMethod" type="RadonTestTypes"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 							</xs:complexType>
@@ -2697,14 +2398,12 @@
 			<xs:element minOccurs="0" name="SourcePollutants">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="UnventedCombustionAppliancesinLivingArea"
-							type="xs:boolean">
+						<xs:element minOccurs="0" name="UnventedCombustionAppliancesinLivingArea" type="xs:boolean">
 							<xs:annotation>
 								<xs:documentation>Are there unvented combustion heating or hearth appliances present in the living area?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="ConformanceWithANSIZ21_11_2"
-							type="xs:boolean">
+						<xs:element minOccurs="0" name="ConformanceWithANSIZ21_11_2" type="xs:boolean">
 							<xs:annotation>
 								<xs:documentation>If yes, does the appliance conform with ANSI Z21.11.2?
 </xs:documentation>
@@ -2720,8 +2419,7 @@
 								<xs:documentation>Does home have attached garage?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="GarageContinuousAirBarrier"
-							type="xs:boolean">
+						<xs:element minOccurs="0" name="GarageContinuousAirBarrier" type="xs:boolean">
 							<xs:annotation>
 								<xs:documentation>If yes, is there a continuous air barrier between garage and living space?</xs:documentation>
 							</xs:annotation>
@@ -2748,8 +2446,7 @@
 								<xs:documentation>Evidence of pesticide, insecticide use?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="IndustryStandardCompliance"
-							type="xs:boolean">
+						<xs:element minOccurs="0" name="IndustryStandardCompliance" type="xs:boolean">
 							<xs:annotation>
 								<xs:documentation>Do measures comply with industry standards to prevent pest entry?
 
@@ -2778,11 +2475,9 @@ NOTE: This is for ALL measures that may create entry points for vermin. For exam
 								<xs:documentation>Was asbestos found?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="TypeofBlowerDoorTest"
-							type="TypeofBlowerDoorTest"/>
+						<xs:element minOccurs="0" name="TypeofBlowerDoorTest" type="TypeofBlowerDoorTest"/>
 						<xs:element minOccurs="0" name="ActionsTaken" type="xs:string"/>
-						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecifications"
-							type="xs:boolean"/>
+						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecifications" type="xs:boolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -2901,8 +2596,7 @@ NOTE: This is for ALL measures that may create entry points for vermin. For exam
 				</xs:element>
 				<xs:element name="RequiredVentilationRateUnits" type="VentilationRateUnits"/>
 			</xs:sequence>
-			<xs:element minOccurs="0" name="VentilationImprovementRecommendation"
-				type="Recommendation"/>
+			<xs:element minOccurs="0" name="VentilationImprovementRecommendation" type="Recommendation"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 	</xs:complexType>
@@ -2992,8 +2686,7 @@ NOTE: This is for ALL measures that may create entry points for vermin. For exam
 					<xs:documentation>should be represented as a fraction (ie 0.5 instead of 50%)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="EndUseSavings"
-				type="EndUseInfoType"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="EndUseSavings" type="EndUseInfoType"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 	</xs:complexType>
@@ -3027,19 +2720,16 @@ NOTE: This is for ALL measures that may create entry points for vermin. For exam
 			<xs:element minOccurs="0" name="SerialNumber" type="xs:string"/>
 			<xs:element minOccurs="0" name="AHRINumber" type="xs:string"/>
 			<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification"
-				type="HVACThirdPartyCertification"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="HVACThirdPartyCertification"/>
 			<xs:element minOccurs="0" name="HasSharedCombustionVentilation" type="xs:boolean"/>
 			<xs:element minOccurs="0" name="CombustionVentingSystem" type="LocalReference"/>
-			<xs:element name="DistributionSystem" type="LocalReference" minOccurs="0"
-				maxOccurs="unbounded"/>
+			<xs:element name="DistributionSystem" type="LocalReference" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element minOccurs="0" name="Installation">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element minOccurs="0" name="Standard" type="HVACInstallationStandard"/>
 						<xs:element minOccurs="0" name="SizingCalculation" type="HVACSizingCalcs"/>
-						<xs:element minOccurs="0" name="EnvelopeImprovementsUsedinSizing"
-							type="xs:boolean">
+						<xs:element minOccurs="0" name="EnvelopeImprovementsUsedinSizing" type="xs:boolean">
 							<xs:annotation>
 								<xs:documentation>Air sealing and insulation implemented prior to replacement and used in calculations for sizing new / replacement system?</xs:documentation>
 							</xs:annotation>
@@ -3069,8 +2759,7 @@ NOTE: This is for ALL measures that may create entry points for vermin. For exam
 							<xs:documentation>[Btuh] Input Heating Capacity</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="AnnualHeatingEfficiency"
-						type="HeatingEfficiencyType" maxOccurs="unbounded"> </xs:element>
+					<xs:element minOccurs="0" name="AnnualHeatingEfficiency" type="HeatingEfficiencyType" maxOccurs="unbounded"> </xs:element>
 					<xs:element name="FractionHeatLoadServed" type="Fraction" minOccurs="0"/>
 					<xs:element minOccurs="0" name="FloorAreaServed" type="SurfaceArea">
 						<xs:annotation>
@@ -3098,8 +2787,7 @@ NOTE: This is for ALL measures that may create entry points for vermin. For exam
 						<xs:element minOccurs="0" name="PowerBurner" type="xs:boolean"/>
 						<xs:element minOccurs="0" name="AutomaticVentDamper" type="xs:boolean"/>
 						<xs:element minOccurs="0" name="PilotLight" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
-							type="xs:boolean"/>
+						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="xs:boolean"/>
 						<xs:element minOccurs="0" name="RetentionHead" type="xs:boolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
@@ -3118,8 +2806,7 @@ NOTE: This is for ALL measures that may create entry points for vermin. For exam
 						<xs:element minOccurs="0" name="RotaryCup" type="xs:boolean"/>
 						<xs:element minOccurs="0" name="AutomaticVentDamper" type="xs:boolean"/>
 						<xs:element minOccurs="0" name="PilotLight" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
-							type="xs:boolean"/>
+						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="xs:boolean"/>
 						<xs:element minOccurs="0" name="RetentionHead" type="xs:boolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
@@ -3128,8 +2815,7 @@ NOTE: This is for ALL measures that may create entry points for vermin. For exam
 			<xs:element name="ElectricResistance">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="ElectricDistribution" type="ElectricDistributionType"
-							minOccurs="0"/>
+						<xs:element name="ElectricDistribution" type="ElectricDistributionType" minOccurs="0"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -3145,8 +2831,7 @@ http://www.epa.gov/compliance/monitoring/programs/caa/woodheaters.html</xs:docum
 						</xs:element>
 						<xs:element minOccurs="0" name="AutomaticVentDamper" type="xs:boolean"/>
 						<xs:element minOccurs="0" name="PilotLight" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
-							type="xs:boolean"/>
+						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="xs:boolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -3162,8 +2847,7 @@ http://www.epa.gov/compliance/monitoring/programs/caa/woodheaters.html</xs:docum
 						</xs:element>
 						<xs:element minOccurs="0" name="AutomaticVentDamper" type="xs:boolean"/>
 						<xs:element minOccurs="0" name="PilotLight" type="xs:boolean"/>
-						<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
-							type="xs:boolean"/>
+						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="xs:boolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -3241,15 +2925,13 @@ http://www.epa.gov/compliance/monitoring/programs/caa/woodheaters.html</xs:docum
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="BackupSystemFuel" type="FuelType" minOccurs="0"/>
-					<xs:element name="BackupAnnualHeatingEfficiency" minOccurs="0"
-						type="HeatingEfficiencyType" maxOccurs="unbounded"> </xs:element>
+					<xs:element name="BackupAnnualHeatingEfficiency" minOccurs="0" type="HeatingEfficiencyType" maxOccurs="unbounded"> </xs:element>
 					<xs:element minOccurs="0" name="BackupHeatingCapacity" type="Capacity">
 						<xs:annotation>
 							<xs:documentation>[Btuh]</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="BackupHeatingSwitchoverTemperature"
-						type="Temperature">
+					<xs:element minOccurs="0" name="BackupHeatingSwitchoverTemperature" type="Temperature">
 						<xs:annotation>
 							<xs:documentation>[deg F] Temperature at which the backup heating is activated.</xs:documentation>
 						</xs:annotation>
@@ -3261,10 +2943,8 @@ http://www.epa.gov/compliance/monitoring/programs/caa/woodheaters.html</xs:docum
 							<xs:documentation>[sq.ft.]</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType"
-						minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="AnnualHeatingEfficiency" minOccurs="0"
-						type="HeatingEfficiencyType" maxOccurs="unbounded"> </xs:element>
+					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="AnnualHeatingEfficiency" minOccurs="0" type="HeatingEfficiencyType" maxOccurs="unbounded"> </xs:element>
 					<xs:element minOccurs="0" ref="extension"/>
 				</xs:sequence>
 			</xs:extension>
@@ -3287,8 +2967,7 @@ http://www.epa.gov/compliance/monitoring/programs/caa/woodheaters.html</xs:docum
 							<xs:documentation>[sq.ft.]</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType"
-						minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType" minOccurs="0" maxOccurs="unbounded"/>
 					<xs:element minOccurs="0" name="SensibleHeatFraction" type="Fraction"/>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
@@ -3326,8 +3005,7 @@ http://www.epa.gov/compliance/monitoring/programs/caa/woodheaters.html</xs:docum
 				</xs:annotation>
 			</xs:element>
 			<xs:element minOccurs="0" name="PipeDiameter" type="PipeDiameterType"/>
-			<xs:element name="HydronicDistributionType" type="HydronicDistributionType"
-				minOccurs="0"/>
+			<xs:element name="HydronicDistributionType" type="HydronicDistributionType" minOccurs="0"/>
 			<xs:element minOccurs="0" name="SupplyTemperature" type="Temperature">
 				<xs:annotation>
 					<xs:documentation>[degF]</xs:documentation>
@@ -3346,8 +3024,7 @@ http://www.epa.gov/compliance/monitoring/programs/caa/woodheaters.html</xs:docum
 								<xs:documentation>System Pump and Zone Valve Corrections made</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="ThermostaticRadiatorValves"
-							type="xs:boolean"/>
+						<xs:element minOccurs="0" name="ThermostaticRadiatorValves" type="xs:boolean"/>
 						<xs:element minOccurs="0" name="VariableSpeedPump" type="xs:boolean"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -3359,25 +3036,21 @@ http://www.epa.gov/compliance/monitoring/programs/caa/woodheaters.html</xs:docum
 		<xs:sequence>
 			<xs:element name="AirDistributionType" type="AirDistributionType" minOccurs="0"/>
 			<xs:element name="AirHandlerMotorType" type="AirHandlerMotorType" minOccurs="0"/>
-			<xs:element minOccurs="0" name="DuctLeakageMeasurement"
-				type="DuctLeakageMeasurementType" maxOccurs="unbounded"/>
+			<xs:element minOccurs="0" name="DuctLeakageMeasurement" type="DuctLeakageMeasurementType" maxOccurs="unbounded"/>
 			<xs:element minOccurs="0" name="DuctSystemSizingAppropriate" type="xs:boolean"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="Ducts">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element name="DuctType" type="DuctType" minOccurs="0"/>
 						<xs:element name="DuctMaterial" type="DuctMaterial" minOccurs="0"/>
-						<xs:element minOccurs="0" name="DuctInsulationMaterial"
-							type="InsulationMaterial"/>
+						<xs:element minOccurs="0" name="DuctInsulationMaterial" type="InsulationMaterial"/>
 						<xs:element name="DuctInsulationRValue" type="RValue" minOccurs="0"/>
-						<xs:element minOccurs="0" name="DuctInsulationThickness"
-							type="LengthMeasurement">
+						<xs:element minOccurs="0" name="DuctInsulationThickness" type="LengthMeasurement">
 							<xs:annotation>
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DuctInsulationCondition"
-							type="InsulationCondition"/>
+						<xs:element minOccurs="0" name="DuctInsulationCondition" type="InsulationCondition"/>
 						<xs:element name="DuctLocation" type="DuctLocation" minOccurs="0"/>
 						<xs:element minOccurs="0" name="FractionDuctArea" type="Fraction">
 							<xs:annotation>
@@ -3393,15 +3066,12 @@ http://www.epa.gov/compliance/monitoring/programs/caa/woodheaters.html</xs:docum
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="NumberofReturnRegisters"
-				type="IntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="NumberofReturnRegisters" type="IntegerGreaterThanOrEqualToZero"/>
 			<xs:element minOccurs="0" name="TotalExternalStaticPressureMeasurement">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="Supply"
-							type="TotalExternalStaticPressureMeasurement"/>
-						<xs:element minOccurs="0" name="Return"
-							type="TotalExternalStaticPressureMeasurement"/>
+						<xs:element minOccurs="0" name="Supply" type="TotalExternalStaticPressureMeasurement"/>
+						<xs:element minOccurs="0" name="Return" type="TotalExternalStaticPressureMeasurement"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
@@ -3445,60 +3115,49 @@ http://www.epa.gov/compliance/monitoring/programs/caa/woodheaters.html</xs:docum
 							<xs:complexType>
 								<xs:sequence>
 									<xs:element minOccurs="0" name="SiteType" type="SiteType"/>
-									<xs:element minOccurs="0" name="Surroundings"
-										type="Surroundings">
+									<xs:element minOccurs="0" name="Surroundings" type="Surroundings">
 										<xs:annotation>
 											<xs:documentation>If the building is attached to other units in the horizontal plane.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="VerticalSurroundings"
-										type="VerticalSurroundings">
+									<xs:element minOccurs="0" name="VerticalSurroundings" type="VerticalSurroundings">
 										<xs:annotation>
 											<xs:documentation>If the building is attached to other units on the vertical plane.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ShieldingofHome" type="ShieldingofHome"
-										minOccurs="0"/>
-									<xs:element minOccurs="0" name="OrientationOfFrontOfHome"
-										type="OrientationType"/>
-									<xs:element minOccurs="0" name="AzimuthOfFrontOfHome"
-										type="AzimuthType"/>
+									<xs:element name="ShieldingofHome" type="ShieldingofHome" minOccurs="0"/>
+									<xs:element minOccurs="0" name="OrientationOfFrontOfHome" type="OrientationType"/>
+									<xs:element minOccurs="0" name="AzimuthOfFrontOfHome" type="AzimuthType"/>
 									<xs:element minOccurs="0" name="PublicTransportation">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="DistanceFromSubway"
-												type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>[ft]</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="DistanceFromSubway" type="LengthMeasurement">
+													<xs:annotation>
+														<xs:documentation>[ft]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="DistanceFromBus"
-												type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>[ft]</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="DistanceFromBus" type="LengthMeasurement">
+													<xs:annotation>
+														<xs:documentation>[ft]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="DistanceFromTrain"
-												type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>[ft]</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="DistanceFromTrain" type="LengthMeasurement">
+													<xs:annotation>
+														<xs:documentation>[ft]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="WalkingScore"
-										type="IntegerGreaterThanOrEqualToZero"/>
-									<xs:element minOccurs="0" name="WalkingScoreSource"
-										type="xs:string"/>
+									<xs:element minOccurs="0" name="WalkingScore" type="IntegerGreaterThanOrEqualToZero"/>
+									<xs:element minOccurs="0" name="WalkingScoreSource" type="xs:string"/>
 									<xs:element minOccurs="0" name="FuelTypesAvailable">
 										<xs:annotation>
 											<xs:documentation>Fuels available on site via utility lines/pipes or delivery.</xs:documentation>
 										</xs:annotation>
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element maxOccurs="unbounded" name="Fuel"
-												type="FuelType"/>
+												<xs:element maxOccurs="unbounded" name="Fuel" type="FuelType"/>
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
@@ -3509,47 +3168,38 @@ http://www.epa.gov/compliance/monitoring/programs/caa/woodheaters.html</xs:docum
 						<xs:element minOccurs="0" name="BuildingOccupancy">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element minOccurs="0" name="HouseholdType"
-										type="HouseholdType"/>
+									<xs:element minOccurs="0" name="HouseholdType" type="HouseholdType"/>
 									<xs:element minOccurs="0" name="YearOccupied" type="Year">
 										<xs:annotation>
 											<xs:documentation>The year the current occupants moved into the building</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="ResidentPopulationType"
-										type="ResidentPopulationType"/>
+									<xs:element minOccurs="0" name="ResidentPopulationType" type="ResidentPopulationType"/>
 									<xs:element minOccurs="0" name="Occupancy" type="Occupancy"/>
-									<xs:element name="NumberofResidents" type="PeopleCount"
-										minOccurs="0"/>
-									<xs:element minOccurs="0" name="NumberofAdults"
-										type="PeopleCount">
+									<xs:element name="NumberofResidents" type="PeopleCount" minOccurs="0"/>
+									<xs:element minOccurs="0" name="NumberofAdults" type="PeopleCount">
 										<xs:annotation>
 											<xs:documentation>18 or older</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofChildren"
-										type="IntegerGreaterThanOrEqualToZero">
+									<xs:element minOccurs="0" name="NumberofChildren" type="IntegerGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>less than 18 years old</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="PubliclySubsidized"
-										type="xs:boolean"/>
+									<xs:element minOccurs="0" name="PubliclySubsidized" type="xs:boolean"/>
 									<xs:element minOccurs="0" name="LowIncome" type="xs:boolean"/>
-									<xs:element minOccurs="0" name="OccupantIncomeRange"
-										type="FractionGreaterThanOne">
+									<xs:element minOccurs="0" name="OccupantIncomeRange" type="FractionGreaterThanOne">
 										<xs:annotation>
 											<xs:documentation>Percentage as a fraction (50% = 0.5)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="OccupantIncomeRangeUnits"
-										type="OccupantIncomeRangeUnits">
+									<xs:element minOccurs="0" name="OccupantIncomeRangeUnits" type="OccupantIncomeRangeUnits">
 										<xs:annotation>
 											<xs:documentation>AMI = Area Median Income; FPL = Federal Poverty Level</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HighestLevelofOccupantEducation"
-										type="EducationLevels"/>
+									<xs:element minOccurs="0" name="HighestLevelofOccupantEducation" type="EducationLevels"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 							</xs:complexType>
@@ -3558,77 +3208,60 @@ http://www.epa.gov/compliance/monitoring/programs/caa/woodheaters.html</xs:docum
 							<xs:complexType>
 								<xs:sequence>
 									<xs:element name="YearBuilt" type="Year" minOccurs="0"/>
-									<xs:element minOccurs="0" name="YearBuiltKnownOrEstimated"
-										type="KnownOrEstimated"/>
+									<xs:element minOccurs="0" name="YearBuiltKnownOrEstimated" type="KnownOrEstimated"/>
 									<xs:element minOccurs="0" name="YearofLastRemodel" type="Year"/>
-									<xs:element name="ResidentialFacilityType"
-										type="ResidentialFacilityType" minOccurs="0"/>
+									<xs:element name="ResidentialFacilityType" type="ResidentialFacilityType" minOccurs="0"/>
 									<xs:element minOccurs="0" name="PassiveSolar" type="xs:boolean">
 										<xs:annotation>
 											<xs:documentation>Passive solar design—also known as climatic design—involves using a building's windows, walls, and floors to collect, store, and distribute solar energy in the form of heat in the winter and reject solar heat in the summer. (source: http://www.eere.energy.gov/basics/buildings/passive_solar_design.html)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="BuildingHeight"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="BuildingHeight" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] height of building</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofUnits"
-										type="IntegerGreaterThanZero"/>
-									<xs:element minOccurs="0" name="NumberofFloors"
-										type="NumberOfFloorsType">
+									<xs:element minOccurs="0" name="NumberofUnits" type="IntegerGreaterThanZero"/>
+									<xs:element minOccurs="0" name="NumberofFloors" type="NumberOfFloorsType">
 										<xs:annotation>
 											<xs:documentation>Total number of floors including a basement, whether conditioned or unconditioned</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofConditionedFloors"
-										type="NumberOfFloorsType">
+									<xs:element minOccurs="0" name="NumberofConditionedFloors" type="NumberOfFloorsType">
 										<xs:annotation>
 											<xs:documentation>Number of floors that are heated/cooled including a basement</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0"
-										name="NumberofConditionedFloorsAboveGrade"
-										type="NumberOfFloorsType">
+									<xs:element minOccurs="0" name="NumberofConditionedFloorsAboveGrade" type="NumberOfFloorsType">
 										<xs:annotation>
 											<xs:documentation>Number of floors above grade that are heated/cooled</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="AverageCeilingHeight" type="LengthMeasurement"
-										minOccurs="0">
+									<xs:element name="AverageCeilingHeight" type="LengthMeasurement" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[ft] Average distance from the floor to the ceiling</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FloorToFloorHeight"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="FloorToFloorHeight" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] distance between floors</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofRooms"
-										type="IntegerGreaterThanZero"/>
-									<xs:element name="NumberofBedrooms"
-										type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
-									<xs:element name="NumberofBathrooms"
-										type="IntegerGreaterThanZero" minOccurs="0"/>
-									<xs:element minOccurs="0" name="NumberofCompleteBathrooms"
-										type="IntegerGreaterThanZero">
+									<xs:element minOccurs="0" name="NumberofRooms" type="IntegerGreaterThanZero"/>
+									<xs:element name="NumberofBedrooms" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+									<xs:element name="NumberofBathrooms" type="IntegerGreaterThanZero" minOccurs="0"/>
+									<xs:element minOccurs="0" name="NumberofCompleteBathrooms" type="IntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Number of bathrooms with a tub or shower</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="BuildingFootprintArea"
-										type="SurfaceArea">
+									<xs:element minOccurs="0" name="BuildingFootprintArea" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FootprintShape"
-										type="FootprintShape"/>
-									<xs:element minOccurs="0" name="GrossFloorArea"
-										type="SurfaceArea">
+									<xs:element minOccurs="0" name="FootprintShape" type="FootprintShape"/>
+									<xs:element minOccurs="0" name="GrossFloorArea" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]
 Gross floor area (based on ASHRAE definition) is the sum of the floor areas of the spaces within the building, including basements, mezzanine and intermediate‐floored tiers, and penthouses with headroom height of 7.5 ft (2.2 meters) or greater. Measurements must be taken from the exterior faces of exterior walls OR from the centerline of walls separating buildings, OR from the centerline of walls separating spaces. Excludes non‐enclosed (or non‐enclosable) roofed‐over areas such as exterior covered walkways, porches, terraces or steps, roof overhangs, and similar features. Excludes air shafts, pipe trenches, and chimneys. Excludes floor area dedicated to the parking and circulation of motor vehicles.</xs:documentation>
@@ -3640,37 +3273,31 @@ Gross floor area (based on ASHRAE definition) is the sum of the floor areas of t
 The floor area of an occupiable space defined by the inside surfaces of its walls but excluding shafts, column enclosures, and other permanently enclosed, inaccessible, and unoccupiable areas. Obstructions in the space such as furnishings, display or storage racks, and other obstructions, whether temporary or permanent, may not be deducted from the space are considered to be part of the net occupiable area.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ConditionedFloorArea" type="SurfaceArea"
-										minOccurs="0">
+									<xs:element name="ConditionedFloorArea" type="SurfaceArea" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]
 All finished space that is within the (insulated) conditioned space boundary (that is, within the insulated envelope), regardless of HVAC configuration.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FinishedFloorArea"
-										type="SurfaceArea">
+									<xs:element minOccurs="0" name="FinishedFloorArea" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Floor area of home that is finished and assumed to be occupied.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="NumberofStoriesAboveGrade"
-										type="IntegerGreaterThanZero" minOccurs="0"/>
-									<xs:element minOccurs="0" name="CooledFloorArea"
-										type="SurfaceArea">
+									<xs:element name="NumberofStoriesAboveGrade" type="IntegerGreaterThanZero" minOccurs="0"/>
+									<xs:element minOccurs="0" name="CooledFloorArea" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]
 The total area of all enclosed spaces measured to the internal face of the external walls. Included are areas of sloping surfaces such as staircases, galleries, raked auditoria, and tiered terraces where the area taken is from the area on the plan. Excluded are areas that are not enclosed such as open floors, covered ways and balconies.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HeatedFloorArea"
-										type="SurfaceArea">
+									<xs:element minOccurs="0" name="HeatedFloorArea" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]
 The total area of all enclosed spaces measured to the internal face of the external walls. Included are areas of sloping surfaces such as staircases, galleries, raked auditoria, and tiered terraces where the area taken is from the area on the plan. Excluded are areas that are not enclosed such as open floors, covered ways and balconies.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="UnconditionedFloorArea"
-										type="SurfaceArea">
+									<xs:element minOccurs="0" name="UnconditionedFloorArea" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]
 An enclosed space within a building that does not meet the requirements of a conditioned space. Spaces that have no control over thermal conditions but intentionally or unintentionally receive thermal energy from adjacent spaces are considered unconditioned spaces (such as an attached garage on a house or a vestibule with no thermal comfort criteria). Spaces that are ventilated only to maintain air quality are considered unconditioned spaces (such as a parking garage with no thermal comfort criteria).</xs:documentation>
@@ -3682,15 +3309,13 @@ An enclosed space within a building that does not meet the requirements of a con
 A volume of a building surrounded by solid surfaces such as walls, roofs, floors, fenestration, and doors where the total opening area to the outside can be reduced to less than 1% of the Gross Interior Floor Area of the space. Spaces that are temporarily enclosed such as patios enclosed with tenting are not considered Enclosed Spaces for annual building analysis. These spaces should be treated as exterior to the building.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ConditionedBuildingVolume" type="Volume"
-										minOccurs="0">
+									<xs:element name="ConditionedBuildingVolume" type="Volume" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[cu.ft.]
 Volume inside the building envelope of the conditioned spaces. This metric can be calculated as the volume of the building if every space is conditioned or on a floor-by-floor basis. For spaces with vertical walls and horizontal ceilings and floors, this is calculated as the Gross Conditioned Floor Area times the height from the top surface of the finished floor to the top surface of the finished floor separating levels of the building or to the inside surface of the roof for the top floor. The volume of spaces that have nonvertical walls or nonhorizontal ceilings of floors should be calculated separately to properly account for the non-rectangular geometry. This metric does include the volume of floor or ceiling return air plenums.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="FoundationType" minOccurs="0"
-										type="FoundationType">
+									<xs:element name="FoundationType" minOccurs="0" type="FoundationType">
 										<xs:annotation>
 											<xs:documentation>Primary foundation type of building</xs:documentation>
 										</xs:annotation>
@@ -3700,19 +3325,14 @@ Volume inside the building envelope of the conditioned spaces. This metric can b
 											<xs:documentation>Primary attic type of building</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="AverageAtticRValue" type="RValue"
-										minOccurs="0"/>
+									<xs:element name="AverageAtticRValue" type="RValue" minOccurs="0"/>
 									<xs:element name="AverageWallRValue" type="RValue" minOccurs="0"/>
-									<xs:element name="AverageFloorRValue" type="RValue"
-										minOccurs="0"/>
+									<xs:element name="AverageFloorRValue" type="RValue" minOccurs="0"/>
 									<xs:element name="AverageDuctRValue" type="RValue" minOccurs="0"/>
 									<xs:element minOccurs="0" name="GaragePresent" type="xs:boolean"/>
-									<xs:element minOccurs="0" name="GarageLocation"
-										type="GarageLocation"/>
-									<xs:element minOccurs="0" name="SpaceAboveGarage"
-										type="SpaceAboveGarage"/>
-									<xs:element maxOccurs="unbounded" minOccurs="0"
-										name="EnergyScore" type="EnergyScoreType"/>
+									<xs:element minOccurs="0" name="GarageLocation" type="GarageLocation"/>
+									<xs:element minOccurs="0" name="SpaceAboveGarage" type="SpaceAboveGarage"/>
+									<xs:element maxOccurs="unbounded" minOccurs="0" name="EnergyScore" type="EnergyScoreType"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 							</xs:complexType>
@@ -3720,8 +3340,7 @@ Volume inside the building envelope of the conditioned spaces. This metric can b
 						<xs:element name="AnnualEnergyUse" minOccurs="0">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"
-										maxOccurs="unbounded"/>
+									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType" maxOccurs="unbounded"/>
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
@@ -3733,15 +3352,13 @@ Volume inside the building envelope of the conditioned spaces. This metric can b
 				<xs:complexType>
 					<xs:sequence minOccurs="0">
 						<xs:element name="ClimateZoneDOE" type="ClimateZoneDOE" minOccurs="0"/>
-						<xs:element name="ClimateZoneIECC" minOccurs="0" type="IECCClimateZoneType"
-							maxOccurs="unbounded"/>
+						<xs:element name="ClimateZoneIECC" minOccurs="0" type="IECCClimateZoneType" maxOccurs="unbounded"/>
 						<xs:element name="RadonZone" type="RadonZone" minOccurs="0"/>
 						<xs:element name="TermiteZone" type="TermiteZone" minOccurs="0"/>
 						<xs:element name="HurricaneZone" type="xs:boolean" minOccurs="0"/>
 						<xs:element name="FloodZone" type="xs:boolean" minOccurs="0"/>
 						<xs:element name="EarthquakeZone" type="EarthquakeZone" minOccurs="0"/>
-						<xs:element maxOccurs="unbounded" minOccurs="0" name="WeatherStation"
-							type="WeatherStation">
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="WeatherStation" type="WeatherStation">
 							<xs:annotation>
 								<xs:documentation>Weather location used in model simulation and/or utility bill regression analysis</xs:documentation>
 							</xs:annotation>
@@ -3771,8 +3388,7 @@ Volume inside the building envelope of the conditioned spaces. This metric can b
 			<xs:element minOccurs="0" name="CertifyingOrganization" type="CertifyingOrganization"/>
 			<xs:element minOccurs="0" name="CertifyingOrganizationURL" type="xs:string"/>
 			<xs:element minOccurs="0" name="YearCertified" type="Year"/>
-			<xs:element minOccurs="0" name="ProgramCertificate" maxOccurs="unbounded"
-				type="ProgramCertificate"/>
+			<xs:element minOccurs="0" name="ProgramCertificate" maxOccurs="unbounded" type="ProgramCertificate"/>
 			<xs:element minOccurs="0" name="EnergyStarHomeVersion" type="xs:string"/>
 			<xs:element name="ProjectType" type="ProjectType" minOccurs="0"/>
 			<xs:element name="Title" type="Title" minOccurs="0"/>
@@ -3811,13 +3427,11 @@ Volume inside the building envelope of the conditioned spaces. This metric can b
 			<xs:element name="Incentives" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="Incentive"
-							type="IncentiveDetailsType"/>
+						<xs:element maxOccurs="unbounded" name="Incentive" type="IncentiveDetailsType"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType"
-				maxOccurs="2"/>
+			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType" maxOccurs="2"/>
 			<xs:element maxOccurs="2" minOccurs="0" name="WaterSavingsInfo" type="WaterSavingsType"/>
 			<xs:element minOccurs="0" name="Measures">
 				<xs:complexType>
@@ -3857,10 +3471,8 @@ The Home Energy Rating System (HERS) index is a measure of a home's energy effic
 	</xs:complexType>
 	<xs:complexType name="TotalCostType">
 		<xs:sequence>
-			<xs:element name="TotalCostHealthSafetyMeasures" type="TotalCostHealthSafetyMeasures"
-				minOccurs="1"/>
-			<xs:element name="TotalCostQualEnergyMeasures" type="TotalCostQualEnergyMeasures"
-				minOccurs="1"/>
+			<xs:element name="TotalCostHealthSafetyMeasures" type="TotalCostHealthSafetyMeasures" minOccurs="1"/>
+			<xs:element name="TotalCostQualEnergyMeasures" type="TotalCostQualEnergyMeasures" minOccurs="1"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="MeasureDetailsType">
@@ -3894,8 +3506,7 @@ The Home Energy Rating System (HERS) index is a measure of a home's energy effic
 			<xs:element minOccurs="0" name="Incentives">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="Incentive"
-							type="IncentiveDetailsType"/>
+						<xs:element maxOccurs="unbounded" name="Incentive" type="IncentiveDetailsType"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
@@ -3912,8 +3523,7 @@ The Home Energy Rating System (HERS) index is a measure of a home's energy effic
 										</xs:annotation>
 									</xs:element>
 									<xs:element name="Quantity" type="Quantity"/>
-									<xs:element name="AnnualAmount" type="AnnualAmount"
-										minOccurs="0"/>
+									<xs:element name="AnnualAmount" type="AnnualAmount" minOccurs="0"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 							</xs:complexType>
@@ -3921,8 +3531,7 @@ The Home Energy Rating System (HERS) index is a measure of a home's energy effic
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType"
-				maxOccurs="2"/>
+			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType" maxOccurs="2"/>
 			<xs:element maxOccurs="2" minOccurs="0" name="WaterSavingsInfo" type="WaterSavingsType"/>
 			<xs:element minOccurs="0" name="CustomerNotes" type="Notes"/>
 			<xs:element minOccurs="0" name="WorkscopeNotes" type="Notes"/>
@@ -3947,16 +3556,14 @@ The Home Energy Rating System (HERS) index is a measure of a home's energy effic
 				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="ReplacedComponent"
-							type="RemoteReference"/>
+						<xs:element maxOccurs="unbounded" name="ReplacedComponent" type="RemoteReference"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="InstalledComponents">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="1" name="InstalledComponent" type="RemoteReference"
-							maxOccurs="unbounded"/>
+						<xs:element minOccurs="1" name="InstalledComponent" type="RemoteReference" maxOccurs="unbounded"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
@@ -3971,8 +3578,7 @@ The Home Energy Rating System (HERS) index is a measure of a home's energy effic
 				</xs:annotation>
 			</xs:element>
 			<xs:element minOccurs="0" name="EnergySavingsReported" type="GrossOrNet"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="FuelSavings"
-				type="FuelSavingsType"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="FuelSavings" type="FuelSavingsType"/>
 			<xs:element name="DemandSavings" minOccurs="0" type="xs:double">
 				<xs:annotation>
 					<xs:documentation>[kW] Demand savings from energy efficiency programs</xs:documentation>
@@ -4005,16 +3611,14 @@ The Home Energy Rating System (HERS) index is a measure of a home's energy effic
 	<xs:complexType name="DuctLeakageMeasurementType">
 		<xs:sequence>
 			<xs:element minOccurs="0" name="DuctType" type="DuctType"/>
-			<xs:element name="LeakinessObservedVisualInspection"
-				type="LeakinessObservedVisualInspection" minOccurs="0"/>
+			<xs:element name="LeakinessObservedVisualInspection" type="LeakinessObservedVisualInspection" minOccurs="0"/>
 			<xs:element name="DuctLeakageTestMethod" type="DuctLeakageTestMethod" minOccurs="0"/>
 			<xs:element minOccurs="0" name="DuctLeakage">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element name="Units" type="DuctLeakageTestUnitofMeasure" minOccurs="0"/>
 						<xs:element name="Value" type="MeasuredDuctLeakage" minOccurs="0"/>
-						<xs:element minOccurs="0" name="TotalOrToOutside"
-							type="DuctLeakageTotalOrToOutside"/>
+						<xs:element minOccurs="0" name="TotalOrToOutside" type="DuctLeakageTotalOrToOutside"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
@@ -4077,8 +3681,7 @@ Leakage Area [sq in] = Duct System Leakage Rate [CFM] / (1.06 * (Test Pressure [
 		<xs:sequence>
 			<xs:element minOccurs="0" name="WeatherRegressionBeginDate" type="xs:date"/>
 			<xs:element minOccurs="0" name="WeatherRegressionEndDate" type="xs:date"/>
-			<xs:element minOccurs="0" name="CalibrationQualification"
-				type="BPI2400CalibrationQualification">
+			<xs:element minOccurs="0" name="CalibrationQualification" type="BPI2400CalibrationQualification">
 				<xs:annotation>
 					<xs:documentation>This identifies which data quality requirements (if any) were met by the bills for the relevant energy source and therefore which calibration metrics (if any) are used to determine whether the calibrated model is accepted.</xs:documentation>
 				</xs:annotation>
@@ -4103,62 +3706,52 @@ Leakage Area [sq in] = Duct System Leakage Rate [CFM] / (1.06 * (Test Pressure [
 					<xs:documentation>Weather Normalized Annual Baseload Usage</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingBiasError"
-				type="xs:double">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingBiasError" type="xs:double">
 				<xs:annotation>
 					<xs:documentation>Eqn. 3.2.3.A.i  of BPI-2400. Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingAbsoluteError"
-				type="xs:double">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingAbsoluteError" type="xs:double">
 				<xs:annotation>
 					<xs:documentation>Eqn. 3.2.3.A.ii  of BPI-2400. In either kWh for electricity or MMBTU for all other fuels.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingBiasError"
-				type="xs:double">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingBiasError" type="xs:double">
 				<xs:annotation>
 					<xs:documentation>Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingAbsoluteError"
-				type="xs:double">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingAbsoluteError" type="xs:double">
 				<xs:annotation>
 					<xs:documentation>In either kWh for electricity or MMBTU for all other fuels.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadBiasError"
-				type="xs:double">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadBiasError" type="xs:double">
 				<xs:annotation>
 					<xs:documentation>Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadAbsoluteError"
-				type="xs:double">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadAbsoluteError" type="xs:double">
 				<xs:annotation>
 					<xs:documentation>In either kWh for electricity or MMBTU for all other fuels.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SimplifiedModelCalibrationHeatingBiasError"
-				nillable="true" type="xs:double">
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationHeatingBiasError" nillable="true" type="xs:double">
 				<xs:annotation>
 					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SimplifiedModelCalibrationCoolingBiasError"
-				type="xs:double">
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationCoolingBiasError" type="xs:double">
 				<xs:annotation>
 					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SimplifiedModelCalibrationBaseloadBiasError"
-				nillable="true" type="xs:double">
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationBaseloadBiasError" nillable="true" type="xs:double">
 				<xs:annotation>
 					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SimplifiedModelCalibrationTotalBiasError"
-				type="xs:double">
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationTotalBiasError" type="xs:double">
 				<xs:annotation>
 					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
 				</xs:annotation>
@@ -4177,8 +3770,7 @@ Leakage Area [sq in] = Duct System Leakage Rate [CFM] / (1.06 * (Test Pressure [
 							</xs:annotation>
 						</xs:element>
 						<xs:element name="UnitofMeasure" type="energyUnitType"/>
-						<xs:element minOccurs="0" name="MeteringConfiguration"
-							type="MeteringConfiguration">
+						<xs:element minOccurs="0" name="MeteringConfiguration" type="MeteringConfiguration">
 							<xs:annotation>
 								<xs:documentation>direct metering = tenants directly metered;
 master meter without sub-metering = tenants not sub metered;
@@ -4192,8 +3784,7 @@ master meter with sub-metering = tenant sub-metered by building owner</xs:docume
 										<xs:complexType>
 											<xs:sequence>
 												<xs:element name="EmissionType" type="EmissionType"/>
-												<xs:element name="EmissionUnits"
-												type="EmissionUnits"/>
+												<xs:element name="EmissionUnits" type="EmissionUnits"/>
 												<xs:element name="Emissions" type="xs:double"/>
 											</xs:sequence>
 										</xs:complexType>
@@ -4201,10 +3792,8 @@ master meter with sub-metering = tenant sub-metered by building owner</xs:docume
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
-						<xs:element minOccurs="0" name="FuelInterruptibility"
-							type="FuelInterruptibility"/>
-						<xs:element minOccurs="0" name="SharedEnergySystem"
-							type="SharedEnergySystem"/>
+						<xs:element minOccurs="0" name="FuelInterruptibility" type="FuelInterruptibility"/>
+						<xs:element minOccurs="0" name="SharedEnergySystem" type="SharedEnergySystem"/>
 						<xs:element minOccurs="0" name="IntervalType" type="IntervalType"/>
 						<xs:element minOccurs="0" name="ReadingTimeZone" type="xs:string"/>
 						<xs:element minOccurs="0" name="MarginalEnergyCostRate" type="xs:double">
@@ -4259,8 +3848,7 @@ master meter with sub-metering = tenant sub-metered by building owner</xs:docume
 			<xs:element name="UnitofMeasure" type="energyUnitType"/>
 			<xs:element minOccurs="0" name="AnnualConsumption" type="xs:double"/>
 			<xs:element minOccurs="0" name="AnnualFuelCost" type="xs:double"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="ConsumptionByEndUse"
-				type="EndUseInfoType"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ConsumptionByEndUse" type="EndUseInfoType"/>
 			<xs:element minOccurs="0" name="BaseLoad" type="xs:double">
 				<xs:annotation>
 					<xs:documentation>Baseload power is the energy consumed for the day-to-day operation of a home that is not used as a response to outside weather (i.e. excludes heating and cooling) (Krigger and Dorsi, 2009).</xs:documentation>
@@ -4310,12 +3898,9 @@ master meter with sub-metering = tenant sub-metered by building owner</xs:docume
 			<xs:element name="BusinessName" type="xs:string"/>
 			<xs:element name="BusinessType" type="BusinessType" minOccurs="0"/>
 			<xs:element name="BusinessSpecialization" type="BusinessSpecialization" minOccurs="0"/>
-			<xs:element name="Certification" type="BusinessCertification" minOccurs="0"
-				maxOccurs="unbounded"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="BusinessContact"
-				type="BusinessContactInfoType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="TelephoneInfo"
-				type="TelephoneInfoType"/>
+			<xs:element name="Certification" type="BusinessCertification" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="BusinessContact" type="BusinessContactInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="TelephoneInfo" type="TelephoneInfoType"/>
 			<xs:element minOccurs="0" maxOccurs="unbounded" name="EmailInfo" type="EmailInfoType"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
@@ -4412,8 +3997,7 @@ master meter with sub-metering = tenant sub-metered by building owner</xs:docume
 			<xs:element name="UFactor" type="UFactor" minOccurs="0"/>
 			<xs:element name="SHGC" type="SHGC" minOccurs="0"/>
 			<xs:element name="NFRCCertified" type="xs:boolean" minOccurs="0"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification"
-				type="WindowThirdPartyCertification"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="WindowThirdPartyCertification"/>
 			<xs:element minOccurs="0" name="VisibleTransmittance" type="Fraction"/>
 			<xs:element minOccurs="0" name="InteriorShading" type="InteriorShading"/>
 			<xs:element minOccurs="0" name="InteriorShadingFactorSummer" type="Fraction"/>
@@ -4427,14 +4011,12 @@ master meter with sub-metering = tenant sub-metered by building owner</xs:docume
 								<xs:documentation>[in] Depth of overhang</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DistanceToTopOfWindow"
-							type="LengthMeasurement">
+						<xs:element minOccurs="0" name="DistanceToTopOfWindow" type="LengthMeasurement">
 							<xs:annotation>
 								<xs:documentation>[in] Vertical distance from overhang to top of window</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DistanceToBottomOfWindow"
-							type="LengthMeasurement">
+						<xs:element minOccurs="0" name="DistanceToBottomOfWindow" type="LengthMeasurement">
 							<xs:annotation>
 								<xs:documentation>[in] Vertical distance from overhang to bottom of window</xs:documentation>
 							</xs:annotation>
@@ -4503,8 +4085,7 @@ master meter with sub-metering = tenant sub-metered by building owner</xs:docume
 				</xs:annotation>
 			</xs:element>
 			<xs:element minOccurs="0" name="WindConditions" type="WindConditions"/>
-			<xs:element name="TypeOfInfiltrationMeasurement" type="TypeofInfiltrationMeasurement"
-				minOccurs="0"/>
+			<xs:element name="TypeOfInfiltrationMeasurement" type="TypeofInfiltrationMeasurement" minOccurs="0"/>
 			<xs:element name="TypeOfBlowerDoorTest" type="TypeofBlowerDoorTest" minOccurs="0"/>
 			<xs:element name="HousePressure" type="HousePressure" minOccurs="0">
 				<xs:annotation>
@@ -4542,10 +4123,8 @@ master meter with sub-metering = tenant sub-metered by building owner</xs:docume
 	<xs:complexType name="MoistureControlInfoType">
 		<xs:sequence>
 			<xs:group ref="SystemInfo"/>
-			<xs:element name="ExteriorLocationsWaterIntrusionorDamage"
-				type="ExteriorLocationsWaterIntrusionorDamage" minOccurs="0" maxOccurs="unbounded"/>
-			<xs:element name="InteriorLocationsofWaterLeaksorDamage"
-				type="InteriorLocationsofWaterLeaksorDamage" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ExteriorLocationsWaterIntrusionorDamage" type="ExteriorLocationsWaterIntrusionorDamage" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="InteriorLocationsofWaterLeaksorDamage" type="InteriorLocationsofWaterLeaksorDamage" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
@@ -4636,8 +4215,7 @@ https://hpxml.nrel.gov/wiki/WallTypes</xs:documentation>
 			<xs:element name="WoodStud">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="ExpandedPolystyreneSheathing"
-							type="xs:boolean">
+						<xs:element minOccurs="0" name="ExpandedPolystyreneSheathing" type="xs:boolean">
 							<xs:annotation>
 								<xs:documentation>Sheathing insulation should be specified in the Insulation element as well.</xs:documentation>
 							</xs:annotation>
@@ -4788,8 +4366,7 @@ https://hpxml.nrel.gov/wiki/WallTypes</xs:documentation>
 					<xs:documentation>Percent of rooms controlled by electronic zone valves with thermostats</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="HVACSystemsServed" type="LocalReference" minOccurs="0"
-				maxOccurs="unbounded"/>
+			<xs:element name="HVACSystemsServed" type="LocalReference" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
@@ -4818,8 +4395,7 @@ https://hpxml.nrel.gov/wiki/WallTypes</xs:documentation>
 					<xs:documentation>The year and month the duct system was sealed.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="DuctOutsideEnvelopeInsulatedaspartofRetrofit" type="xs:boolean"
-				minOccurs="0"/>
+			<xs:element name="DuctOutsideEnvelopeInsulatedaspartofRetrofit" type="xs:boolean" minOccurs="0"/>
 			<xs:element name="DuctSystemReplaced" type="xs:boolean" minOccurs="0"/>
 			<xs:element name="SystemPumpandZoneValveCorrectionsMade" type="xs:boolean" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
@@ -4833,10 +4409,8 @@ https://hpxml.nrel.gov/wiki/WallTypes</xs:documentation>
 					<xs:documentation>Year and month of the last tune and repair for this HVAC equipment.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="NumberofCoilsReplaced"
-				type="IntegerGreaterThanOrEqualToZero"/>
-			<xs:element minOccurs="0" name="NumberofAirHandlersReplaced"
-				type="IntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="NumberofCoilsReplaced" type="IntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="NumberofAirHandlersReplaced" type="IntegerGreaterThanOrEqualToZero"/>
 			<xs:element minOccurs="0" name="AirFilter">
 				<xs:complexType>
 					<xs:sequence>
@@ -4885,10 +4459,8 @@ https://hpxml.nrel.gov/wiki/WallTypes</xs:documentation>
 	<xs:complexType name="WaterHeaterImprovementInfo">
 		<xs:sequence>
 			<xs:element name="JacketInstalledIndicator" type="xs:boolean" minOccurs="0"/>
-			<xs:element name="DispositionofExistingSystem" type="DispositionofExistingSystem"
-				minOccurs="0"/>
-			<xs:element name="RepairsDescription" type="xs:string" minOccurs="0"
-				maxOccurs="unbounded"/>
+			<xs:element name="DispositionofExistingSystem" type="DispositionofExistingSystem" minOccurs="0"/>
+			<xs:element name="RepairsDescription" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="PipeInsulated" type="PipeInsulated" minOccurs="0"/>
 			<xs:element name="LengthofPipeInsulated" type="LengthMeasurement" minOccurs="0">
 				<xs:annotation>
@@ -4939,8 +4511,7 @@ https://hpxml.nrel.gov/wiki/WallTypes</xs:documentation>
 								<xs:documentation>Indicates which weather station is used for the modeling. It's a reference that points to Building/BuildingDetails/ClimateAndRiskZones/WeatherStation</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element maxOccurs="unbounded" name="ModeledUsage"
-							type="ModeledUsageType"/>
+						<xs:element maxOccurs="unbounded" name="ModeledUsage" type="ModeledUsageType"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
@@ -5020,8 +4591,7 @@ https://hpxml.nrel.gov/wiki/WallTypes</xs:documentation>
 			<xs:element minOccurs="0" name="ConsumptionDetails">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="ConsumptionInfo"
-							type="ConsumptionInfoType"/>
+						<xs:element maxOccurs="unbounded" name="ConsumptionInfo" type="ConsumptionInfoType"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
@@ -5065,8 +4635,7 @@ https://hpxml.nrel.gov/wiki/WallTypes</xs:documentation>
 					<xs:documentation>[Pa] positive for supply side measurements, negative for return side.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="MeasurementLocation"
-				type="AirHandlerStaticPressureMeasurementLocation"/>
+			<xs:element minOccurs="0" name="MeasurementLocation" type="AirHandlerStaticPressureMeasurementLocation"/>
 			<xs:element minOccurs="0" name="LocationDescription" type="xs:string"/>
 			<xs:element minOccurs="0" name="StaticPressureSource" type="StaticPressureSource"/>
 			<xs:element minOccurs="0" ref="extension"/>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10"
-	targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.0">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.0">
 	<!-- Value Lists -->
 	<!--Address Information Below-->
 	<xs:simpleType name="schemaVersionType">
@@ -2184,6 +2183,18 @@
 			<xs:enumeration value="inner"/>
 			<xs:enumeration value="outer"/>
 			<xs:enumeration value="nominal"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DHWControllerTechnology">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="smart"/>
+			<xs:enumeration value="timer"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DHWTemperatureControl">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="fixed"/>
+			<xs:enumeration value="variable"/>
 		</xs:restriction>
 	</xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
Fixes #172.

Add the following element under `Building/BuildingDetails/Systems/WaterHeating`.

![BaseElements_WaterHeatingControl](https://user-images.githubusercontent.com/5325034/66867163-f1d56c80-ef57-11e9-9b07-709052b6980a.png)

It also adds a boolean element `HasMixingValve` to `WaterHeatingSystem`.