### PR TITLE
Clarify NumberofConditionedFloorsAboveGrade should include walkout basements

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -3553,7 +3553,7 @@
 									</xs:element>
 									<xs:element minOccurs="0" name="NumberofConditionedFloorsAboveGrade" type="NumberOfFloorsType">
 										<xs:annotation>
-											<xs:documentation>Number of floors above grade that are heated/cooled</xs:documentation>
+											<xs:documentation>Number of floors above grade that are heated/cooled including a walkout basement</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element name="AverageCeilingHeight" type="LengthMeasurement" minOccurs="0">


### PR DESCRIPTION
Previously:
- `NumberofConditionedFloors`: Number of floors that are heated/cooled including a basement
- `NumberofConditionedFloorsAboveGrade`: Number of floors above grade that are heated/cooled

Now:
- `NumberofConditionedFloors`: Number of floors that are heated/cooled including a basement
- `NumberofConditionedFloorsAboveGrade`: Number of floors above grade that are heated/cooled  **including a walkout basement**
