### PR TITLE
Additional AdjacentTo enumerations

### DIFF
--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -607,6 +607,8 @@
 			<xs:enumeration value="living space"/>
 			<xs:enumeration value="other"/>
 			<xs:enumeration value="other housing unit"/>
+			<xs:enumeration value="other housing unit above"/>
+			<xs:enumeration value="other housing unit below"/>
 			<xs:enumeration value="outside"/>
 			<xs:enumeration value="unconditioned space"/>
 		</xs:restriction>


### PR DESCRIPTION
Adds "other housing unit above" and "other housing unit below" enumerations for `AdjacentTo`. The "other housing unit" enumeration is still available.

Usually you can infer whether a `FrameFloor` is actually a ceiling or floor surface. For example: 
- A `FrameFloor` with InteriorAdjacentTo="living space" and ExteriorAdjacentTo="attic - vented" is clearly a ceiling below the attic 
- A `FrameFloor` with InteriorAdjacentTo="living space" and ExteriorAdjacentTo="basement - unconditioned" is clearly a floor above a basement

But if you have a `FrameFloor` with InteriorAdjacentTo="living space" and ExteriorAdjacentTo="other housing unit" it is impossible to infer. With this change, you can clarify the ExteriorAdjacentTo as either "other housing unit above" (i.e., ceiling) or "other housing unit below" (i.e., floor).