### PR TITLE
Adds Dishwasher/ClothesWasher label fields

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -346,6 +346,21 @@
 							<xs:documentation>loads/week</xs:documentation>
 						</xs:annotation>
 					</xs:element>
+					<xs:element minOccurs="0" name="LabelElectricRate" type="HPXMLDouble">
+						<xs:annotation>
+							<xs:documentation>$/kWh</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element minOccurs="0" name="LabelGasRate" type="HPXMLDouble">
+						<xs:annotation>
+							<xs:documentation>$/therm</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element minOccurs="0" name="LabelAnnualGasCost" type="HPXMLDouble">
+						<xs:annotation>
+							<xs:documentation>$</xs:documentation>
+						</xs:annotation>
+					</xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -242,7 +242,7 @@
 					<xs:element name="FuelType" type="FuelType" minOccurs="0"/>
 					<xs:element minOccurs="0" name="Usage" type="HPXMLDouble">
 						<xs:annotation>
-							<xs:documentation>loads/week</xs:documentation>
+							<xs:documentation>loads/week of actual usage by the occupants</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element minOccurs="0" name="EnergyFactor" type="HPXMLDouble">
@@ -294,7 +294,7 @@
 					</xs:element>
 					<xs:element minOccurs="0" name="Usage" type="HPXMLDouble">
 						<xs:annotation>
-							<xs:documentation>loads/week</xs:documentation>
+							<xs:documentation>loads/week of actual usage by the occupants; use LabelUsage instead for the loads/week on the EnergyGuide label</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element minOccurs="0" name="RatedAnnualkWh" type="RatedAnnualkWh">
@@ -319,7 +319,7 @@
 					</xs:element>
 					<xs:element minOccurs="0" name="LabelUsage" type="HPXMLDouble">
 						<xs:annotation>
-							<xs:documentation>loads/week per the Energy Guide label</xs:documentation>
+							<xs:documentation>loads/week per the Energy Guide label; use Usage instead for loads/week of actual usage by the occupants</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element minOccurs="0" name="Capacity" type="HPXMLDouble">
@@ -348,7 +348,7 @@
 					<xs:element minOccurs="0" name="PlaceSettingCapacity" type="IntegerGreaterThanZero"/>
 					<xs:element minOccurs="0" name="Usage" type="HPXMLDouble">
 						<xs:annotation>
-							<xs:documentation>loads/week</xs:documentation>
+							<xs:documentation>loads/week of actual usage by the occupants; use LabelUsage instead for the loads/week on the EnergyGuide label</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element minOccurs="0" name="LabelElectricRate" type="HPXMLDouble">
@@ -368,7 +368,7 @@
 					</xs:element>
 					<xs:element minOccurs="0" name="LabelUsage" type="HPXMLDouble">
 						<xs:annotation>
-							<xs:documentation>loads/week per the Energy Guide label</xs:documentation>
+							<xs:documentation>loads/week per the Energy Guide label; use Usage instead for loads/week of actual usage by the occupants</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element ref="extension" minOccurs="0"/>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -317,6 +317,11 @@
 							<xs:documentation>$</xs:documentation>
 						</xs:annotation>
 					</xs:element>
+					<xs:element minOccurs="0" name="LabelUsage" type="HPXMLDouble">
+						<xs:annotation>
+							<xs:documentation>loads/week per the Energy Guide label</xs:documentation>
+						</xs:annotation>
+					</xs:element>
 					<xs:element minOccurs="0" name="Capacity" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>ft^3</xs:documentation>
@@ -359,6 +364,11 @@
 					<xs:element minOccurs="0" name="LabelAnnualGasCost" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>$</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element minOccurs="0" name="LabelUsage" type="HPXMLDouble">
+						<xs:annotation>
+							<xs:documentation>loads/week per the Energy Guide label</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element ref="extension" minOccurs="0"/>


### PR DESCRIPTION
Adds Energy Guide Label fields for Dishwashers; uses the same names that ClothesWashers use.
- `LabelElectricRate`
- `LabelGasRate`
- `LabelAnnualGasCost`

Also adds `LabelUsage` to both Dishwashers and ClothesWashers, to make a distinction between the cycles/week used in the label/rating and the cycles/week of actual operation (`Usage`).