### PR TITLE
PerformanceAdjustment clarification

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -1378,7 +1378,11 @@
 									<xs:element name="ModelNumber" type="Model" minOccurs="0"/>
 									<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
-									<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction"/>
+									<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction">
+										<xs:annotation>
+											<xs:documentation>A multiplier on the performance of the system. A value of 1 implies no performance adjustment.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
 									<xs:element minOccurs="0" name="ThirdPartyCertification" type="DHWThirdPartyCertification" maxOccurs="unbounded"/>
 									<xs:element name="TankVolume" type="Volume" minOccurs="0">
 										<xs:annotation>
@@ -3013,7 +3017,11 @@
 			<xs:element name="ModelNumber" type="Model" minOccurs="0"/>
 			<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
-			<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction"/>
+			<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction">
+				<xs:annotation>
+					<xs:documentation>A multiplier on the performance of the system. A value of 1 implies no performance adjustment.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="HVACThirdPartyCertification"/>
 			<xs:element minOccurs="0" name="HasSharedCombustionVentilation" type="HPXMLBoolean"/>
 			<xs:element minOccurs="0" name="CombustionVentingSystem" type="LocalReference"/>


### PR DESCRIPTION
Documents that the `PerformanceAdjustment` elements for HVAC and water heaters should be entered as a multiplier (instead of, e.g., an adder).