### PR TITLE
Window sub-components

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -4103,7 +4103,6 @@
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element minOccurs="0" name="RValue" type="RValue"/>
-						<xs:element minOccurs="0" name="Material" type="InsulationMaterial"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -4026,78 +4026,63 @@
 				</xs:annotation>
 			</xs:element>
 			<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
-			<xs:element name="FrameType" minOccurs="0">
-				<xs:complexType>
-					<xs:choice>
-						<xs:element name="Aluminum">
-							<xs:complexType>
-								<xs:sequence>
-									<xs:element minOccurs="0" name="ThermalBreak" type="xs:boolean"/>
-									<xs:element minOccurs="0" ref="extension"/>
-								</xs:sequence>
-							</xs:complexType>
-						</xs:element>
-						<xs:element name="Composite">
-							<xs:complexType>
-								<xs:sequence>
-									<xs:element minOccurs="0" ref="extension"/>
-								</xs:sequence>
-							</xs:complexType>
-						</xs:element>
-						<xs:element name="Fiberglass">
-							<xs:complexType>
-								<xs:sequence>
-									<xs:element minOccurs="0" ref="extension"/>
-								</xs:sequence>
-							</xs:complexType>
-						</xs:element>
-						<xs:element name="Metal">
-							<xs:complexType>
-								<xs:sequence>
-									<xs:element minOccurs="0" name="ThermalBreak" type="xs:boolean"/>
-									<xs:element minOccurs="0" ref="extension"/>
-								</xs:sequence>
-							</xs:complexType>
-						</xs:element>
-						<xs:element name="Vinyl">
-							<xs:complexType>
-								<xs:sequence>
-									<xs:element minOccurs="0" ref="extension"/>
-								</xs:sequence>
-							</xs:complexType>
-						</xs:element>
-						<xs:element name="Wood">
-							<xs:complexType>
-								<xs:sequence>
-									<xs:element minOccurs="0" ref="extension"/>
-								</xs:sequence>
-							</xs:complexType>
-						</xs:element>
-						<xs:element name="Other">
-							<xs:complexType>
-								<xs:sequence>
-									<xs:element minOccurs="0" name="Description"/>
-									<xs:element minOccurs="0" ref="extension"/>
-								</xs:sequence>
-							</xs:complexType>
-						</xs:element>
-					</xs:choice>
-				</xs:complexType>
-			</xs:element>
+			<xs:element name="FrameType" minOccurs="0" type="WindowFrameType"> </xs:element>
 			<xs:element minOccurs="0" name="GlassLayers" type="GlassLayers"/>
 			<xs:element minOccurs="0" name="GlassType" type="GlassType"/>
 			<xs:element minOccurs="0" name="GasFill" type="GasFill"/>
-			<xs:element name="Treatments" type="Treatments" minOccurs="0"/>
 			<xs:element name="Condition" type="WindowCondition" minOccurs="0"/>
 			<xs:element name="UFactor" type="UFactor" minOccurs="0"/>
 			<xs:element name="SHGC" type="SHGC" minOccurs="0"/>
+			<xs:element minOccurs="0" name="VisibleTransmittance" type="Fraction"/>
 			<xs:element name="NFRCCertified" type="xs:boolean" minOccurs="0"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="WindowThirdPartyCertification"/>
-			<xs:element minOccurs="0" name="VisibleTransmittance" type="Fraction"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="WindowFilm">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:group ref="SystemInfo"/>
+						<xs:element minOccurs="0" name="ShadingFactor" type="xs:decimal"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ExteriorShading">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:group ref="SystemInfo"/>
+						<xs:element minOccurs="0" name="Type" type="ExteriorShading"/>
+						<xs:element minOccurs="0" name="ShadingFactor" type="xs:decimal"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="StormWindow">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:group ref="SystemInfo"/>
+						<xs:element minOccurs="0" name="GlassType" type="GlassType"/>
+						<xs:element minOccurs="0" name="FrameType" type="WindowFrameType"/>
+						<xs:element minOccurs="0" name="Operable" type="xs:boolean"/>
+						<xs:element minOccurs="0" name="Condition" type="WindowCondition"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="MoveableInsulation">
+				<xs:annotation>
+					<xs:documentation>Rigid opaque foam panels (permanently installed or not) or cellular shades that provide insulation. </xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:group ref="SystemInfo"/>
+						<xs:element minOccurs="0" name="RValue" type="RValue"/>
+						<xs:element minOccurs="0" name="Material" type="InsulationMaterial"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
 			<xs:element minOccurs="0" name="InteriorShading" type="InteriorShading"/>
 			<xs:element minOccurs="0" name="InteriorShadingFactorSummer" type="Fraction"/>
 			<xs:element minOccurs="0" name="InteriorShadingFactorWinter" type="Fraction"/>
-			<xs:element minOccurs="0" name="ExteriorShading" type="ExteriorShading"/>
 			<xs:element minOccurs="0" name="Overhangs">
 				<xs:complexType>
 					<xs:sequence>
@@ -4121,14 +4106,65 @@
 			</xs:element>
 			<xs:element minOccurs="0" name="WeatherStripping" type="xs:boolean"/>
 			<xs:element minOccurs="0" name="Operable" type="xs:boolean"/>
-			<xs:element minOccurs="0" name="MovableInsulationRValue" type="RValue">
-				<xs:annotation>
-					<xs:documentation>Rigid opaque foam panels (permanently installed or not) or cellular shades that provide insulation. </xs:documentation>
-				</xs:annotation>
-			</xs:element>
 			<xs:element minOccurs="0" name="LeakinessDescription" type="BuildingLeakiness"/>
 		</xs:sequence>
 	</xs:group>
+	<xs:complexType name="WindowFrameType">
+		<xs:choice>
+			<xs:element name="Aluminum">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="ThermalBreak" type="xs:boolean"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Composite">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Fiberglass">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Metal">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="ThermalBreak" type="xs:boolean"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Vinyl">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Wood">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Other">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="Description"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:choice>
+	</xs:complexType>
 	<xs:complexType name="AssociationsType">
 		<xs:all minOccurs="0">
 			<xs:element name="Job" minOccurs="0">

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -4215,12 +4215,12 @@
 						<xs:element minOccurs="0" name="Type" type="ExteriorShading"/>
 						<xs:element minOccurs="0" name="SummerShadingCoefficient" type="Fraction">
 							<xs:annotation>
-								<xs:documentation>The shading coefficient to apply during the summer months. Shading coefficients are defined as a multiplier on tranmittance: 1 is transparent, 0 is opaque. </xs:documentation>
+								<xs:documentation>The shading coefficient to apply during the summer months. Shading coefficients are defined as a multiplier on transmittance: 1 is transparent, 0 is opaque. </xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element minOccurs="0" name="WinterShadingCoefficient" type="Fraction">
 							<xs:annotation>
-								<xs:documentation>The shading coefficient to apply during the winter months. Shading coefficients are defined as a multiplier on tranmittance: 1 is transparent, 0 is opaque. </xs:documentation>
+								<xs:documentation>The shading coefficient to apply during the winter months. Shading coefficients are defined as a multiplier on transmittance: 1 is transparent, 0 is opaque. </xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
@@ -4239,12 +4239,12 @@ If moveable insulation also provides shading, the shading should be documented h
 						<xs:element minOccurs="0" name="Type" type="InteriorShading"/>
 						<xs:element minOccurs="0" name="SummerShadingCoefficient" type="Fraction">
 							<xs:annotation>
-								<xs:documentation>The shading coefficient to apply during the summer months. Shading coefficients are defined as a multiplier on tranmittance: 1 is transparent, 0 is opaque. </xs:documentation>
+								<xs:documentation>The shading coefficient to apply during the summer months. Shading coefficients are defined as a multiplier on transmittance: 1 is transparent, 0 is opaque. </xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element minOccurs="0" name="WinterShadingCoefficient" type="Fraction">
 							<xs:annotation>
-								<xs:documentation>The shading coefficient to apply during the winter months. Shading coefficients are defined as a multiplier on tranmittance: 1 is transparent, 0 is opaque. </xs:documentation>
+								<xs:documentation>The shading coefficient to apply during the winter months. Shading coefficients are defined as a multiplier on transmittance: 1 is transparent, 0 is opaque. </xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -4073,6 +4073,11 @@
 				</xs:complexType>
 			</xs:element>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="InteriorShading">
+				<xs:annotation>
+					<xs:documentation>Used to describe drapes, blinds, etc. 
+
+If moveable insulation also provides shading, the shading should be documented here. </xs:documentation>
+				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -1749,8 +1749,7 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="Manufacturer"
-										type="Manufacturer"/>
+									<xs:element minOccurs="0" name="Manufacturer" type="Manufacturer"/>
 									<xs:element minOccurs="0" name="ModelNumber" type="Model"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="xs:string"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
@@ -1761,16 +1760,13 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="BatteryType" type="BatteryType"/>
-									<xs:element minOccurs="0" name="CoolingStrategy"
-										type="BatteryCoolingStrategy"/>
-									<xs:element minOccurs="0" name="NominalCapacity"
-										type="BatteryCapacity">
+									<xs:element minOccurs="0" name="CoolingStrategy" type="BatteryCoolingStrategy"/>
+									<xs:element minOccurs="0" name="NominalCapacity" type="BatteryCapacity">
 										<xs:annotation>
 											<xs:documentation>[Ah] The total Ampere hours available when the battery is discharged starting from 100% state of charge until it reaches the cut-off voltage. Capacity is computed by multiplying the discharge current (Amps) by the discharge time (hours).</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="UsableCapacity"
-										type="BatteryCapacity">
+									<xs:element minOccurs="0" name="UsableCapacity" type="BatteryCapacity">
 										<xs:annotation>
 											<xs:documentation>[Ah] The stored energy that can actually be used. In most cases usable capacity is less than the nominal capacity.</xs:documentation>
 										</xs:annotation>
@@ -1785,14 +1781,12 @@
 											<xs:documentation>[W] The peak power that the battery can generate for a short period of time.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NominalVoltage"
-										type="xs:decimal">
+									<xs:element minOccurs="0" name="NominalVoltage" type="xs:decimal">
 										<xs:annotation>
 											<xs:documentation>[V] The nominal voltage is the battery voltage when the state of charge is 0.5 (midway between being fully charged, and fully discharged) with a 0.2C discharge current.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RoundTripEfficiency"
-										type="Fraction">
+									<xs:element minOccurs="0" name="RoundTripEfficiency" type="Fraction">
 										<xs:annotation>
 											<xs:documentation>Not all the power that is used to charge the battery is available during discharge. Round trip efficiency is the ratio of the energy put in to the energy retrieved from storage.</xs:documentation>
 										</xs:annotation>
@@ -3621,14 +3615,12 @@
 											<xs:documentation>Many verifications or certifications have a rating system that provides an indication of the structure's level of energy efficiency. When expressed in a numeric value, please use the GreenVerificationMetric field. Verifications and Certifications can also be a name, such as Gold or Silver, which is the purpose of this field.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Source"
-										type="GreenBuildingVerificationSource">
+									<xs:element minOccurs="0" name="Source" type="GreenBuildingVerificationSource">
 										<xs:annotation>
 											<xs:documentation>The source of the green data. May address photovoltaic characteristics, or a verified score, certification, label, etc. This may be a pick list of options showing the source. i.e. Program Sponsor, Program Verifier, Public Record, Assessor, etc.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Status"
-										type="GreenBuildingVerificationStatus">
+									<xs:element minOccurs="0" name="Status" type="GreenBuildingVerificationStatus">
 										<xs:annotation>
 											<xs:documentation>Many verification programs include a multi-step process that may begin with plans and specs, involve testing and/or submission of building specifications along the way and include a final verification step. When ratings are involved it is not uncommon for the final rating to be either higher or lower than the target preliminary rating. Sometimes the final approval is not available until after sale and occupancy. Status indicates what the target was at the time of listing and may be updated when verification is complete. To limit liability concerns this field reflects information that was available at the time of listing or updated later and should be confirmed by the buyer.</xs:documentation>
 										</xs:annotation>
@@ -4221,8 +4213,16 @@
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element minOccurs="0" name="Type" type="ExteriorShading"/>
-						<xs:element minOccurs="0" name="SummerShadingFactor" type="Fraction"/>
-						<xs:element minOccurs="0" name="WinterShadingFactor" type="Fraction"/>
+						<xs:element minOccurs="0" name="SummerShadingCoefficient" type="Fraction">
+							<xs:annotation>
+								<xs:documentation>The shading coefficient to apply during the summer months. Shading coefficients are defined as a multiplier on tranmittance: 1 is transparent, 0 is opaque. </xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="WinterShadingCoefficient" type="Fraction">
+							<xs:annotation>
+								<xs:documentation>The shading coefficient to apply during the winter months. Shading coefficients are defined as a multiplier on tranmittance: 1 is transparent, 0 is opaque. </xs:documentation>
+							</xs:annotation>
+						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -4237,8 +4237,16 @@ If moveable insulation also provides shading, the shading should be documented h
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element minOccurs="0" name="Type" type="InteriorShading"/>
-						<xs:element minOccurs="0" name="SummerShadingFactor" type="Fraction"/>
-						<xs:element minOccurs="0" name="WinterShadingFactor" type="Fraction"/>
+						<xs:element minOccurs="0" name="SummerShadingCoefficient" type="Fraction">
+							<xs:annotation>
+								<xs:documentation>The shading coefficient to apply during the summer months. Shading coefficients are defined as a multiplier on tranmittance: 1 is transparent, 0 is opaque. </xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="WinterShadingCoefficient" type="Fraction">
+							<xs:annotation>
+								<xs:documentation>The shading coefficient to apply during the winter months. Shading coefficients are defined as a multiplier on tranmittance: 1 is transparent, 0 is opaque. </xs:documentation>
+							</xs:annotation>
+						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -4066,7 +4066,19 @@
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element minOccurs="0" name="Type" type="ExteriorShading"/>
-						<xs:element minOccurs="0" name="ShadingFactor" type="xs:decimal"/>
+						<xs:element minOccurs="0" name="SummerShadingFactor" type="Fraction"/>
+						<xs:element minOccurs="0" name="WinterShadingFactor" type="Fraction"/>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="InteriorShading">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:group ref="SystemInfo"/>
+						<xs:element minOccurs="0" name="Type" type="InteriorShading"/>
+						<xs:element minOccurs="0" name="SummerShadingFactor" type="Fraction"/>
+						<xs:element minOccurs="0" name="WinterShadingFactor" type="Fraction"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>
@@ -4096,9 +4108,6 @@
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="InteriorShading" type="InteriorShading"/>
-			<xs:element minOccurs="0" name="InteriorShadingFactorSummer" type="Fraction"/>
-			<xs:element minOccurs="0" name="InteriorShadingFactorWinter" type="Fraction"/>
 			<xs:element minOccurs="0" name="Overhangs">
 				<xs:complexType>
 					<xs:sequence>
@@ -4889,10 +4898,8 @@
 			<xs:sequence>
 				<xs:group ref="SystemInfo"/>
 				<xs:element name="IsConnected" type="xs:boolean"/>
-				<xs:element maxOccurs="unbounded" minOccurs="0" name="CommunicatesWith"
-					type="LocalReference"/>
-				<xs:element minOccurs="0" name="CommunicationProtocol"
-					type="ConnectedDeviceCommunicationProtocol" maxOccurs="unbounded"/>
+				<xs:element maxOccurs="unbounded" minOccurs="0" name="CommunicatesWith" type="LocalReference"/>
+				<xs:element minOccurs="0" name="CommunicationProtocol" type="ConnectedDeviceCommunicationProtocol" maxOccurs="unbounded"/>
 				<xs:element minOccurs="0" name="DemandResponseCapability" type="xs:boolean"/>
 				<xs:element minOccurs="0" name="OccupancySensor" type="xs:boolean"/>
 				<xs:element minOccurs="0" ref="extension"/>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -4203,7 +4203,11 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
-						<xs:element minOccurs="0" name="ShadingFactor" type="xs:decimal"/>
+						<xs:element minOccurs="0" name="ShadingCoefficient" type="Fraction">
+							<xs:annotation>
+								<xs:documentation>Shading coefficients are defined as a multiplier on transmittance: 1 is transparent, 0 is opaque. </xs:documentation>
+							</xs:annotation>
+						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 				</xs:complexType>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -850,8 +850,6 @@
 			<xs:enumeration value="double-pane"/>
 			<xs:enumeration value="triple-pane"/>
 			<xs:enumeration value="multi-layered"/>
-			<xs:enumeration value="single-paned with storms"/>
-			<xs:enumeration value="single-paned with low-e storms"/>
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
@@ -889,13 +887,6 @@
 			<xs:enumeration value="building"/>
 			<xs:enumeration value="other"/>
 			<xs:enumeration value="none"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="Treatments">
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="window film"/>
-			<xs:enumeration value="solar screen"/>
-			<xs:enumeration value="shading"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="UFactor">


### PR DESCRIPTION
Fixes #12.

Moving a bunch of window features into separate sub components with their own ids.

![BaseElements_WindowInfo](https://user-images.githubusercontent.com/5325034/66872850-294a1600-ef64-11e9-9225-ddcb97437e32.png)

Questions:
- `MoveableInsulation/Material` uses the [same list](https://hpxml.nrel.gov/datadictionary/3/Building/BuildingDetails/Enclosure/Walls/Wall/Insulation/Layer/InsulationMaterial) that's in any other insulation element. Is that appropriate here?
- Should `Overhangs` be connected to or under `ExteriorShading`?
- Should interior shading be similarly described?
- Did I miss anything?