### PR TITLE
Shared PV Systems

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -1733,6 +1733,12 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
+									<xs:element minOccurs="0" name="IsSharedSystem" type="HPXMLBoolean">
+										<xs:annotation>
+											<xs:documentation>Does the system serve multiple building/dwelling units?</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="NumberofUnitsServed" type="HPXMLInteger"/>
 									<xs:element minOccurs="0" name="Location" type="PVSystemLocation"/>
 									<xs:element minOccurs="0" name="Ownership" type="PVSystemOwnership"/>
 									<xs:element minOccurs="0" name="ModuleType" type="PVModuleType"> </xs:element>
@@ -1748,17 +1754,17 @@
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="MaxPowerOutput" type="Power">
+									<xs:element minOccurs="0" name="MaxPowerOutput" type="PVSystemMaxPowerOutput" maxOccurs="unbounded">
 										<xs:annotation>
 											<xs:documentation>[DC Watts] Peak power as supplied by the manufacturer</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="CollectorArea" type="PVSystemCollectorArea" maxOccurs="unbounded">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberOfPanels" type="IntegerGreaterThanZero"/>
+									<xs:element minOccurs="0" name="NumberOfPanels" type="PVSystemNumberOfPanels" maxOccurs="unbounded"/>
 									<xs:element minOccurs="0" name="InverterEfficiency" type="Fraction"/>
 									<xs:element minOccurs="0" name="SystemLossesFraction" type="Fraction">
 										<xs:annotation>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -4530,4 +4530,40 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+	<xs:simpleType name="PVSystemMaxPowerOutput_simple">
+		<xs:restriction base="Power_simple"/>
+	</xs:simpleType>
+	<xs:complexType name="PVSystemMaxPowerOutput">
+		<xs:simpleContent>
+			<xs:extension base="PVSystemMaxPowerOutput_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="PVSystemCollectorArea_simple">
+		<xs:restriction base="SurfaceArea_simple"/>
+	</xs:simpleType>
+	<xs:complexType name="PVSystemCollectorArea">
+		<xs:simpleContent>
+			<xs:extension base="PVSystemCollectorArea_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="PVSystemNumberOfPanels_simple">
+		<xs:restriction base="IntegerGreaterThanZero_simple"/>
+	</xs:simpleType>
+	<xs:complexType name="PVSystemNumberOfPanels">
+		<xs:simpleContent>
+			<xs:extension base="PVSystemNumberOfPanels_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="DataScope">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="single unit"/>
+			<xs:enumeration value="multiple units"/>
+		</xs:restriction>
+	</xs:simpleType>
 </xs:schema>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -4537,6 +4537,7 @@
 		<xs:simpleContent>
 			<xs:extension base="PVSystemMaxPowerOutput_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
+				<xs:attribute name="scope" type="DataScope"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4547,6 +4548,7 @@
 		<xs:simpleContent>
 			<xs:extension base="PVSystemCollectorArea_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
+				<xs:attribute name="scope" type="DataScope"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -4557,6 +4559,7 @@
 		<xs:simpleContent>
 			<xs:extension base="PVSystemNumberOfPanels_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
+				<xs:attribute name="scope" type="DataScope"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>


### PR DESCRIPTION
Adds `IsSharedSystem` and `NumberofUnitsServed` for PVSystems. Also allows scope attribute ("single unit" or "multiple units") for some elements (`MaxPowerOutput`, `CollectorArea`, and `NumberOfPanels`).