### PR TITLE
Shared DHW Systems and Appliances

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -230,6 +230,11 @@
 			<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 			<xs:element name="ModelYear" type="Year" minOccurs="0"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="ApplianceThirdPartyCertifications"/>
+			<xs:element minOccurs="0" name="IsSharedAppliance" type="xs:boolean">
+				<xs:annotation>
+					<xs:documentation>Does the appliance serve multiple building/dwelling units?</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -274,7 +274,7 @@
 
 				<xs:sequence>
 					<xs:choice minOccurs="0">
-						<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference" maxOccurs="unbounded"/>
+						<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference" maxOccurs="1"/>
 						<xs:element name="AttachedToHotWaterDistribution" type="LocalReference"/>
 					</xs:choice>
 					<xs:element name="Type" type="ClothesWasherType" minOccurs="0"/>
@@ -343,7 +343,7 @@
 			<xs:extension base="ApplianceTypeSummaryInfo">
 				<xs:sequence>
 					<xs:choice minOccurs="0">
-						<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference" maxOccurs="unbounded"/>
+						<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference" maxOccurs="1"/>
 						<xs:element name="AttachedToHotWaterDistribution" type="LocalReference"/>
 					</xs:choice>
 					<xs:element minOccurs="0" name="Type" type="DishwasherType"/>
@@ -1379,6 +1379,11 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
+									<xs:element minOccurs="0" name="HotWaterDistributionSystem" type="LocalReference" maxOccurs="1">
+										<xs:annotation>
+											<xs:documentation>The hot water distribution system served by this water heating system.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
 									<xs:element minOccurs="0" ref="AttachedToZone"/>
 									<xs:element minOccurs="0" name="AttachedToCAZ" type="LocalReference"/>
@@ -1541,9 +1546,9 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="AttachedToWaterHeatingSystem" type="LocalReference" maxOccurs="unbounded">
+									<xs:element minOccurs="0" name="AttachedToWaterHeatingSystem" type="LocalReference" maxOccurs="1">
 										<xs:annotation>
-											<xs:documentation>The water heating system that this distribution system serves.</xs:documentation>
+											<xs:documentation>DEPRECATED. This will be removed in v4.0. Use WaterHeatingSystem/HotWaterDistributionSystem instead.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="SystemType">
@@ -1621,7 +1626,7 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:choice minOccurs="0">
-										<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference" maxOccurs="unbounded"/>
+										<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference" maxOccurs="1"/>
 										<xs:element name="AttachedToHotWaterDistribution" type="LocalReference"/>
 									</xs:choice>
 									<xs:element minOccurs="1" name="WaterFixtureType" type="WaterFixtureType"/>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -274,7 +274,7 @@
 
 				<xs:sequence>
 					<xs:choice minOccurs="0">
-						<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference"/>
+						<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference" maxOccurs="unbounded"/>
 						<xs:element name="AttachedToHotWaterDistribution" type="LocalReference"/>
 					</xs:choice>
 					<xs:element name="Type" type="ClothesWasherType" minOccurs="0"/>
@@ -343,7 +343,7 @@
 			<xs:extension base="ApplianceTypeSummaryInfo">
 				<xs:sequence>
 					<xs:choice minOccurs="0">
-						<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference"/>
+						<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference" maxOccurs="unbounded"/>
 						<xs:element name="AttachedToHotWaterDistribution" type="LocalReference"/>
 					</xs:choice>
 					<xs:element minOccurs="0" name="Type" type="DishwasherType"/>
@@ -1541,7 +1541,7 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="AttachedToWaterHeatingSystem" type="LocalReference">
+									<xs:element minOccurs="0" name="AttachedToWaterHeatingSystem" type="LocalReference" maxOccurs="unbounded">
 										<xs:annotation>
 											<xs:documentation>The water heating system that this distribution system serves.</xs:documentation>
 										</xs:annotation>
@@ -1621,7 +1621,7 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:choice minOccurs="0">
-										<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference"/>
+										<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference" maxOccurs="unbounded"/>
 										<xs:element name="AttachedToHotWaterDistribution" type="LocalReference"/>
 									</xs:choice>
 									<xs:element minOccurs="1" name="WaterFixtureType" type="WaterFixtureType"/>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -274,7 +274,7 @@
 
 				<xs:sequence>
 					<xs:choice minOccurs="0">
-						<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference" maxOccurs="1"/>
+						<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference"/>
 						<xs:element name="AttachedToHotWaterDistribution" type="LocalReference"/>
 					</xs:choice>
 					<xs:element name="Type" type="ClothesWasherType" minOccurs="0"/>
@@ -343,7 +343,7 @@
 			<xs:extension base="ApplianceTypeSummaryInfo">
 				<xs:sequence>
 					<xs:choice minOccurs="0">
-						<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference" maxOccurs="1"/>
+						<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference"/>
 						<xs:element name="AttachedToHotWaterDistribution" type="LocalReference"/>
 					</xs:choice>
 					<xs:element minOccurs="0" name="Type" type="DishwasherType"/>
@@ -1546,7 +1546,7 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="AttachedToWaterHeatingSystem" type="LocalReference" maxOccurs="1">
+									<xs:element minOccurs="0" name="AttachedToWaterHeatingSystem" type="LocalReference">
 										<xs:annotation>
 											<xs:documentation>DEPRECATED. This will be removed in v4.0. Use WaterHeatingSystem/HotWaterDistributionSystem instead.</xs:documentation>
 										</xs:annotation>
@@ -1626,7 +1626,7 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:choice minOccurs="0">
-										<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference" maxOccurs="1"/>
+										<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference"/>
 										<xs:element name="AttachedToHotWaterDistribution" type="LocalReference"/>
 									</xs:choice>
 									<xs:element minOccurs="1" name="WaterFixtureType" type="WaterFixtureType"/>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -268,6 +268,10 @@
 			<xs:extension base="ApplianceTypeSummaryInfo">
 
 				<xs:sequence>
+					<xs:choice minOccurs="0">
+						<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference"/>
+						<xs:element name="AttachedToHotWaterDistribution" type="LocalReference"/>
+					</xs:choice>
 					<xs:element name="Type" type="ClothesWasherType" minOccurs="0"/>
 					<xs:element minOccurs="0" name="Location" type="LaundryMachineLocation"/>
 					<xs:element name="ModifiedEnergyFactor" type="HPXMLDouble" minOccurs="0">
@@ -333,6 +337,10 @@
 		<xs:complexContent>
 			<xs:extension base="ApplianceTypeSummaryInfo">
 				<xs:sequence>
+					<xs:choice minOccurs="0">
+						<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference"/>
+						<xs:element name="AttachedToHotWaterDistribution" type="LocalReference"/>
+					</xs:choice>
 					<xs:element minOccurs="0" name="Type" type="DishwasherType"/>
 					<xs:element minOccurs="0" name="Fuel" type="FuelType"/>
 					<xs:element name="HeatDryDefaultOff" type="HPXMLBoolean" minOccurs="0"/>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -235,6 +235,7 @@
 					<xs:documentation>Does the appliance serve multiple building/dwelling units?</xs:documentation>
 				</xs:annotation>
 			</xs:element>
+			<xs:element minOccurs="0" name="NumberofUnitsServed" type="xs:integer"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -1378,6 +1378,12 @@
 									<xs:element name="ModelNumber" type="Model" minOccurs="0"/>
 									<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
+									<xs:element minOccurs="0" name="IsSharedSystem" type="xs:boolean">
+										<xs:annotation>
+											<xs:documentation>Does the system serve multiple building/dwelling units or a shared laundry/equipment room?</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="NumberofUnitsServed" type="xs:integer"/>
 									<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction"/>
 									<xs:element minOccurs="0" name="ThirdPartyCertification" type="DHWThirdPartyCertification" maxOccurs="unbounded"/>
 									<xs:element name="TankVolume" type="Volume" minOccurs="0">

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -1725,7 +1725,15 @@
 											<xs:documentation>[gal]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="ConnectedTo" type="LocalReference"/>
+									<xs:choice minOccurs="0">
+										<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference"/>
+										<xs:element name="AttachedToHotWaterDistribution" type="LocalReference"/>
+									</xs:choice>
+									<xs:element minOccurs="0" name="ConnectedTo" type="LocalReference">
+										<xs:annotation>
+											<xs:documentation>DEPRECATED. This will be removed in v4.0. Use AttachedToWaterHeatingSystem or AttachedToHotWaterDistribution instead.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
 									<xs:element minOccurs="0" name="SolarFraction" type="SolarFraction">
 										<xs:annotation>
 											<xs:documentation>The Solar Fraction is the portion of the total conventional hot water heating load (delivered energy and tank standby losses). The higher


### PR DESCRIPTION
Changes:
- Adds `IsSharedSystem` and `NumberofUnitsServed` elements for WaterHeatingSystems to describe water heaters either A) serving multiple dwelling units or B) serving a shared laundry room.
- Adds `IsSharedAppliance` and `NumberofUnitsServed` elements for all appliances to describe appliances in a shared laundry room.
- Allows `ClothesWashers` and `Dishwashers` to be attached to DHW systems (via `AttachedToWaterHeatingSystem` or `AttachedToHotWaterDistribution`), as was already the case for `WaterFixtures`. Also adds these two elements to `SolarThermalSystem` for more consistency/clarity and marks existing (ambiguous) `ConnectedTo` as deprecated.
- Adds `WaterHeatingSystem/HotWaterDistributionSystem` to be used instead of `HotWaterDistribution/AttachedToWaterHeatingSystem`, marks the latter as deprecated. The new element A) can support multiple water heaters connected to a single distribution system and B) is more consistent with HVAC systems (e.g., `HeatingSystem/DistributionSystem`).