### PR TITLE
Allows DuctSurfaceArea to be 0

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -3121,7 +3121,7 @@
 									the fraction of the total duct area. </xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DuctSurfaceArea" type="SurfaceArea">
+						<xs:element minOccurs="0" name="DuctSurfaceArea" type="DuctSurfaceArea">
 							<xs:annotation>
 								<xs:documentation>[sq.ft.]</xs:documentation>
 							</xs:annotation>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1417,6 +1417,11 @@
 	</xs:simpleType>
 	<xs:simpleType name="SurfaceArea">
 		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DuctSurfaceArea">
+		<xs:restriction base="xs:double">
 			<xs:minInclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1417,7 +1417,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="SurfaceArea">
 		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
+			<xs:minInclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TransactionType">


### PR DESCRIPTION
Previously `DuctSurfaceArea` had to be greater than zero, now it has to be greater than _or equal to_ zero. This allows, for example, describing a ducted evaporative cooler, where you want to declare that there is zero return duct area. (Leaving out a return `Duct` is not the same thing, as it could mean that the return duct information is simply unknown.)