### PR TITLE
Adds PerformanceClass element for fenestration

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.0">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10"
+	targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.0">
 	<xs:include schemaLocation="HPXMLDataTypes.xsd"/>
 	<xs:element name="XMLTransactionHeaderInformation">
 		<xs:annotation>
@@ -38,10 +39,14 @@
 				systems, and have it identified in the two systems. Also, there is an id attribute to define a local id to be used internally. </xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType" minOccurs="0"/>
-			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue" minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType" minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue" minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType"
+				minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue"
+				minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType"
+				minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue"
+				minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="id" type="xs:ID" use="required">
 			<xs:annotation>
@@ -65,10 +70,14 @@
 				elements in other xml transactions.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType" minOccurs="0"/>
-			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue" minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType" minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue" minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType"
+				minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue"
+				minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType"
+				minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue"
+				minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="id" type="xs:IDREF">
 			<xs:annotation>
@@ -127,7 +136,8 @@
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="IndividualType" type="IndividualType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="Telephone" type="TelephoneInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="Telephone"
+				type="TelephoneInfoType"/>
 			<xs:element minOccurs="0" maxOccurs="unbounded" name="Email" type="EmailInfoType"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
@@ -144,9 +154,11 @@
 				<xs:element minOccurs="0" name="MeterNumber" type="HPXMLString"/>
 				<xs:element name="UtilityAccountNumber" type="HPXMLString" minOccurs="0"/>
 				<xs:element minOccurs="0" name="Permission" type="HPXMLBoolean"/>
-				<xs:element name="UtilityServiceTypeProvided" type="ConsumptionType" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element name="UtilityServiceTypeProvided" type="ConsumptionType" minOccurs="0"
+					maxOccurs="unbounded"/>
 				<xs:element minOccurs="0" name="BusinessInfo" type="BusinessInfoType"/>
-				<xs:element maxOccurs="unbounded" minOccurs="0" name="BusinessContactInfo" type="BusinessContactInfoType"/>
+				<xs:element maxOccurs="unbounded" minOccurs="0" name="BusinessContactInfo"
+					type="BusinessContactInfoType"/>
 				<xs:element ref="extension" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attribute name="dataSource" type="DataSource"/>
@@ -199,7 +211,8 @@
 				<xs:complexType>
 					<xs:sequence maxOccurs="1">
 						<xs:element name="InstallationType" type="InstallationType" minOccurs="0"/>
-						<xs:element name="InsulationMaterial" type="InsulationMaterial" minOccurs="0"/>
+						<xs:element name="InsulationMaterial" type="InsulationMaterial"
+							minOccurs="0"/>
 						<xs:element name="NominalRValue" type="RValue" minOccurs="0"/>
 						<xs:element name="Thickness" type="LengthMeasurement" minOccurs="0">
 							<xs:annotation>
@@ -229,7 +242,8 @@
 			<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 			<xs:element name="ModelYear" type="Year" minOccurs="0"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="ApplianceThirdPartyCertifications"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification"
+				type="ApplianceThirdPartyCertifications"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
@@ -257,7 +271,8 @@
 								drying cycle energy as well as energy consumed during Stand-by and Off modes.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element maxOccurs="unbounded" minOccurs="0" name="ControlType" type="ClothesDryerControlType"> </xs:element>
+					<xs:element maxOccurs="unbounded" minOccurs="0" name="ControlType"
+						type="ClothesDryerControlType"> </xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -276,7 +291,8 @@
 								Factor.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="IntegratedModifiedEnergyFactor" type="HPXMLDouble" minOccurs="0">
+					<xs:element name="IntegratedModifiedEnergyFactor" type="HPXMLDouble"
+						minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>The energy performance metric for ENERGY STAR certified residential clothes washers as of March 7, 2015.</xs:documentation>
 						</xs:annotation>
@@ -336,11 +352,14 @@
 					<xs:element minOccurs="0" name="Type" type="DishwasherType"/>
 					<xs:element minOccurs="0" name="Fuel" type="FuelType"/>
 					<xs:element name="HeatDryDefaultOff" type="HPXMLBoolean" minOccurs="0"/>
-					<xs:element name="AuxillaryWaterHeaterDefaultOff" type="HPXMLBoolean" minOccurs="0"/>
+					<xs:element name="AuxillaryWaterHeaterDefaultOff" type="HPXMLBoolean"
+						minOccurs="0"/>
 					<xs:element minOccurs="0" name="RatedAnnualkWh" type="RatedAnnualkWh"/>
 					<xs:element minOccurs="0" name="EnergyFactor" type="EnergyFactor"/>
-					<xs:element minOccurs="0" name="RatedWaterGalPerCycle" type="RatedWaterGalPerCycle"/>
-					<xs:element minOccurs="0" name="PlaceSettingCapacity" type="IntegerGreaterThanZero"/>
+					<xs:element minOccurs="0" name="RatedWaterGalPerCycle"
+						type="RatedWaterGalPerCycle"/>
+					<xs:element minOccurs="0" name="PlaceSettingCapacity"
+						type="IntegerGreaterThanZero"/>
 					<xs:element minOccurs="0" name="Usage" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>loads/week</xs:documentation>
@@ -441,7 +460,8 @@
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element name="SoftwareProgramUsed" type="SoftwareProgramUsed" minOccurs="0"/>
-				<xs:element name="SoftwareProgramVersion" type="SoftwareProgramVersion" minOccurs="0"/>
+				<xs:element name="SoftwareProgramVersion" type="SoftwareProgramVersion"
+					minOccurs="0"/>
 				<xs:element ref="extension" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attribute name="dataSource" type="DataSource"/>
@@ -460,9 +480,12 @@
 			<xs:element name="Auditor">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="Qualification" type="AuditorQualification" maxOccurs="unbounded"/>
-						<xs:element minOccurs="0" name="StateWhereQualificationHeld" type="StateCode"/>
-						<xs:element minOccurs="0" name="YearsExperience" type="IntegerGreaterThanOrEqualToZero"/>
+						<xs:element minOccurs="0" name="Qualification" type="AuditorQualification"
+							maxOccurs="unbounded"/>
+						<xs:element minOccurs="0" name="StateWhereQualificationHeld"
+							type="StateCode"/>
+						<xs:element minOccurs="0" name="YearsExperience"
+							type="IntegerGreaterThanOrEqualToZero"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -471,8 +494,10 @@
 			<xs:element name="Implementer">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" minOccurs="0" name="Qualification" type="ImplementerQualification"/>
-						<xs:element minOccurs="0" name="StateWhereQualificationHeld" type="StateCode"/>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="Qualification"
+							type="ImplementerQualification"/>
+						<xs:element minOccurs="0" name="StateWhereQualificationHeld"
+							type="StateCode"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -494,7 +519,8 @@
 		<xs:sequence>
 			<xs:group maxOccurs="unbounded" ref="SystemInfo"/>
 			<xs:element name="BusinessInfo" type="BusinessInfoType"/>
-			<xs:element name="SubContractor" type="ContractorType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="SubContractor" type="ContractorType" minOccurs="0"
+				maxOccurs="unbounded"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -508,7 +534,8 @@
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element name="SpaceName" type="HPXMLString" minOccurs="0"/>
-						<xs:element minOccurs="0" name="NumberOfBedrooms" type="IntegerGreaterThanOrEqualToZero"/>
+						<xs:element minOccurs="0" name="NumberOfBedrooms"
+							type="IntegerGreaterThanOrEqualToZero"/>
 						<xs:element minOccurs="0" name="FloorArea" type="SurfaceArea">
 							<xs:annotation>
 								<xs:documentation>[sq.ft.]</xs:documentation>
@@ -554,7 +581,8 @@
 			<xs:element name="AirInfiltration" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="AirInfiltrationMeasurement" type="AirInfiltrationMeasurementType" maxOccurs="unbounded"> </xs:element>
+						<xs:element minOccurs="0" name="AirInfiltrationMeasurement"
+							type="AirInfiltrationMeasurementType" maxOccurs="unbounded"> </xs:element>
 						<xs:element minOccurs="0" name="AirSealing" maxOccurs="unbounded">
 							<xs:complexType>
 								<xs:sequence>
@@ -563,9 +591,14 @@
 									<xs:element minOccurs="0" name="ComponentsAirSealed">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element maxOccurs="unbounded" minOccurs="0" name="Attic" type="AtticComponentsAirSealed"/>
-												<xs:element maxOccurs="unbounded" minOccurs="0" name="BasementCrawlspace" type="BasementCrawlspaceComponentsAirSealed"/>
-												<xs:element maxOccurs="unbounded" minOccurs="0" name="LivingSpace" type="LivingSpaceComponentsAirSealed"/>
+												<xs:element maxOccurs="unbounded" minOccurs="0"
+												name="Attic" type="AtticComponentsAirSealed"/>
+												<xs:element maxOccurs="unbounded" minOccurs="0"
+												name="BasementCrawlspace"
+												type="BasementCrawlspaceComponentsAirSealed"/>
+												<xs:element maxOccurs="unbounded" minOccurs="0"
+												name="LivingSpace"
+												type="LivingSpaceComponentsAirSealed"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -603,14 +636,19 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="1" name="AtticType" type="AtticType"/>
-									<xs:element minOccurs="0" name="VentilationRate" type="VentilationType"/>
-									<xs:element minOccurs="0" name="AttachedToRoof" type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFrameFloor" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="VentilationRate"
+										type="VentilationType"/>
+									<xs:element minOccurs="0" name="AttachedToRoof"
+										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToWall"
+										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFrameFloor"
+										type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -636,17 +674,25 @@
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
 									<xs:element name="FoundationType" type="FoundationType"/>
-									<xs:element minOccurs="0" name="VentilationRate" type="VentilationType"/>
-									<xs:element minOccurs="0" name="ThermalBoundary" type="FoundationThermalBoundary"/>
-									<xs:element minOccurs="0" name="AttachedToRimJoist" type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFoundationWall" type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFrameFloor" type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToSlab" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="VentilationRate"
+										type="VentilationType"/>
+									<xs:element minOccurs="0" name="ThermalBoundary"
+										type="FoundationThermalBoundary"/>
+									<xs:element minOccurs="0" name="AttachedToRimJoist"
+										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToWall"
+										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFoundationWall"
+										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFrameFloor"
+										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToSlab"
+										type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -678,23 +724,32 @@
 									<xs:element minOccurs="1" name="GarageType">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="AttachedtoHouse" type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="Vented" type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="AttachedtoHouse"
+												type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="Vented"
+												type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="Conditioned"
+												type="HPXMLBoolean"/>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="AttachedToRoof" type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFoundationWall" type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFrameFloor" type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToSlab" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToRoof"
+										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToWall"
+										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFoundationWall"
+										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFrameFloor"
+										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToSlab"
+										type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -719,21 +774,25 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo"
+										type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Surface area of the roof itself</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation"
+										type="OrientationType"/>
 									<xs:element name="Azimuth" type="AzimuthType" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="RoofType" type="RoofType"/>
-									<xs:element minOccurs="0" name="RoofColor" type="WallAndRoofColor"/>
-									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
+									<xs:element minOccurs="0" name="RoofColor"
+										type="WallAndRoofColor"/>
+									<xs:element minOccurs="0" name="SolarAbsorptance"
+										type="SolarAbsorptance"/>
 									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
 									<xs:element minOccurs="0" name="Rafters" type="StudProperties"/>
 									<xs:element minOccurs="0" name="DeckType" type="DeckType"/>
@@ -742,9 +801,12 @@
 											<xs:documentation>Pitch of roof ?/12</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="RadiantBarrier" type="HPXMLBoolean" minOccurs="0"/>
-									<xs:element name="RadiantBarrierLocation" type="RadiantBarrierLocation" minOccurs="0"/>
-									<xs:element minOccurs="0" name="Insulation" type="InsulationInfo"/>
+									<xs:element name="RadiantBarrier" type="HPXMLBoolean"
+										minOccurs="0"/>
+									<xs:element name="RadiantBarrierLocation"
+										type="RadiantBarrierLocation" minOccurs="0"/>
+									<xs:element minOccurs="0" name="Insulation"
+										type="InsulationInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -762,32 +824,40 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element minOccurs="0" name="ExteriorAdjacentTo" type="AdjacentTo"/>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="ExteriorAdjacentTo"
+										type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo"
+										type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation"
+										type="OrientationType"/>
 									<xs:element name="Azimuth" type="AzimuthType" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Perimeter" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Perimeter"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
+									<xs:element minOccurs="0" name="SolarAbsorptance"
+										type="SolarAbsorptance"/>
 									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
-									<xs:element minOccurs="0" name="Insulation" type="InsulationInfo"/>
-									<xs:element minOccurs="0" name="FloorJoists" type="StudProperties"/>
+									<xs:element minOccurs="0" name="Insulation"
+										type="InsulationInfo"/>
+									<xs:element minOccurs="0" name="FloorJoists"
+										type="StudProperties"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -809,11 +879,15 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo" minOccurs="0"> </xs:element>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
-									<xs:element minOccurs="0" name="AtticWallType" type="AtticWallType"/>
+									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo"
+										minOccurs="0"> </xs:element>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo"
+										type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="AtticWallType"
+										type="AtticWallType"/>
 									<xs:element name="WallType" type="WallType" minOccurs="0"> </xs:element>
-									<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Thickness"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[in] Thickness of the wall assembly</xs:documentation>
 										</xs:annotation>
@@ -823,7 +897,8 @@
 											<xs:documentation>[sq.ft.] Gross wall area</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation"
+										type="OrientationType"/>
 									<xs:element name="Azimuth" type="AzimuthType" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
@@ -832,13 +907,16 @@
 									<xs:element minOccurs="0" name="Studs" type="StudProperties"/>
 									<xs:element minOccurs="0" name="Siding" type="Siding"/>
 									<xs:element minOccurs="0" name="Color" type="WallAndRoofColor"/>
-									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
+									<xs:element minOccurs="0" name="SolarAbsorptance"
+										type="SolarAbsorptance"/>
 									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
-									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"/>
+									<xs:element minOccurs="0" maxOccurs="1" name="Insulation"
+										type="InsulationInfo"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -860,8 +938,10 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo" minOccurs="0"> </xs:element>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
+									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo"
+										minOccurs="0"> </xs:element>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo"
+										type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="Type" type="FoundationWallType"/>
 									<xs:element minOccurs="0" name="Length" type="LengthMeasurement">
 										<xs:annotation>
@@ -878,39 +958,47 @@
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation"
+										type="OrientationType"/>
 									<xs:element name="Azimuth" type="AzimuthType" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Thickness"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[in] Thickness of foundation wall excluding interior framing.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="DepthBelowGrade" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="DepthBelowGrade"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Depth below grade of foundation wall</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AdjacentToFoundation" type="LocalReference">
+									<xs:element minOccurs="0" name="AdjacentToFoundation"
+										type="LocalReference">
 										<xs:annotation>
 											<xs:documentation>If this foundation wall is adjacent to another foundation, use this reference to indicate which one.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="InteriorStuds" type="StudProperties"/>
-									<xs:element minOccurs="0" name="DistanceToTopOfInsulation" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="InteriorStuds"
+										type="StudProperties"/>
+									<xs:element minOccurs="0" name="DistanceToTopOfInsulation"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Vertical distance from top of foundation wall to top of insulation.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="DistanceToBottomOfInsulation" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="DistanceToBottomOfInsulation"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Vertical distance from top of foundation wall to bottom of insulation.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element maxOccurs="1" minOccurs="0" name="Insulation" type="InsulationInfo"/>
+									<xs:element maxOccurs="1" minOccurs="0" name="Insulation"
+										type="InsulationInfo"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -932,17 +1020,23 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo" minOccurs="0"> </xs:element>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
-									<xs:element minOccurs="0" name="FloorJoists" type="StudProperties"/>
-									<xs:element minOccurs="0" name="FloorTrusses" type="StudProperties"/>
-									<xs:element minOccurs="0" name="FloorCovering" type="FloorCovering"/>
+									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo"
+										minOccurs="0"> </xs:element>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo"
+										type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="FloorJoists"
+										type="StudProperties"/>
+									<xs:element minOccurs="0" name="FloorTrusses"
+										type="StudProperties"/>
+									<xs:element minOccurs="0" name="FloorCovering"
+										type="FloorCovering"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"> </xs:element>
+									<xs:element minOccurs="0" maxOccurs="1" name="Insulation"
+										type="InsulationInfo"> </xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -963,51 +1057,64 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo"
+										type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Area of the slab</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Thickness"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[in] Thickness of foundation slab.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Perimeter" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Perimeter"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Length of slab perimeter.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="ExposedPerimeter" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="ExposedPerimeter"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Perimeter of the slab exposed to ambient conditions</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="PerimeterInsulationDepth" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="PerimeterInsulationDepth"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Depth from grade to bottom of vertical slab perimeter insulation</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="UnderSlabInsulationWidth" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="UnderSlabInsulationWidth"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Width from slab edge inward of horizontal under-slab insulation</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="UnderSlabInsulationSpansEntireSlab" type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="OnGradeExposedPerimeter" type="LengthMeasurement">
+									<xs:element minOccurs="0"
+										name="UnderSlabInsulationSpansEntireSlab"
+										type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="OnGradeExposedPerimeter"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Perimeter of slab measured in feet that is on-grade (2 ft. below grade or less) and exposed to ambient conditions.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="DepthBelowGrade" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="DepthBelowGrade"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Depth from the top of the slab surface to grade</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FloorCovering" type="FloorCovering"/>
-									<xs:element maxOccurs="1" minOccurs="0" name="PerimeterInsulation" type="InsulationInfo"/>
-									<xs:element minOccurs="0" name="UnderSlabInsulation" type="InsulationInfo"/>
+									<xs:element minOccurs="0" name="FloorCovering"
+										type="FloorCovering"/>
+									<xs:element maxOccurs="1" minOccurs="0"
+										name="PerimeterInsulation" type="InsulationInfo"/>
+									<xs:element minOccurs="0" name="UnderSlabInsulation"
+										type="InsulationInfo"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1028,12 +1135,15 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="WindowInfo"/>
-									<xs:element minOccurs="0" name="WindowtoWallRatio" type="Fraction"/>
-									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference"/>
+									<xs:element minOccurs="0" name="WindowtoWallRatio"
+										type="Fraction"/>
+									<xs:element minOccurs="0" name="AttachedToWall"
+										type="LocalReference"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -1064,11 +1174,13 @@
 											<xs:documentation>Pitch of skylight ?/12</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AttachedToRoof" type="LocalReference"/>
+									<xs:element minOccurs="0" name="AttachedToRoof"
+										type="LocalReference"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -1089,8 +1201,10 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference"/>
-									<xs:element minOccurs="0" name="Quantity" type="IntegerGreaterThanZero"/>
+									<xs:element minOccurs="0" name="AttachedToWall"
+										type="LocalReference"/>
+									<xs:element minOccurs="0" name="Quantity"
+										type="IntegerGreaterThanZero"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Total door surface area for this group of doors</xs:documentation>
@@ -1101,18 +1215,27 @@
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation"
+										type="OrientationType"/>
 									<xs:element minOccurs="0" name="DoorType" type="DoorType"/>
-									<xs:element name="DoorMaterial" type="DoorMaterial" minOccurs="0"/>
-									<xs:element minOccurs="0" name="WeatherStripping" type="HPXMLBoolean"/>
+									<xs:element name="DoorMaterial" type="DoorMaterial"
+										minOccurs="0"/>
+									<xs:element minOccurs="0" name="WeatherStripping"
+										type="HPXMLBoolean"/>
 									<xs:element name="StormDoor" type="HPXMLBoolean" minOccurs="0"/>
 									<xs:element name="RValue" type="RValue" minOccurs="0"/>
-									<xs:element minOccurs="0" name="LeakinessDescription" type="BuildingLeakiness"/>
-									<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="DoorThirdPartyCertifications"/>
+									<xs:element minOccurs="0" name="LeakinessDescription"
+										type="BuildingLeakiness"/>
+									<xs:element minOccurs="0" name="PerformanceClass"
+										type="PerformanceClass"/>
+									<xs:element maxOccurs="unbounded" minOccurs="0"
+										name="ThirdPartyCertification"
+										type="DoorThirdPartyCertifications"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -1144,21 +1267,28 @@
 										</xs:annotation>
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="PrimaryHeatingSystem" type="LocalReference"/>
-												<xs:element minOccurs="0" name="PrimaryCoolingSystem" type="LocalReference"/>
+												<xs:element minOccurs="0"
+												name="PrimaryHeatingSystem" type="LocalReference"/>
+												<xs:element minOccurs="0"
+												name="PrimaryCoolingSystem" type="LocalReference"
+												/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" maxOccurs="unbounded" name="HeatingSystem" type="HeatingSystemInfoType"/>
-									<xs:element minOccurs="0" maxOccurs="unbounded" name="CoolingSystem" type="CoolingSystemInfoType"/>
-									<xs:element minOccurs="0" maxOccurs="unbounded" name="HeatPump" type="HeatPumpInfoType"/>
+									<xs:element minOccurs="0" maxOccurs="unbounded"
+										name="HeatingSystem" type="HeatingSystemInfoType"/>
+									<xs:element minOccurs="0" maxOccurs="unbounded"
+										name="CoolingSystem" type="CoolingSystemInfoType"/>
+									<xs:element minOccurs="0" maxOccurs="unbounded" name="HeatPump"
+										type="HeatPumpInfoType"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
-						<xs:element maxOccurs="unbounded" minOccurs="0" name="HVACControl" type="HVACControlType"> </xs:element>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="HVACControl"
+							type="HVACControlType"> </xs:element>
 						<xs:element maxOccurs="unbounded" minOccurs="0" name="HVACDistribution">
 							<xs:complexType>
 								<xs:sequence>
@@ -1167,37 +1297,45 @@
 									<xs:element minOccurs="0" name="DistributionSystemType">
 										<xs:complexType>
 											<xs:choice>
-												<xs:element name="AirDistribution" type="AirDistributionInfo"/>
-												<xs:element name="HydronicDistribution" type="HydronicDistributionInfo"/>
+												<xs:element name="AirDistribution"
+												type="AirDistributionInfo"/>
+												<xs:element name="HydronicDistribution"
+												type="HydronicDistributionInfo"/>
 												<xs:element name="Other" type="HPXMLString">
-													<xs:annotation>
-														<xs:documentation>describe</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>describe</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 											</xs:choice>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="ConditionedFloorAreaServed" type="SurfaceArea">
+									<xs:element minOccurs="0" name="ConditionedFloorAreaServed"
+										type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Conditioned floor area that this distribution system serves.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AnnualHeatingDistributionSystemEfficiency" type="HPXMLDouble">
+									<xs:element minOccurs="0"
+										name="AnnualHeatingDistributionSystemEfficiency"
+										type="HPXMLDouble">
 										<xs:annotation>
 											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for heating, the DSE may be approximated by equation
 												3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use
 												History.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AnnualCoolingDistributionSystemEfficiency" type="HPXMLDouble">
+									<xs:element minOccurs="0"
+										name="AnnualCoolingDistributionSystemEfficiency"
+										type="HPXMLDouble">
 										<xs:annotation>
 											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for cooling, the DSE may be approximated by equation
 												3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use
 												History.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HVACDistributionImprovement" type="HVACDistributionImprovementInfo"/>
+									<xs:element minOccurs="0" name="HVACDistributionImprovement"
+										type="HVACDistributionImprovementInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1206,8 +1344,10 @@
 						<xs:element minOccurs="0" name="Maintenance">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element minOccurs="0" name="Schedule" type="HVACMaintenanceSchedule"/>
-									<xs:element minOccurs="0" name="ACReplacedinLastTenYears" type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="Schedule"
+										type="HVACMaintenanceSchedule"/>
+									<xs:element minOccurs="0" name="ACReplacedinLastTenYears"
+										type="HPXMLBoolean"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1216,7 +1356,8 @@
 						<xs:element name="AnnualEnergyUse" minOccurs="0">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType" maxOccurs="unbounded"/>
+									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"
+										maxOccurs="unbounded"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
@@ -1237,95 +1378,126 @@
 											<xs:sequence>
 												<xs:group ref="SystemInfo"/>
 												<xs:element minOccurs="0" ref="ConnectedDevice"/>
-												<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
-												<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
-												<xs:element minOccurs="0" name="FanType" type="VentilationFanType"/>
-												<xs:element minOccurs="0" name="RatedFlowRate" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>[CFM] as rated by manufacturer</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="Manufacturer"
+												type="HPXMLString"/>
+												<xs:element minOccurs="0" name="SerialNumber"
+												type="HPXMLString"/>
+												<xs:element minOccurs="0" name="FanType"
+												type="VentilationFanType"/>
+												<xs:element minOccurs="0" name="RatedFlowRate"
+												type="HPXMLDouble">
+												<xs:annotation>
+												<xs:documentation>[CFM] as rated by manufacturer</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="CalculatedFlowRate" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>[CFM] as calculated using duct size, prescriptive approach</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="CalculatedFlowRate"
+												type="HPXMLDouble">
+												<xs:annotation>
+												<xs:documentation>[CFM] as calculated using duct size, prescriptive approach</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="TestedFlowRate" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>[CFM] as tested by assessor/auditor/inspector</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="TestedFlowRate"
+												type="HPXMLDouble">
+												<xs:annotation>
+												<xs:documentation>[CFM] as tested by assessor/auditor/inspector</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="HoursInOperation" type="HoursPerDay">
-													<xs:annotation>
-														<xs:documentation>24 = continuous, less than 24 = intermittent</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="HoursInOperation"
+												type="HoursPerDay">
+												<xs:annotation>
+												<xs:documentation>24 = continuous, less than 24 = intermittent</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="DeliveredVentilation" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>[CFM]</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0"
+												name="DeliveredVentilation" type="HPXMLDouble">
+												<xs:annotation>
+												<xs:documentation>[CFM]</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="FanControlProperlyLabeled" type="BooleanWithNA"/>
-												<xs:element minOccurs="0" name="ProperlyVented" type="BooleanWithNA"/>
-												<xs:element minOccurs="0" name="FanLocation" type="VentilationFanLocation"/>
-												<xs:element minOccurs="0" name="UsedForLocalVentilation" type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="UsedForWholeBuildingVentilation" type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="UsedForSeasonalCoolingLoadReduction" type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="UsedForGarageVentilation" type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="RatedNoise" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>[sones] from manufacturer's info</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0"
+												name="FanControlProperlyLabeled"
+												type="BooleanWithNA"/>
+												<xs:element minOccurs="0" name="ProperlyVented"
+												type="BooleanWithNA"/>
+												<xs:element minOccurs="0" name="FanLocation"
+												type="VentilationFanLocation"/>
+												<xs:element minOccurs="0"
+												name="UsedForLocalVentilation" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0"
+												name="UsedForWholeBuildingVentilation"
+												type="HPXMLBoolean"/>
+												<xs:element minOccurs="0"
+												name="UsedForSeasonalCoolingLoadReduction"
+												type="HPXMLBoolean"/>
+												<xs:element minOccurs="0"
+												name="UsedForGarageVentilation"
+												type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="RatedNoise"
+												type="HPXMLDouble">
+												<xs:annotation>
+												<xs:documentation>[sones] from manufacturer's info</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="TestedNoise" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>[sones] as tested in field</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="TestedNoise"
+												type="HPXMLDouble">
+												<xs:annotation>
+												<xs:documentation>[sones] as tested in field</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="TotalRecoveryEfficiency" type="Fraction">
-													<xs:annotation>
-														<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by electric
+												<xs:element minOccurs="0"
+												name="TotalRecoveryEfficiency" type="Fraction">
+												<xs:annotation>
+												<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by electric
 															consumption, case heat loss or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential
 															total energy that could be recovered plus the exhaust fan energy. Values for some products can be found at the Home Ventilating Institute
 															(hvi.org).</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="SensibleRecoveryEfficiency" type="Fraction">
-													<xs:annotation>
-														<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by electric consumption, case heat loss or heat gain,
+												<xs:element minOccurs="0"
+												name="SensibleRecoveryEfficiency" type="Fraction">
+												<xs:annotation>
+												<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by electric consumption, case heat loss or heat gain,
 															air leakage, airflow mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test),
 															as a percent of the potential sensible energy that could be recovered plus the exhaust fan energy. Values for some products can be found at
 															the Home Ventilating Institute (hvi.org).</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="AdjustedTotalRecoveryEfficiency" type="Fraction">
-													<xs:annotation>
-														<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by case heat loss
+												<xs:element minOccurs="0"
+												name="AdjustedTotalRecoveryEfficiency"
+												type="Fraction">
+												<xs:annotation>
+												<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by case heat loss
 															or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential total energy that could be
 															recovered. This value is used to predict and compare Cooling Season Performance for the HRV/ERV unit. This value should be used for energy
 															modeling when wattage for air movement is separately accounted for in the energy model. Values for some products can be found at the Home
 															Ventilating Institute (hvi.org).</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="AdjustedSensibleRecoveryEfficiency" type="Fraction">
-													<xs:annotation>
-														<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by case heat loss or heat gain, air leakage, airflow
+												<xs:element minOccurs="0"
+												name="AdjustedSensibleRecoveryEfficiency"
+												type="Fraction">
+												<xs:annotation>
+												<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by case heat loss or heat gain, air leakage, airflow
 															mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test), as a percent of the
 															potential sensible energy that could be recovered. This value should be used for energy modeling when wattage for air movement is separately
 															accounted for in the energy model. Values for some products can be found at the Home Ventilating Institute (hvi.org).</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="FanPower" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>[W]</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="FanPower"
+												type="HPXMLDouble">
+												<xs:annotation>
+												<xs:documentation>[W]</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="VentilationFanThirdPartyCertification"/>
-												<xs:element name="AttachedToHVACDistributionSystem" type="LocalReference" minOccurs="0" maxOccurs="1">
-													<xs:annotation>
-														<xs:documentation>For central fan integrated supply mechanical ventilation, specifies the HVAC distribution system it is attached
+												<xs:element maxOccurs="unbounded" minOccurs="0"
+												name="ThirdPartyCertification"
+												type="VentilationFanThirdPartyCertification"/>
+												<xs:element name="AttachedToHVACDistributionSystem"
+												type="LocalReference" minOccurs="0" maxOccurs="1">
+												<xs:annotation>
+												<xs:documentation>For central fan integrated supply mechanical ventilation, specifies the HVAC distribution system it is attached
 															to.</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -1348,7 +1520,8 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="VentSystemType" type="VentSystem"/>
+									<xs:element minOccurs="0" name="VentSystemType"
+										type="VentSystem"/>
 									<xs:element minOccurs="0" ref="AttachedToZone"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
@@ -1368,36 +1541,44 @@
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
 									<xs:element minOccurs="0" ref="AttachedToZone"/>
-									<xs:element minOccurs="0" name="AttachedToCAZ" type="LocalReference"/>
+									<xs:element minOccurs="0" name="AttachedToCAZ"
+										type="LocalReference"/>
 									<xs:element name="FuelType" type="FuelType" minOccurs="0"/>
-									<xs:element name="WaterHeaterType" type="WaterHeaterType" minOccurs="0"/>
+									<xs:element name="WaterHeaterType" type="WaterHeaterType"
+										minOccurs="0"/>
 									<xs:element name="Location" type="UnitLocation" minOccurs="0"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
 									<xs:element name="ModelYear" type="Year" minOccurs="0"/>
-									<xs:element name="Manufacturer" type="Manufacturer" minOccurs="0"/>
+									<xs:element name="Manufacturer" type="Manufacturer"
+										minOccurs="0"/>
 									<xs:element name="ModelNumber" type="Model" minOccurs="0"/>
 									<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
-									<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction"/>
-									<xs:element minOccurs="0" name="ThirdPartyCertification" type="DHWThirdPartyCertification" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="PerformanceAdjustment"
+										type="Fraction"/>
+									<xs:element minOccurs="0" name="ThirdPartyCertification"
+										type="DHWThirdPartyCertification" maxOccurs="unbounded"/>
 									<xs:element name="TankVolume" type="Volume" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[gal]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FractionDHWLoadServed" type="Fraction"/>
+									<xs:element minOccurs="0" name="FractionDHWLoadServed"
+										type="Fraction"/>
 									<xs:element name="HeatingCapacity" type="Capacity" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[Btuh]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="EnergyFactor" type="EnergyFactor" minOccurs="0">
+									<xs:element name="EnergyFactor" type="EnergyFactor"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>The amount of energy delivered as heated water in a day divided by the total daily energy consumption of a residential water heater, as
 												determined following standardized DOE testing procedure.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="UniformEnergyFactor" type="EnergyFactor" minOccurs="0">
+									<xs:element name="UniformEnergyFactor" type="EnergyFactor"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>DOE’s new metric for communicating the energy efficiency of a residential water heater, which replaces the Energy Factor (EF) metric. More
 												efficient water heaters have a higher Uniform Energy Factor (UEF). UEF is determined by the Department of Energy’s test method outlined in 10 CFR Part
@@ -1416,74 +1597,96 @@
 												nominal temperature rise of 77°F during steady state operation.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="RecoveryEfficiency" type="RecoveryEfficiency" minOccurs="0">
+									<xs:element name="RecoveryEfficiency" type="RecoveryEfficiency"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>The ratio of energy delivered to heat cold water compared to the energy consumed by the water heater, as determined following standardized
 												DOE testing procedure.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ThermalEfficiency" type="ThermalEfficiency" minOccurs="0"/>
+									<xs:element name="ThermalEfficiency" type="ThermalEfficiency"
+										minOccurs="0"/>
 									<xs:element minOccurs="0" name="WaterHeaterInsulation">
 										<xs:complexType>
 											<xs:sequence>
 												<xs:element minOccurs="0" name="Jacket">
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element minOccurs="0" name="InsulationMaterial" type="InsulationMaterial"/>
-															<xs:element name="JacketRValue" type="RValue" minOccurs="0"/>
-															<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
-																<xs:annotation>
-																	<xs:documentation>[in]</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" ref="extension"/>
-														</xs:sequence>
-														<xs:attribute name="dataSource" type="DataSource"/>
-													</xs:complexType>
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element minOccurs="0"
+												name="InsulationMaterial"
+												type="InsulationMaterial"/>
+												<xs:element name="JacketRValue" type="RValue"
+												minOccurs="0"/>
+												<xs:element minOccurs="0" name="Thickness"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[in]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												<xs:attribute name="dataSource" type="DataSource"
+												/>
+												</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="TankWall">
-													<xs:annotation>
-														<xs:documentation>Refers to the insulation in the tank wall itself. This information is sometimes available on the water heater's name plate or
+												<xs:annotation>
+												<xs:documentation>Refers to the insulation in the tank wall itself. This information is sometimes available on the water heater's name plate or
 															the units specification sheet, or can be estimated by removing the water heater's access plate.</xs:documentation>
-													</xs:annotation>
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element minOccurs="0" name="InsulationMaterial" type="InsulationMaterial"/>
-															<xs:element name="TankWallRValue" type="RValue" minOccurs="0"/>
-															<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
-																<xs:annotation>
-																	<xs:documentation>[in]</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" ref="extension"/>
-														</xs:sequence>
-														<xs:attribute name="dataSource" type="DataSource"/>
-													</xs:complexType>
+												</xs:annotation>
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element minOccurs="0"
+												name="InsulationMaterial"
+												type="InsulationMaterial"/>
+												<xs:element name="TankWallRValue" type="RValue"
+												minOccurs="0"/>
+												<xs:element minOccurs="0" name="Thickness"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[in]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												<xs:attribute name="dataSource" type="DataSource"
+												/>
+												</xs:complexType>
 												</xs:element>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element name="MeetsACCA5QIHVACSpecification" type="HPXMLBoolean" minOccurs="0"/>
-									<xs:element name="HotWaterTemperature" type="Temperature" minOccurs="0">
+									<xs:element name="MeetsACCA5QIHVACSpecification"
+										type="HPXMLBoolean" minOccurs="0"/>
+									<xs:element name="HotWaterTemperature" type="Temperature"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg F]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HasMixingValve" type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="UsesDesuperheater" type="HPXMLBoolean">
+									<xs:element minOccurs="0" name="HasMixingValve"
+										type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="UsesDesuperheater"
+										type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Indicates whether this water heater uses a desuperheater. The attached heat pump or air conditioner can be referenced in the
 												RelatedHVACSystem element.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HasSharedCombustionVentilation" type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="CombustionVentilationOrphaned" type="HPXMLBoolean"/>
-									<xs:element name="CombustionVentingSystem" minOccurs="0" type="LocalReference"> </xs:element>
-									<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="HasSharedCombustionVentilation"
+										type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="CombustionVentilationOrphaned"
+										type="HPXMLBoolean"/>
+									<xs:element name="CombustionVentingSystem" minOccurs="0"
+										type="LocalReference"> </xs:element>
+									<xs:element minOccurs="0" name="AutomaticVentDamper"
+										type="HPXMLBoolean"/>
 									<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
-									<xs:element name="RelatedHVACSystem" type="LocalReference" minOccurs="0">
+									<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
+										type="HPXMLBoolean"/>
+									<xs:element name="RelatedHVACSystem" type="LocalReference"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>Reference a HeatingSystem, HeatPump, or CoolingSystem.</xs:documentation>
 										</xs:annotation>
@@ -1491,13 +1694,15 @@
 									<xs:element minOccurs="0" name="Installation">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="Standard" type="HVACInstallationStandard"/>
+												<xs:element minOccurs="0" name="Standard"
+												type="HVACInstallationStandard"/>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="WaterHeaterImprovement" type="WaterHeaterImprovementInfo"/>
+									<xs:element minOccurs="0" name="WaterHeaterImprovement"
+										type="WaterHeaterImprovementInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1511,8 +1716,10 @@
 									<xs:element minOccurs="0" name="Model" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
-									<xs:element minOccurs="0" name="ControlTechnology" type="DHWControllerTechnology"/>
-									<xs:element minOccurs="0" name="TemperatureControl" type="DHWTemperatureControl"/>
+									<xs:element minOccurs="0" name="ControlTechnology"
+										type="DHWControllerTechnology"/>
+									<xs:element minOccurs="0" name="TemperatureControl"
+										type="DHWTemperatureControl"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1522,7 +1729,8 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="AttachedToWaterHeatingSystem" type="LocalReference">
+									<xs:element minOccurs="0" name="AttachedToWaterHeatingSystem"
+										type="LocalReference">
 										<xs:annotation>
 											<xs:documentation>The water heating system that this distribution system serves.</xs:documentation>
 										</xs:annotation>
@@ -1531,61 +1739,74 @@
 										<xs:complexType>
 											<xs:choice>
 												<xs:element name="Standard">
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element minOccurs="0" name="PipingLength" type="LengthMeasurement">
-																<xs:annotation>
-																	<xs:documentation>Measured length of hot water piping from the hot water heater to the farthest hot water fixture, measured
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element minOccurs="0" name="PipingLength"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>Measured length of hot water piping from the hot water heater to the farthest hot water fixture, measured
 																		longitudinally from plans, assuming the hot water piping does not run diagonally, plus 10 feet of piping for each floor level,
 																		plus 5 feet of piping for unconditioned basements. [ft]</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" ref="extension"/>
-														</xs:sequence>
-														<xs:attribute name="dataSource" type="DataSource"/>
-													</xs:complexType>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												<xs:attribute name="dataSource" type="DataSource"
+												/>
+												</xs:complexType>
 												</xs:element>
 												<xs:element name="Recirculation">
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element minOccurs="0" name="ControlType" type="RecirculationControlType"/>
-															<xs:element minOccurs="0" name="RecirculationPipingLoopLength" type="LengthMeasurement">
-																<xs:annotation>
-																	<xs:documentation>Hot water recirculation loop piping length including both supply and return sides of the loop, measured
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element minOccurs="0" name="ControlType"
+												type="RecirculationControlType"/>
+												<xs:element minOccurs="0"
+												name="RecirculationPipingLoopLength"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>Hot water recirculation loop piping length including both supply and return sides of the loop, measured
 																		longitudinally from plans, assuming the hot water piping does not run diagonally. [ft]</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" name="BranchPipingLoopLength" type="LengthMeasurement">
-																<xs:annotation>
-																	<xs:documentation>Length of the branch hot water piping from the recirculation loop to the farthest hot water fixture from the
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0"
+												name="BranchPipingLoopLength"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>Length of the branch hot water piping from the recirculation loop to the farthest hot water fixture from the
 																		recirculation loop, measured longitudinally from plans, assuming the branch hot water piping does not run diagonally, plus 20
 																		feet of piping for each floor level greater than one plus 10 feet of piping for unconditioned basements. [ft]</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" name="PumpPower" type="Power">
-																<xs:annotation>
-																	<xs:documentation>[W]</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" ref="extension"/>
-														</xs:sequence>
-														<xs:attribute name="dataSource" type="DataSource"/>
-													</xs:complexType>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="PumpPower"
+												type="Power">
+												<xs:annotation>
+												<xs:documentation>[W]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												<xs:attribute name="dataSource" type="DataSource"
+												/>
+												</xs:complexType>
 												</xs:element>
 											</xs:choice>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="PipeInsulation" type="PipeInsulationType"/>
+									<xs:element minOccurs="0" name="PipeInsulation"
+										type="PipeInsulationType"/>
 									<xs:element minOccurs="0" name="DrainWaterHeatRecovery">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="FacilitiesConnected" type="DrainWaterHeatRecoveryFacilitiesConnected"/>
-												<xs:element minOccurs="0" name="EqualFlow" type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="Efficiency" type="Fraction">
-													<xs:annotation>
-														<xs:documentation>Efficiency percent expressed as a fraction from 0-1.</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="FacilitiesConnected"
+												type="DrainWaterHeatRecoveryFacilitiesConnected"/>
+												<xs:element minOccurs="0" name="EqualFlow"
+												type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="Efficiency"
+												type="Fraction">
+												<xs:annotation>
+												<xs:documentation>Efficiency percent expressed as a fraction from 0-1.</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -1602,11 +1823,15 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:choice minOccurs="0">
-										<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference"/>
-										<xs:element name="AttachedToHotWaterDistribution" type="LocalReference"/>
+										<xs:element name="AttachedToWaterHeatingSystem"
+											type="LocalReference"/>
+										<xs:element name="AttachedToHotWaterDistribution"
+											type="LocalReference"/>
 									</xs:choice>
-									<xs:element minOccurs="1" name="WaterFixtureType" type="WaterFixtureType"/>
-									<xs:element minOccurs="0" name="Quantity" type="IntegerGreaterThanZero">
+									<xs:element minOccurs="1" name="WaterFixtureType"
+										type="WaterFixtureType"/>
+									<xs:element minOccurs="0" name="Quantity"
+										type="IntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Number of similar water fixtures.</xs:documentation>
 										</xs:annotation>
@@ -1621,22 +1846,28 @@
 											<xs:documentation>Is the fixture considered low-flow?</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FaucetAerator" type="HPXMLBoolean">
+									<xs:element minOccurs="0" name="FaucetAerator"
+										type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Does this faucet have an aerator?</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="MinutesPerDay" type="MinutesPerDay">
+									<xs:element minOccurs="0" name="MinutesPerDay"
+										type="MinutesPerDay">
 										<xs:annotation>
 											<xs:documentation>[minutes] Number of minutes per day a water fixture operates.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="TemperatureInitiatedShowerFlowRestrictionValve" type="HPXMLBoolean">
+									<xs:element minOccurs="0"
+										name="TemperatureInitiatedShowerFlowRestrictionValve"
+										type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Does the shower have a device that restricts the flow of water automatically once it has reached temperature?</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="WaterFixtureThirdPartyCertification">
+									<xs:element maxOccurs="unbounded" minOccurs="0"
+										name="ThirdPartyCertification"
+										type="WaterFixtureThirdPartyCertification">
 										<xs:annotation>
 											<xs:documentation>Independent organization has verified that product or appliance meets or exceeds the standard in question.</xs:documentation>
 										</xs:annotation>
@@ -1669,28 +1900,36 @@
 									<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="ModelNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" ref="AttachedToZone"/>
-									<xs:element name="SystemType" minOccurs="0" type="SolarThermalSystemType"/>
-									<xs:element name="CollectorArea" type="SurfaceArea" minOccurs="0">
+									<xs:element name="SystemType" minOccurs="0"
+										type="SolarThermalSystemType"/>
+									<xs:element name="CollectorArea" type="SurfaceArea"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorLoopType" type="SolarThermalCollectorLoopType"/>
-									<xs:element minOccurs="0" name="CollectorType" type="SolarThermalCollectorType"/>
-									<xs:element minOccurs="0" name="CollectorOrientation" type="OrientationType"/>
-									<xs:element minOccurs="0" name="CollectorAzimuth" type="AzimuthType"/>
+									<xs:element minOccurs="0" name="CollectorLoopType"
+										type="SolarThermalCollectorLoopType"/>
+									<xs:element minOccurs="0" name="CollectorType"
+										type="SolarThermalCollectorType"/>
+									<xs:element minOccurs="0" name="CollectorOrientation"
+										type="OrientationType"/>
+									<xs:element minOccurs="0" name="CollectorAzimuth"
+										type="AzimuthType"/>
 									<xs:element minOccurs="0" name="CollectorTilt" type="Tilt">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorRatedOpticalEfficiency" type="CollectorRatedOpticalEfficiency">
+									<xs:element minOccurs="0" name="CollectorRatedOpticalEfficiency"
+										type="CollectorRatedOpticalEfficiency">
 										<xs:annotation>
 											<xs:documentation>Often referred to as Fr-tau-alpha (FRta), this describes the optical efficiency portion of the overall collector efficiency. In the OG-100
 												SRCC Certified Solar Thermal Collector Directory, this is the y-intercept of the efficiency curve.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorRatedThermalLosses" type="CollectorRatedThermalLosses">
+									<xs:element minOccurs="0" name="CollectorRatedThermalLosses"
+										type="CollectorRatedThermalLosses">
 										<xs:annotation>
 											<xs:documentation>Often referred to as Fr-Ul (FRUl), this describes the collector thermal losses portion of the overall collector efficiency. In the OG-100
 												SRCC Certified Solar Thermal Collector Directory, this is the slope of the efficiency curve.</xs:documentation>
@@ -1701,15 +1940,18 @@
 											<xs:documentation>[gal]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="ConnectedTo" type="LocalReference"/>
-									<xs:element minOccurs="0" name="SolarFraction" type="SolarFraction">
+									<xs:element minOccurs="0" name="ConnectedTo"
+										type="LocalReference"/>
+									<xs:element minOccurs="0" name="SolarFraction"
+										type="SolarFraction">
 										<xs:annotation>
 											<xs:documentation>The Solar Fraction is the portion of the total conventional hot water heating load (delivered energy and tank standby losses). The higher
 												the solar fraction, the greater the solar contribution to water heating, which reduces the energy required by the backup water heater. This value can be
 												found in the OG-300 SRCC Certified Solar Water Heating System Directory.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="SolarEnergyFactor" type="SolarThermalSystemEnergyFactor">
+									<xs:element minOccurs="0" name="SolarEnergyFactor"
+										type="SolarThermalSystemEnergyFactor">
 										<xs:annotation>
 											<xs:documentation>The Solar Energy Factor is defined as the energy delivered by the system divided by the electrical or gas energy put into the system. The
 												higher the number, the more energy efficient. This value can be found in the OG-300 SRCC Certified Solar Water Heating System
@@ -1733,11 +1975,15 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
-									<xs:element minOccurs="0" name="Location" type="PVSystemLocation"/>
-									<xs:element minOccurs="0" name="Ownership" type="PVSystemOwnership"/>
+									<xs:element minOccurs="0" name="Location"
+										type="PVSystemLocation"/>
+									<xs:element minOccurs="0" name="Ownership"
+										type="PVSystemOwnership"/>
 									<xs:element minOccurs="0" name="ModuleType" type="PVModuleType"> </xs:element>
-									<xs:element maxOccurs="1" minOccurs="0" name="Tracking" type="PVTracking"> </xs:element>
-									<xs:element minOccurs="0" name="ArrayOrientation" type="OrientationType"/>
+									<xs:element maxOccurs="1" minOccurs="0" name="Tracking"
+										type="PVTracking"> </xs:element>
+									<xs:element minOccurs="0" name="ArrayOrientation"
+										type="OrientationType"/>
 									<xs:element minOccurs="0" name="ArrayAzimuth" type="AzimuthType">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
@@ -1753,28 +1999,36 @@
 											<xs:documentation>[DC Watts] Peak power as supplied by the manufacturer</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="CollectorArea"
+										type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberOfPanels" type="IntegerGreaterThanZero"/>
-									<xs:element minOccurs="0" name="InverterEfficiency" type="Fraction"/>
-									<xs:element minOccurs="0" name="SystemLossesFraction" type="Fraction">
+									<xs:element minOccurs="0" name="NumberOfPanels"
+										type="IntegerGreaterThanZero"/>
+									<xs:element minOccurs="0" name="InverterEfficiency"
+										type="Fraction"/>
+									<xs:element minOccurs="0" name="SystemLossesFraction"
+										type="Fraction">
 										<xs:annotation>
 											<xs:documentation>System losses can be due to soiling, shading, snow, mismatch, wiring, electrical connections, light-induced degradation, nameplate rating
 												inaccuracies, age, and availability.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="YearInverterManufactured" type="Year"/>
-									<xs:element minOccurs="0" name="YearModulesManufactured" type="Year"/>
+									<xs:element minOccurs="0" name="YearInverterManufactured"
+										type="Year"/>
+									<xs:element minOccurs="0" name="YearModulesManufactured"
+										type="Year"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
-									<xs:element minOccurs="0" name="AnnualOutput" type="RatedAnnualkWh">
+									<xs:element minOccurs="0" name="AnnualOutput"
+										type="RatedAnnualkWh">
 										<xs:annotation>
 											<xs:documentation>[kWh] Projected Annual Output for a typical meteorological year as determined by PVWatts or similar. </xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="LevelizedCostOfElectricity" type="Cost">
+									<xs:element minOccurs="0" name="LevelizedCostOfElectricity"
+										type="Cost">
 										<xs:annotation>
 											<xs:documentation>[$] The LCOE is the total cost of installing and operating a project expressed in dollars per kilowatt-hour of electricity generated by
 												the system over its life. Can be calculated with System Advisor Model, a similar software, or through a simplified calculation at
@@ -1797,25 +2051,30 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="Manufacturer" type="Manufacturer"/>
+									<xs:element minOccurs="0" name="Manufacturer"
+										type="Manufacturer"/>
 									<xs:element minOccurs="0" name="ModelNumber" type="Model"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
 									<xs:element minOccurs="0" name="Location" type="BatteryLocation"/>
-									<xs:element minOccurs="0" name="GridConnected" type="HPXMLBoolean">
+									<xs:element minOccurs="0" name="GridConnected"
+										type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Has the ability to feed electricity back on to the grid.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="BatteryType" type="BatteryType"/>
-									<xs:element minOccurs="0" name="CoolingStrategy" type="BatteryCoolingStrategy"/>
-									<xs:element minOccurs="0" name="NominalCapacity" type="BatteryCapacity">
+									<xs:element minOccurs="0" name="CoolingStrategy"
+										type="BatteryCoolingStrategy"/>
+									<xs:element minOccurs="0" name="NominalCapacity"
+										type="BatteryCapacity">
 										<xs:annotation>
 											<xs:documentation>[Ah] The total Ampere hours available when the battery is discharged starting from 100% state of charge until it reaches the cut-off
 												voltage. Capacity is computed by multiplying the discharge current (Amps) by the discharge time (hours).</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="UsableCapacity" type="BatteryCapacity">
+									<xs:element minOccurs="0" name="UsableCapacity"
+										type="BatteryCapacity">
 										<xs:annotation>
 											<xs:documentation>[Ah] The stored energy that can actually be used. In most cases usable capacity is less than the nominal capacity.</xs:documentation>
 										</xs:annotation>
@@ -1830,13 +2089,15 @@
 											<xs:documentation>[W] The peak power that the battery can generate for a short period of time.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NominalVoltage" type="HPXMLDecimal">
+									<xs:element minOccurs="0" name="NominalVoltage"
+										type="HPXMLDecimal">
 										<xs:annotation>
 											<xs:documentation>[V] The nominal voltage is the battery voltage when the state of charge is 0.5 (midway between being fully charged, and fully discharged)
 												with a 0.2C discharge current.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RoundTripEfficiency" type="Fraction">
+									<xs:element minOccurs="0" name="RoundTripEfficiency"
+										type="Fraction">
 										<xs:annotation>
 											<xs:documentation>Not all the power that is used to charge the battery is available during discharge. Round trip efficiency is the ratio of the energy put
 												in to the energy retrieved from storage.</xs:documentation>
@@ -1858,15 +2119,22 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="NumberofUnits" type="IntegerGreaterThanOrEqualToZero"/>
-									<xs:element minOccurs="0" name="Manufacturer" type="Manufacturer"/>
-									<xs:element maxOccurs="1" minOccurs="0" name="ModelNumber" type="Model"/>
+									<xs:element minOccurs="0" name="NumberofUnits"
+										type="IntegerGreaterThanOrEqualToZero"/>
+									<xs:element minOccurs="0" name="Manufacturer"
+										type="Manufacturer"/>
+									<xs:element maxOccurs="1" minOccurs="0" name="ModelNumber"
+										type="Model"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
-									<xs:element minOccurs="0" name="ChargingLevel" type="EVChargingLevel"/>
-									<xs:element minOccurs="0" name="ChargingConnector" type="EVChargingConnector"/>
-									<xs:element maxOccurs="1" minOccurs="0" name="ModelYear" type="Year"/>
-									<xs:element minOccurs="0" name="ACPowerSourceVoltage" type="Voltage">
+									<xs:element minOccurs="0" name="ChargingLevel"
+										type="EVChargingLevel"/>
+									<xs:element minOccurs="0" name="ChargingConnector"
+										type="EVChargingConnector"/>
+									<xs:element maxOccurs="1" minOccurs="0" name="ModelYear"
+										type="Year"/>
+									<xs:element minOccurs="0" name="ACPowerSourceVoltage"
+										type="Voltage">
 										<xs:annotation>
 											<xs:documentation>[V] Voltage of the AC power source</xs:documentation>
 										</xs:annotation>
@@ -1904,14 +2172,17 @@
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" name="Model" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
-									<xs:element minOccurs="0" name="ThirdPartyCertification" maxOccurs="unbounded" type="WindThirdPartyCertification"/>
-									<xs:element minOccurs="0" name="AWEARatedAnnualEnergy" type="RatedAnnualkWh">
+									<xs:element minOccurs="0" name="ThirdPartyCertification"
+										maxOccurs="unbounded" type="WindThirdPartyCertification"/>
+									<xs:element minOccurs="0" name="AWEARatedAnnualEnergy"
+										type="RatedAnnualkWh">
 										<xs:annotation>
 											<xs:documentation>[kWh] the calculated total energy that would be produced during a one-year period with an average wind speed of 5 m/s (11.2
 												mph)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AWEARatedSoundLevel" type="HPXMLDouble">
+									<xs:element minOccurs="0" name="AWEARatedSoundLevel"
+										type="HPXMLDouble">
 										<xs:annotation>
 											<xs:documentation>[dBA] the sound pressure level not exceeded by the wind turbine 95% of the time at a distance of 60 meters from the rotor with an average
 												wind speed of 5 m/s (11.2 mph). </xs:documentation>
@@ -1928,17 +2199,20 @@
 											<xs:documentation>[kW] the highest point on the certified power curve.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RotorDiameter" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="RotorDiameter"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HubHeight" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="HubHeight"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="LevelizedCostOfElectricity" type="Cost">
+									<xs:element minOccurs="0" name="LevelizedCostOfElectricity"
+										type="Cost">
 										<xs:annotation>
 											<xs:documentation>[$] The LCOE is the total cost of installing and operating a project expressed in dollars per kilowatt-hour of electricity generated by
 												the system over its life. Can be calculated with System Advisor Model, a similar software, or through a simplified calculation at
@@ -1960,13 +2234,19 @@
 	</xs:complexType>
 	<xs:complexType name="Appliances">
 		<xs:sequence>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="ClothesWasher" type="ClothesWasherInfoType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="ClothesDryer" type="ClothesDryerInfoType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="Dishwasher" type="DishwasherInfoType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="Refrigerator" type="RefrigeratorInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="ClothesWasher"
+				type="ClothesWasherInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="ClothesDryer"
+				type="ClothesDryerInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="Dishwasher"
+				type="DishwasherInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="Refrigerator"
+				type="RefrigeratorInfoType"/>
 			<xs:element minOccurs="0" maxOccurs="unbounded" name="Freezer" type="FreezerInfoType"/>
-			<xs:element name="Dehumidifier" maxOccurs="unbounded" minOccurs="0" type="DehumidifierInfoType"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="CookingRange" type="CookingRangeInfoType"/>
+			<xs:element name="Dehumidifier" maxOccurs="unbounded" minOccurs="0"
+				type="DehumidifierInfoType"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="CookingRange"
+				type="CookingRangeInfoType"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="Oven" type="OvenInfoType"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
@@ -2009,13 +2289,15 @@
 								<xs:documentation>[W] per unit</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="LightingThirdPartyCertification"/>
+						<xs:element maxOccurs="unbounded" minOccurs="0"
+							name="ThirdPartyCertification" type="LightingThirdPartyCertification"/>
 						<xs:element name="AverageHoursPerDay" type="HoursPerDay" minOccurs="0">
 							<xs:annotation>
 								<xs:documentation>[h]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="LightingDailyHours" type="LightingDailyHours">
+						<xs:element minOccurs="0" name="LightingDailyHours"
+							type="LightingDailyHours">
 							<xs:annotation>
 								<xs:documentation>[h]</xs:documentation>
 							</xs:annotation>
@@ -2035,7 +2317,9 @@
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element minOccurs="0" ref="ConnectedDevice"/>
-						<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="LightingFixtureThirdPartyCertification"/>
+						<xs:element maxOccurs="unbounded" minOccurs="0"
+							name="ThirdPartyCertification"
+							type="LightingFixtureThirdPartyCertification"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -2046,9 +2330,12 @@
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element minOccurs="0" ref="ConnectedDevice"/>
-						<xs:element minOccurs="0" name="AttachedToLightingGroup" type="LocalReference"/>
-						<xs:element name="LightingControlType" type="LightingControls" minOccurs="0"> </xs:element>
-						<xs:element name="NumberofLightingControls" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+						<xs:element minOccurs="0" name="AttachedToLightingGroup"
+							type="LocalReference"/>
+						<xs:element name="LightingControlType" type="LightingControls" minOccurs="0"
+							> </xs:element>
+						<xs:element name="NumberofLightingControls"
+							type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
 						<xs:element name="Location" type="LightingLocation" minOccurs="0"> </xs:element>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
@@ -2083,7 +2370,8 @@
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
-						<xs:element minOccurs="0" name="ThirdPartyCertification" type="ApplianceThirdPartyCertifications" maxOccurs="unbounded"/>
+						<xs:element minOccurs="0" name="ThirdPartyCertification"
+							type="ApplianceThirdPartyCertifications" maxOccurs="unbounded"/>
 						<xs:element minOccurs="0" name="Quantity" type="IntegerGreaterThanZero">
 							<xs:annotation>
 								<xs:documentation>Number of similar ceiling fans.</xs:documentation>
@@ -2145,7 +2433,8 @@
 									<xs:element name="Sodium">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="Pressure" type="SodiumLight_Pressure"> </xs:element>
+												<xs:element minOccurs="0" name="Pressure"
+												type="SodiumLight_Pressure"> </xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
@@ -2189,7 +2478,8 @@
 								<xs:documentation>[gal] Volume of pool.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="MonthsPerYearofOperation" type="MonthsPerYear">
+						<xs:element minOccurs="0" name="MonthsPerYearofOperation"
+							type="MonthsPerYear">
 							<xs:annotation>
 								<xs:documentation>Months per year pool is in operation.</xs:documentation>
 							</xs:annotation>
@@ -2199,7 +2489,8 @@
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="SuctionPipeDiameter" type="LengthMeasurement">
+						<xs:element minOccurs="0" name="SuctionPipeDiameter"
+							type="LengthMeasurement">
 							<xs:annotation>
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
@@ -2221,91 +2512,109 @@
 											<xs:sequence>
 												<xs:group ref="SystemInfo"/>
 												<xs:element minOccurs="0" ref="ConnectedDevice"/>
-												<xs:element minOccurs="0" name="Type" type="PoolPumpType"/>
-												<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString">
-													<xs:annotation>
-														<xs:documentation>Manufacturer of pool pump.</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="Type"
+												type="PoolPumpType"/>
+												<xs:element minOccurs="0" name="Manufacturer"
+												type="HPXMLString">
+												<xs:annotation>
+												<xs:documentation>Manufacturer of pool pump.</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString">
-													<xs:annotation>
-														<xs:documentation>Serial number of pool pump.</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="SerialNumber"
+												type="HPXMLString">
+												<xs:annotation>
+												<xs:documentation>Serial number of pool pump.</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="ModelNumber" type="HPXMLString">
-													<xs:annotation>
-														<xs:documentation>Model number of pool pump.</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="ModelNumber"
+												type="HPXMLString">
+												<xs:annotation>
+												<xs:documentation>Model number of pool pump.</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="ThirdPartyCertification" type="PoolPump3rdPartyCertification" maxOccurs="unbounded">
-													<xs:annotation>
-														<xs:documentation>Independent organization has verified that product or appliance meets or exceeds the standard in question (ENERGY STAR, CEE,
+												<xs:element minOccurs="0"
+												name="ThirdPartyCertification"
+												type="PoolPump3rdPartyCertification"
+												maxOccurs="unbounded">
+												<xs:annotation>
+												<xs:documentation>Independent organization has verified that product or appliance meets or exceeds the standard in question (ENERGY STAR, CEE,
 															or other)</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="EnergyFactor" type="Efficiency">
-													<xs:annotation>
-														<xs:documentation>[gal/Wh] The measure of overall pool filter pump efficiency in units of gallons per watt-hour, as determined using the
+												<xs:element minOccurs="0" name="EnergyFactor"
+												type="Efficiency">
+												<xs:annotation>
+												<xs:documentation>[gal/Wh] The measure of overall pool filter pump efficiency in units of gallons per watt-hour, as determined using the
 															applicable test method in Section 4.1.2. Energy factor is analogous to other energy factors such as miles per gallon. Energy factor (EF) is
 															calculated as: EF (gal/Wh) = flow rate (gpm) * 60 ÷ power (watts) (ANSI/APSP/ICC-15 2011).</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="SpeedSetting" type="PoolPumpSpeedSetting">
-													<xs:annotation>
-														<xs:documentation>The speed setting at which the Energy Factor was measured (ENERGY STAR, 2013).</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="SpeedSetting"
+												type="PoolPumpSpeedSetting">
+												<xs:annotation>
+												<xs:documentation>The speed setting at which the Energy Factor was measured (ENERGY STAR, 2013).</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="RatedHorsepower" type="Power">
-													<xs:annotation>
-														<xs:documentation>The motor power output designed by the manufacturer for a rated RPM, voltage and frequency. May be less than total horsepower
+												<xs:element minOccurs="0" name="RatedHorsepower"
+												type="Power">
+												<xs:annotation>
+												<xs:documentation>The motor power output designed by the manufacturer for a rated RPM, voltage and frequency. May be less than total horsepower
 															where the service factor is greater than 1.0, or equal to total horsepower where the service factor = 1.0 (ANSI/APSP/ICC-15
 															2011).</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="TotalHorsepower" type="Power">
-													<xs:annotation>
-														<xs:documentation>The total horsepower, or product of the rated horsepower and the service factor of a motor used on a pool pump (also known as
+												<xs:element minOccurs="0" name="TotalHorsepower"
+												type="Power">
+												<xs:annotation>
+												<xs:documentation>The total horsepower, or product of the rated horsepower and the service factor of a motor used on a pool pump (also known as
 															SFHP) based on the maximum continuous duty motor power output rating allowable for the nameplate ambient rating and motor insulation class
 															(e.g., total horsepower = rated horsepower * service factor) (ANSI/APSP/ICC-15 2011).</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="ServiceFactor" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>A multiplier applied to the rated horsepower of a pump motor to indicate the percent above nameplate horsepower at which the
+												<xs:element minOccurs="0" name="ServiceFactor"
+												type="HPXMLDouble">
+												<xs:annotation>
+												<xs:documentation>A multiplier applied to the rated horsepower of a pump motor to indicate the percent above nameplate horsepower at which the
 															motor can operate continuously without exceeding its allowable insulation class temperature limit, provided that other design parameters,
 															such rated voltage, frequency and ambient temperature, are within limits. A 1.5 hp pump with a 1.65 service factor produces 2.475 hp (total
 															horsepower) at the maximum service factor point (ANSI/APSP/ICC-15 2011).</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element maxOccurs="unbounded" minOccurs="0" name="PumpSpeed">
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element minOccurs="0" name="Power" type="Power">
-																<xs:annotation>
-																	<xs:documentation>[W]</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" name="MotorNominalSpeed" type="Speed">
-																<xs:annotation>
-																	<xs:documentation>[Rev/min] The number of revolutions of the motor shaft in a given unit of time, expressed as revolutions per
+												<xs:element maxOccurs="unbounded" minOccurs="0"
+												name="PumpSpeed">
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element minOccurs="0" name="Power"
+												type="Power">
+												<xs:annotation>
+												<xs:documentation>[W]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="MotorNominalSpeed"
+												type="Speed">
+												<xs:annotation>
+												<xs:documentation>[Rev/min] The number of revolutions of the motor shaft in a given unit of time, expressed as revolutions per
 																		minute (RPM) (ENERGY STAR, 2013).</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" name="FlowRate" type="FlowRate">
-																<xs:annotation>
-																	<xs:documentation>[gal/min] The volume of water flowing through the filtration system in a given time, usually measured in gallons
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="FlowRate"
+												type="FlowRate">
+												<xs:annotation>
+												<xs:documentation>[gal/min] The volume of water flowing through the filtration system in a given time, usually measured in gallons
 																		per minute (gpm) (ANSI/APSP/ICC-15 2011).</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" name="HoursPerDay" type="HoursPerDay">
-																<xs:annotation>
-																	<xs:documentation>[hours] Number of hours per day a pool pump operates at a particular speed setting.</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" ref="extension"/>
-														</xs:sequence>
-														<xs:attribute name="dataSource" type="DataSource"/>
-													</xs:complexType>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="HoursPerDay"
+												type="HoursPerDay">
+												<xs:annotation>
+												<xs:documentation>[hours] Number of hours per day a pool pump operates at a particular speed setting.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												<xs:attribute name="dataSource" type="DataSource"
+												/>
+												</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -2373,8 +2682,10 @@
 						<xs:element minOccurs="0" ref="ConnectedDevice"/>
 						<xs:element minOccurs="0" name="ControlsPlugLoad" type="LocalReference"/>
 						<xs:element minOccurs="0" ref="AttachedToSpace"/>
-						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
-						<xs:element name="PlugLoadControlType" minOccurs="0" type="PlugLoadControlType"/>
+						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero"
+							minOccurs="0"/>
+						<xs:element name="PlugLoadControlType" minOccurs="0"
+							type="PlugLoadControlType"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -2388,7 +2699,8 @@
 						<xs:element minOccurs="0" ref="AttachedToSpace"/>
 						<xs:element name="PlugLoadType" type="PlugLoadType" minOccurs="0"/>
 						<xs:element minOccurs="0" name="Location" type="PlugLoadLocation"/>
-						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero"
+							minOccurs="0"/>
 						<xs:element minOccurs="0" name="Load">
 							<xs:complexType>
 								<xs:sequence>
@@ -2421,10 +2733,14 @@
 			<xs:element name="Ventilation" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="WholeBuildingVentilationDesign" type="WholeBldgVentDesignInfo"/>
-						<xs:element minOccurs="0" name="SpotVentilationDesign" type="SpotVentDesignInfo"/>
-						<xs:element minOccurs="0" name="OtherVentilationIssues" type="OtherVentIssues"/>
-						<xs:element minOccurs="0" name="VentilationImprovement" type="VentilationImprovementInfo"/>
+						<xs:element minOccurs="0" name="WholeBuildingVentilationDesign"
+							type="WholeBldgVentDesignInfo"/>
+						<xs:element minOccurs="0" name="SpotVentilationDesign"
+							type="SpotVentDesignInfo"/>
+						<xs:element minOccurs="0" name="OtherVentilationIssues"
+							type="OtherVentIssues"/>
+						<xs:element minOccurs="0" name="VentilationImprovement"
+							type="VentilationImprovementInfo"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -2433,8 +2749,10 @@
 			<xs:element name="MoistureControl" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="MoistureControlInfo" type="MoistureControlInfoType"> </xs:element>
-						<xs:element minOccurs="0" name="MoistureControlImprovement" type="MoistureControlImprovementInfo"/>
+						<xs:element maxOccurs="unbounded" name="MoistureControlInfo"
+							type="MoistureControlInfoType"> </xs:element>
+						<xs:element minOccurs="0" name="MoistureControlImprovement"
+							type="MoistureControlImprovementInfo"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -2443,22 +2761,26 @@
 			<xs:element minOccurs="0" name="CombustionAppliances">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="CombustionApplianceZone" maxOccurs="unbounded">
+						<xs:element minOccurs="0" name="CombustionApplianceZone"
+							maxOccurs="unbounded">
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element name="CAZDepressurizationLimit" type="CAZDepressurizationLimit" minOccurs="0">
+									<xs:element name="CAZDepressurizationLimit"
+										type="CAZDepressurizationLimit" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>Pulled from industry standards by users (e.g. BPI Gold Sheet) or via software program</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="BaselineTest" type="CAZTestConfiguration" minOccurs="0">
+									<xs:element name="BaselineTest" type="CAZTestConfiguration"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>Baseline pressure is read under the following conditions: no items running, all fans off, all exterior doors closed, and all interior
 												doors are opened.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="PoorCaseTest" type="CAZTestConfiguration">
+									<xs:element minOccurs="0" name="PoorCaseTest"
+										type="CAZTestConfiguration">
 										<xs:annotation>
 											<xs:documentation>The poor case CAZ depressurization test is configured by determining the largest combustion appliance zone depressurization attainable at
 												the time of testing due to the combined effects of door position, exhaust appliance operation, and air handler fan operation. A base pressure must be
@@ -2466,102 +2788,123 @@
 												depressurization attained at the time of testing and the base pressure.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="NetPressureChange" type="NetPressureChange" minOccurs="0">
+									<xs:element name="NetPressureChange" type="NetPressureChange"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>With respect to the baseline pressure (e.g. no fans running, all exterior doors closed, and all interior doors opened)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="DepressurizationFindingPoorCase" type="DepressurizationFindingPoorCase" minOccurs="0"/>
-									<xs:element name="AmountAmbientCOinCAZduringTesting" type="HPXMLDouble" minOccurs="0">
+									<xs:element name="DepressurizationFindingPoorCase"
+										type="DepressurizationFindingPoorCase" minOccurs="0"/>
+									<xs:element name="AmountAmbientCOinCAZduringTesting"
+										type="HPXMLDouble" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>parts per million (ppm)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="AmbientCOinCAZExceeded35ppmduringTesting" type="HPXMLBoolean" minOccurs="0"/>
-									<xs:element minOccurs="0" name="CombustionApplianceTest" maxOccurs="unbounded">
+									<xs:element name="AmbientCOinCAZExceeded35ppmduringTesting"
+										type="HPXMLBoolean" minOccurs="0"/>
+									<xs:element minOccurs="0" name="CombustionApplianceTest"
+										maxOccurs="unbounded">
 										<xs:complexType>
 											<xs:sequence minOccurs="0">
-												<xs:element name="CAZAppliance" type="RemoteReference">
-													<xs:annotation>
-														<xs:documentation>The ID of the system tested</xs:documentation>
-													</xs:annotation>
+												<xs:element name="CAZAppliance"
+												type="RemoteReference">
+												<xs:annotation>
+												<xs:documentation>The ID of the system tested</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="CombustionVentingSystem" type="RemoteReference"/>
-												<xs:element name="FlueVisualCondition" type="FlueCondition" minOccurs="0"/>
-												<xs:element minOccurs="0" name="FlueConditionNotes" type="HPXMLString"/>
-												<xs:element name="OutsideTemperatureFlueDraftTest" type="Temperature" minOccurs="0">
-													<xs:annotation>
-														<xs:documentation>[deg F]</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0"
+												name="CombustionVentingSystem"
+												type="RemoteReference"/>
+												<xs:element name="FlueVisualCondition"
+												type="FlueCondition" minOccurs="0"/>
+												<xs:element minOccurs="0" name="FlueConditionNotes"
+												type="HPXMLString"/>
+												<xs:element name="OutsideTemperatureFlueDraftTest"
+												type="Temperature" minOccurs="0">
+												<xs:annotation>
+												<xs:documentation>[deg F]</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="FlueDraftTest">
-													<xs:annotation>
-														<xs:documentation>[Pa]</xs:documentation>
-													</xs:annotation>
-													<xs:complexType>
-														<xs:complexContent>
-															<xs:extension base="CAZApplianceReading">
-																<xs:sequence>
-																	<xs:element ref="extension" minOccurs="0"/>
-																</xs:sequence>
-															</xs:extension>
-														</xs:complexContent>
-													</xs:complexType>
+												<xs:annotation>
+												<xs:documentation>[Pa]</xs:documentation>
+												</xs:annotation>
+												<xs:complexType>
+												<xs:complexContent>
+												<xs:extension base="CAZApplianceReading">
+												<xs:sequence>
+												<xs:element ref="extension" minOccurs="0"/>
+												</xs:sequence>
+												</xs:extension>
+												</xs:complexContent>
+												</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="SpillageTest">
-													<xs:annotation>
-														<xs:documentation>[seconds]</xs:documentation>
-													</xs:annotation>
-													<xs:complexType>
-														<xs:complexContent>
-															<xs:extension base="CAZApplianceReading">
-																<xs:sequence>
-																	<xs:element ref="extension" minOccurs="0"/>
-																</xs:sequence>
-															</xs:extension>
-														</xs:complexContent>
-													</xs:complexType>
+												<xs:annotation>
+												<xs:documentation>[seconds]</xs:documentation>
+												</xs:annotation>
+												<xs:complexType>
+												<xs:complexContent>
+												<xs:extension base="CAZApplianceReading">
+												<xs:sequence>
+												<xs:element ref="extension" minOccurs="0"/>
+												</xs:sequence>
+												</xs:extension>
+												</xs:complexContent>
+												</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="CarbonMonoxideTest">
-													<xs:annotation>
-														<xs:documentation>[ppm]</xs:documentation>
-													</xs:annotation>
-													<xs:complexType>
-														<xs:complexContent>
-															<xs:extension base="CAZApplianceReading">
-																<xs:sequence>
-																	<xs:element name="MaxAmbientCOinLivingSpaceDuringAudit" minOccurs="0" type="HPXMLDouble">
-																		<xs:annotation>
-																			<xs:documentation>Monitored throughout assessment, not just appliance testing</xs:documentation>
-																		</xs:annotation>
-																	</xs:element>
-																	<xs:element minOccurs="0" name="AmbientCOActionDuringCAZTesting" type="HPXMLString">
-																		<xs:annotation>
-																			<xs:documentation>BPI Gold Sheet is one example that shows action levels based upon decision logic</xs:documentation>
-																		</xs:annotation>
-																	</xs:element>
-																	<xs:element minOccurs="0" ref="extension"/>
-																</xs:sequence>
-															</xs:extension>
-														</xs:complexContent>
-													</xs:complexType>
+												<xs:annotation>
+												<xs:documentation>[ppm]</xs:documentation>
+												</xs:annotation>
+												<xs:complexType>
+												<xs:complexContent>
+												<xs:extension base="CAZApplianceReading">
+												<xs:sequence>
+												<xs:element
+												name="MaxAmbientCOinLivingSpaceDuringAudit"
+												minOccurs="0" type="HPXMLDouble">
+												<xs:annotation>
+												<xs:documentation>Monitored throughout assessment, not just appliance testing</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element name="StackTemperature" type="Temperature" minOccurs="0">
-													<xs:annotation>
-														<xs:documentation>[deg F] after 10 minutes run time</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0"
+												name="AmbientCOActionDuringCAZTesting"
+												type="HPXMLString">
+												<xs:annotation>
+												<xs:documentation>BPI Gold Sheet is one example that shows action levels based upon decision logic</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element name="FuelLeaks" minOccurs="0" maxOccurs="unbounded">
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element name="FuelType" type="FuelType"/>
-															<xs:element name="LeaksIdentified" type="HPXMLBoolean"/>
-															<xs:element name="LeaksAddressed" type="HPXMLBoolean"/>
-															<xs:element minOccurs="0" name="Notes" type="HPXMLString"/>
-															<xs:element minOccurs="0" ref="extension"/>
-														</xs:sequence>
-														<xs:attribute name="dataSource" type="DataSource"/>
-													</xs:complexType>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												</xs:extension>
+												</xs:complexContent>
+												</xs:complexType>
+												</xs:element>
+												<xs:element name="StackTemperature"
+												type="Temperature" minOccurs="0">
+												<xs:annotation>
+												<xs:documentation>[deg F] after 10 minutes run time</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element name="FuelLeaks" minOccurs="0"
+												maxOccurs="unbounded">
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element name="FuelType" type="FuelType"/>
+												<xs:element name="LeaksIdentified"
+												type="HPXMLBoolean"/>
+												<xs:element name="LeaksAddressed"
+												type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="Notes"
+												type="HPXMLString"/>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												<xs:attribute name="dataSource" type="DataSource"
+												/>
+												</xs:complexType>
 												</xs:element>
 												<xs:element ref="extension" minOccurs="0"/>
 											</xs:sequence>
@@ -2583,7 +2926,8 @@
 					<xs:sequence>
 						<xs:element name="StoveID" type="SystemIdentifiersInfoType"/>
 						<xs:element minOccurs="0" name="StoveFuel" type="FuelType"/>
-						<xs:element name="HeatingStoveProperlyVented" type="HPXMLBoolean" minOccurs="0"/>
+						<xs:element name="HeatingStoveProperlyVented" type="HPXMLBoolean"
+							minOccurs="0"/>
 						<xs:element name="COReading" type="COReading" minOccurs="0"/>
 						<xs:element minOccurs="0" name="TimeofCOReading" type="HPXMLDateTime"/>
 						<xs:element name="GasLeaksIdentified" type="HPXMLBoolean" minOccurs="0"/>
@@ -2611,7 +2955,8 @@
 								<xs:documentation>Did the contracted scope of work include window replacement?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="LeadSafeCertificationNumber" type="HPXMLString">
+						<xs:element minOccurs="0" name="LeadSafeCertificationNumber"
+							type="HPXMLString">
 							<xs:annotation>
 								<xs:documentation>Certification Number of the EPA Lead-Safe Certified firm that performed the work.</xs:documentation>
 							</xs:annotation>
@@ -2629,27 +2974,34 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="StartDateTime" type="HPXMLDateTime"/>
-									<xs:element minOccurs="0" name="EndDateTime" type="HPXMLDateTime"/>
-									<xs:element minOccurs="0" name="TestLocation" type="RadonTestLocation"/>
-									<xs:element name="RadonTestResults" type="HPXMLDouble" minOccurs="0">
+									<xs:element minOccurs="0" name="StartDateTime"
+										type="HPXMLDateTime"/>
+									<xs:element minOccurs="0" name="EndDateTime"
+										type="HPXMLDateTime"/>
+									<xs:element minOccurs="0" name="TestLocation"
+										type="RadonTestLocation"/>
+									<xs:element name="RadonTestResults" type="HPXMLDouble"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>in pCi/L</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RadonTestMethod" type="RadonTestTypes"/>
+									<xs:element minOccurs="0" name="RadonTestMethod"
+										type="RadonTestTypes"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
-						<xs:element minOccurs="0" name="EducationMaterialProvided" type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="EducationMaterialProvided"
+							type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Was the homeowner provided with educational material?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element minOccurs="0" name="ActionsTaken" type="HPXMLString"/>
-						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecs" type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecs"
+							type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>If moisture management of a crawlspace (e.g., installation of polyethylene sheeting) or radon mitigation measures were a part of the scope of
 									work,were measures installed to be compliant with one of the following: - Specifications of EPA’s Indoor airPLUS program - Techniques detailed in EPA's
@@ -2670,12 +3022,14 @@
 			<xs:element minOccurs="0" name="SourcePollutants">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="UnventedCombustionAppliancesinLivingArea" type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="UnventedCombustionAppliancesinLivingArea"
+							type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Are there unvented combustion heating or hearth appliances present in the living area?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="ConformanceWithANSIZ21_11_2" type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="ConformanceWithANSIZ21_11_2"
+							type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>If yes, does the appliance conform with ANSI Z21.11.2? </xs:documentation>
 							</xs:annotation>
@@ -2690,7 +3044,8 @@
 								<xs:documentation>Does home have attached garage?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="GarageContinuousAirBarrier" type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="GarageContinuousAirBarrier"
+							type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>If yes, is there a continuous air barrier between garage and living space?</xs:documentation>
 							</xs:annotation>
@@ -2718,7 +3073,8 @@
 								<xs:documentation>Evidence of pesticide, insecticide use?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="IndustryStandardCompliance" type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="IndustryStandardCompliance"
+							type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Do measures comply with industry standards to prevent pest entry? NOTE: This is for ALL measures that may create entry points for vermin. For example,
 									air sealing measures identified to reduce infiltration should have proper sealants - even if those measures were not recommended/installed for pest control
@@ -2748,9 +3104,11 @@
 								<xs:documentation>Was asbestos found?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="TypeofBlowerDoorTest" type="TypeofBlowerDoorTest"/>
+						<xs:element minOccurs="0" name="TypeofBlowerDoorTest"
+							type="TypeofBlowerDoorTest"/>
 						<xs:element minOccurs="0" name="ActionsTaken" type="HPXMLString"/>
-						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecifications" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecifications"
+							type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -2882,7 +3240,8 @@
 				</xs:element>
 				<xs:element name="RequiredVentilationRateUnits" type="VentilationRateUnits"/>
 			</xs:sequence>
-			<xs:element minOccurs="0" name="VentilationImprovementRecommendation" type="Recommendation"/>
+			<xs:element minOccurs="0" name="VentilationImprovementRecommendation"
+				type="Recommendation"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -2978,7 +3337,8 @@
 					<xs:documentation>should be represented as a fraction (ie 0.5 instead of 50%)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="EndUseSavings" type="EndUseInfoType"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="EndUseSavings"
+				type="EndUseInfoType"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -3014,16 +3374,19 @@
 			<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="HVACThirdPartyCertification"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification"
+				type="HVACThirdPartyCertification"/>
 			<xs:element minOccurs="0" name="HasSharedCombustionVentilation" type="HPXMLBoolean"/>
 			<xs:element minOccurs="0" name="CombustionVentingSystem" type="LocalReference"/>
-			<xs:element name="DistributionSystem" type="LocalReference" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="DistributionSystem" type="LocalReference" minOccurs="0"
+				maxOccurs="unbounded"/>
 			<xs:element minOccurs="0" name="Installation">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element minOccurs="0" name="Standard" type="HVACInstallationStandard"/>
 						<xs:element minOccurs="0" name="SizingCalculation" type="HVACSizingCalcs"/>
-						<xs:element minOccurs="0" name="EnvelopeImprovementsUsedinSizing" type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="EnvelopeImprovementsUsedinSizing"
+							type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Air sealing and insulation implemented prior to replacement and used in calculations for sizing new / replacement system?</xs:documentation>
 							</xs:annotation>
@@ -3056,7 +3419,8 @@
 							<xs:documentation>[Btuh] Input Heating Capacity</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="AnnualHeatingEfficiency" type="HeatingEfficiencyType" maxOccurs="unbounded"> </xs:element>
+					<xs:element minOccurs="0" name="AnnualHeatingEfficiency"
+						type="HeatingEfficiencyType" maxOccurs="unbounded"> </xs:element>
 					<xs:element name="FractionHeatLoadServed" type="Fraction" minOccurs="0"/>
 					<xs:element minOccurs="0" name="FloorAreaServed" type="SurfaceArea">
 						<xs:annotation>
@@ -3085,7 +3449,8 @@
 						<xs:element minOccurs="0" name="PowerBurner" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
-						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
+							type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="RetentionHead" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
@@ -3105,7 +3470,8 @@
 						<xs:element minOccurs="0" name="RotaryCup" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
-						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
+							type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="RetentionHead" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
@@ -3115,7 +3481,8 @@
 			<xs:element name="ElectricResistance">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="ElectricDistribution" type="ElectricDistributionType" minOccurs="0"/>
+						<xs:element name="ElectricDistribution" type="ElectricDistributionType"
+							minOccurs="0"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -3131,7 +3498,8 @@
 						</xs:element>
 						<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
-						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
+							type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -3147,7 +3515,8 @@
 						</xs:element>
 						<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
-						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
+							type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -3226,13 +3595,15 @@
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="BackupSystemFuel" type="FuelType" minOccurs="0"/>
-					<xs:element name="BackupAnnualHeatingEfficiency" minOccurs="0" type="HeatingEfficiencyType" maxOccurs="unbounded"> </xs:element>
+					<xs:element name="BackupAnnualHeatingEfficiency" minOccurs="0"
+						type="HeatingEfficiencyType" maxOccurs="unbounded"> </xs:element>
 					<xs:element minOccurs="0" name="BackupHeatingCapacity" type="Capacity">
 						<xs:annotation>
 							<xs:documentation>[Btuh]</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="BackupHeatingSwitchoverTemperature" type="Temperature">
+					<xs:element minOccurs="0" name="BackupHeatingSwitchoverTemperature"
+						type="Temperature">
 						<xs:annotation>
 							<xs:documentation>[deg F] Temperature at which the backup heating is activated.</xs:documentation>
 						</xs:annotation>
@@ -3244,8 +3615,10 @@
 							<xs:documentation>[sq.ft.]</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="AnnualHeatingEfficiency" minOccurs="0" type="HeatingEfficiencyType" maxOccurs="unbounded"> </xs:element>
+					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType"
+						minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="AnnualHeatingEfficiency" minOccurs="0"
+						type="HeatingEfficiencyType" maxOccurs="unbounded"> </xs:element>
 					<xs:element minOccurs="0" ref="extension"/>
 				</xs:sequence>
 			</xs:extension>
@@ -3268,7 +3641,8 @@
 							<xs:documentation>[sq.ft.]</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType"
+						minOccurs="0" maxOccurs="unbounded"/>
 					<xs:element minOccurs="0" name="SensibleHeatFraction" type="Fraction"/>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
@@ -3308,7 +3682,8 @@
 				</xs:annotation>
 			</xs:element>
 			<xs:element minOccurs="0" name="PipeDiameter" type="PipeDiameterType"/>
-			<xs:element name="HydronicDistributionType" type="HydronicDistributionType" minOccurs="0"/>
+			<xs:element name="HydronicDistributionType" type="HydronicDistributionType"
+				minOccurs="0"/>
 			<xs:element minOccurs="0" name="SupplyTemperature" type="Temperature">
 				<xs:annotation>
 					<xs:documentation>[degF]</xs:documentation>
@@ -3327,7 +3702,8 @@
 								<xs:documentation>System Pump and Zone Valve Corrections made</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="ThermostaticRadiatorValves" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="ThermostaticRadiatorValves"
+							type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="VariableSpeedPump" type="HPXMLBoolean"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -3341,21 +3717,25 @@
 		<xs:sequence>
 			<xs:element name="AirDistributionType" type="AirDistributionType" minOccurs="0"/>
 			<xs:element name="AirHandlerMotorType" type="AirHandlerMotorType" minOccurs="0"/>
-			<xs:element minOccurs="0" name="DuctLeakageMeasurement" type="DuctLeakageMeasurementType" maxOccurs="unbounded"/>
+			<xs:element minOccurs="0" name="DuctLeakageMeasurement"
+				type="DuctLeakageMeasurementType" maxOccurs="unbounded"/>
 			<xs:element minOccurs="0" name="DuctSystemSizingAppropriate" type="HPXMLBoolean"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="Ducts">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element name="DuctType" type="DuctType" minOccurs="0"/>
 						<xs:element name="DuctMaterial" type="DuctMaterial" minOccurs="0"/>
-						<xs:element minOccurs="0" name="DuctInsulationMaterial" type="InsulationMaterial"/>
+						<xs:element minOccurs="0" name="DuctInsulationMaterial"
+							type="InsulationMaterial"/>
 						<xs:element name="DuctInsulationRValue" type="RValue" minOccurs="0"/>
-						<xs:element minOccurs="0" name="DuctInsulationThickness" type="LengthMeasurement">
+						<xs:element minOccurs="0" name="DuctInsulationThickness"
+							type="LengthMeasurement">
 							<xs:annotation>
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DuctInsulationCondition" type="InsulationCondition"/>
+						<xs:element minOccurs="0" name="DuctInsulationCondition"
+							type="InsulationCondition"/>
 						<xs:element name="DuctLocation" type="DuctLocation" minOccurs="0"/>
 						<xs:element minOccurs="0" name="FractionDuctArea" type="Fraction">
 							<xs:annotation>
@@ -3373,12 +3753,15 @@
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="NumberofReturnRegisters" type="IntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="NumberofReturnRegisters"
+				type="IntegerGreaterThanOrEqualToZero"/>
 			<xs:element minOccurs="0" name="TotalExternalStaticPressureMeasurement">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="Supply" type="TotalExternalStaticPressureMeasurement"/>
-						<xs:element minOccurs="0" name="Return" type="TotalExternalStaticPressureMeasurement"/>
+						<xs:element minOccurs="0" name="Supply"
+							type="TotalExternalStaticPressureMeasurement"/>
+						<xs:element minOccurs="0" name="Return"
+							type="TotalExternalStaticPressureMeasurement"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -3428,50 +3811,61 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:element minOccurs="0" name="SiteType" type="SiteType"/>
-									<xs:element minOccurs="0" name="Surroundings" type="Surroundings">
+									<xs:element minOccurs="0" name="Surroundings"
+										type="Surroundings">
 										<xs:annotation>
 											<xs:documentation>If the building is attached to other units in the horizontal plane.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="VerticalSurroundings" type="VerticalSurroundings">
+									<xs:element minOccurs="0" name="VerticalSurroundings"
+										type="VerticalSurroundings">
 										<xs:annotation>
 											<xs:documentation>If the building is attached to other units on the vertical plane.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ShieldingofHome" type="ShieldingofHome" minOccurs="0"/>
-									<xs:element minOccurs="0" name="OrientationOfFrontOfHome" type="OrientationType"/>
-									<xs:element minOccurs="0" name="AzimuthOfFrontOfHome" type="AzimuthType"/>
+									<xs:element name="ShieldingofHome" type="ShieldingofHome"
+										minOccurs="0"/>
+									<xs:element minOccurs="0" name="OrientationOfFrontOfHome"
+										type="OrientationType"/>
+									<xs:element minOccurs="0" name="AzimuthOfFrontOfHome"
+										type="AzimuthType"/>
 									<xs:element minOccurs="0" name="PublicTransportation">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="DistanceFromSubway" type="LengthMeasurement">
-													<xs:annotation>
-														<xs:documentation>[ft]</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="DistanceFromSubway"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft]</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="DistanceFromBus" type="LengthMeasurement">
-													<xs:annotation>
-														<xs:documentation>[ft]</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="DistanceFromBus"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft]</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="DistanceFromTrain" type="LengthMeasurement">
-													<xs:annotation>
-														<xs:documentation>[ft]</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="DistanceFromTrain"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft]</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="WalkingScore" type="IntegerGreaterThanOrEqualToZero"/>
-									<xs:element minOccurs="0" name="WalkingScoreSource" type="HPXMLString"/>
+									<xs:element minOccurs="0" name="WalkingScore"
+										type="IntegerGreaterThanOrEqualToZero"/>
+									<xs:element minOccurs="0" name="WalkingScoreSource"
+										type="HPXMLString"/>
 									<xs:element minOccurs="0" name="FuelTypesAvailable">
 										<xs:annotation>
 											<xs:documentation>Fuels available on site via utility lines/pipes or delivery.</xs:documentation>
 										</xs:annotation>
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element maxOccurs="unbounded" name="Fuel" type="FuelType"/>
+												<xs:element maxOccurs="unbounded" name="Fuel"
+												type="FuelType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -3484,38 +3878,47 @@
 						<xs:element minOccurs="0" name="BuildingOccupancy">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element minOccurs="0" name="HouseholdType" type="HouseholdType"/>
+									<xs:element minOccurs="0" name="HouseholdType"
+										type="HouseholdType"/>
 									<xs:element minOccurs="0" name="YearOccupied" type="Year">
 										<xs:annotation>
 											<xs:documentation>The year the current occupants moved into the building</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="ResidentPopulationType" type="ResidentPopulationType"/>
+									<xs:element minOccurs="0" name="ResidentPopulationType"
+										type="ResidentPopulationType"/>
 									<xs:element minOccurs="0" name="Occupancy" type="Occupancy"/>
-									<xs:element name="NumberofResidents" type="PeopleCount" minOccurs="0"/>
-									<xs:element minOccurs="0" name="NumberofAdults" type="PeopleCount">
+									<xs:element name="NumberofResidents" type="PeopleCount"
+										minOccurs="0"/>
+									<xs:element minOccurs="0" name="NumberofAdults"
+										type="PeopleCount">
 										<xs:annotation>
 											<xs:documentation>18 or older</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofChildren" type="IntegerGreaterThanOrEqualToZero">
+									<xs:element minOccurs="0" name="NumberofChildren"
+										type="IntegerGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>less than 18 years old</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="PubliclySubsidized" type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="PubliclySubsidized"
+										type="HPXMLBoolean"/>
 									<xs:element minOccurs="0" name="LowIncome" type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="OccupantIncomeRange" type="FractionGreaterThanOne">
+									<xs:element minOccurs="0" name="OccupantIncomeRange"
+										type="FractionGreaterThanOne">
 										<xs:annotation>
 											<xs:documentation>Percentage as a fraction (50% = 0.5)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="OccupantIncomeRangeUnits" type="OccupantIncomeRangeUnits">
+									<xs:element minOccurs="0" name="OccupantIncomeRangeUnits"
+										type="OccupantIncomeRangeUnits">
 										<xs:annotation>
 											<xs:documentation>AMI = Area Median Income; FPL = Federal Poverty Level</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HighestLevelofOccupantEducation" type="EducationLevels"/>
+									<xs:element minOccurs="0" name="HighestLevelofOccupantEducation"
+										type="EducationLevels"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -3525,62 +3928,80 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:element name="YearBuilt" type="Year" minOccurs="0"/>
-									<xs:element minOccurs="0" name="YearBuiltKnownOrEstimated" type="KnownOrEstimated"/>
+									<xs:element minOccurs="0" name="YearBuiltKnownOrEstimated"
+										type="KnownOrEstimated"/>
 									<xs:element minOccurs="0" name="YearofLastRemodel" type="Year"/>
-									<xs:element name="ResidentialFacilityType" type="ResidentialFacilityType" minOccurs="0"/>
-									<xs:element minOccurs="0" name="PassiveSolar" type="HPXMLBoolean">
+									<xs:element name="ResidentialFacilityType"
+										type="ResidentialFacilityType" minOccurs="0"/>
+									<xs:element minOccurs="0" name="PassiveSolar"
+										type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Passive solar design—also known as climatic design—involves using a building's windows, walls, and floors to collect, store, and
 												distribute solar energy in the form of heat in the winter and reject solar heat in the summer. (source:
 												http://www.eere.energy.gov/basics/buildings/passive_solar_design.html)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="BuildingHeight" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="BuildingHeight"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] height of building</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofUnits" type="IntegerGreaterThanZero"/>
-									<xs:element minOccurs="0" name="NumberofFloors" type="NumberOfFloorsType">
+									<xs:element minOccurs="0" name="NumberofUnits"
+										type="IntegerGreaterThanZero"/>
+									<xs:element minOccurs="0" name="NumberofFloors"
+										type="NumberOfFloorsType">
 										<xs:annotation>
 											<xs:documentation>Total number of floors including a basement, whether conditioned or unconditioned</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofConditionedFloors" type="NumberOfFloorsType">
+									<xs:element minOccurs="0" name="NumberofConditionedFloors"
+										type="NumberOfFloorsType">
 										<xs:annotation>
 											<xs:documentation>Number of floors that are heated/cooled including a basement</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofConditionedFloorsAboveGrade" type="NumberOfFloorsType">
+									<xs:element minOccurs="0"
+										name="NumberofConditionedFloorsAboveGrade"
+										type="NumberOfFloorsType">
 										<xs:annotation>
 											<xs:documentation>Number of floors above grade that are heated/cooled</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="AverageCeilingHeight" type="LengthMeasurement" minOccurs="0">
+									<xs:element name="AverageCeilingHeight" type="LengthMeasurement"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[ft] Average distance from the floor to the ceiling</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FloorToFloorHeight" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="FloorToFloorHeight"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] distance between floors</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofRooms" type="IntegerGreaterThanZero"/>
-									<xs:element name="NumberofBedrooms" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
-									<xs:element name="NumberofBathrooms" type="IntegerGreaterThanZero" minOccurs="0"/>
-									<xs:element minOccurs="0" name="NumberofCompleteBathrooms" type="IntegerGreaterThanZero">
+									<xs:element minOccurs="0" name="NumberofRooms"
+										type="IntegerGreaterThanZero"/>
+									<xs:element name="NumberofBedrooms"
+										type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+									<xs:element name="NumberofBathrooms"
+										type="IntegerGreaterThanZero" minOccurs="0"/>
+									<xs:element minOccurs="0" name="NumberofCompleteBathrooms"
+										type="IntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Number of bathrooms with a tub or shower</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="BuildingFootprintArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="BuildingFootprintArea"
+										type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FootprintShape" type="FootprintShape"/>
-									<xs:element minOccurs="0" name="GrossFloorArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="FootprintShape"
+										type="FootprintShape"/>
+									<xs:element minOccurs="0" name="GrossFloorArea"
+										type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Gross floor area (based on ASHRAE definition) is the sum of the floor areas of the spaces within the building, including
 												basements, mezzanine and intermediate‐floored tiers, and penthouses with headroom height of 7.5 ft (2.2 meters) or greater. Measurements must be taken
@@ -3598,33 +4019,39 @@
 												area.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ConditionedFloorArea" type="SurfaceArea" minOccurs="0">
+									<xs:element name="ConditionedFloorArea" type="SurfaceArea"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] All finished space that is within the (insulated) conditioned space boundary (that is, within the insulated envelope), regardless
 												of HVAC configuration.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FinishedFloorArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="FinishedFloorArea"
+										type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Floor area of home that is finished and assumed to be occupied.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="NumberofStoriesAboveGrade" type="IntegerGreaterThanZero" minOccurs="0"/>
-									<xs:element minOccurs="0" name="CooledFloorArea" type="SurfaceArea">
+									<xs:element name="NumberofStoriesAboveGrade"
+										type="IntegerGreaterThanZero" minOccurs="0"/>
+									<xs:element minOccurs="0" name="CooledFloorArea"
+										type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] The total area of all enclosed spaces measured to the internal face of the external walls. Included are areas of sloping surfaces
 												such as staircases, galleries, raked auditoria, and tiered terraces where the area taken is from the area on the plan. Excluded are areas that are not
 												enclosed such as open floors, covered ways and balconies.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HeatedFloorArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="HeatedFloorArea"
+										type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] The total area of all enclosed spaces measured to the internal face of the external walls. Included are areas of sloping surfaces
 												such as staircases, galleries, raked auditoria, and tiered terraces where the area taken is from the area on the plan. Excluded are areas that are not
 												enclosed such as open floors, covered ways and balconies.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="UnconditionedFloorArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="UnconditionedFloorArea"
+										type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] An enclosed space within a building that does not meet the requirements of a conditioned space. Spaces that have no control over
 												thermal conditions but intentionally or unintentionally receive thermal energy from adjacent spaces are considered unconditioned spaces (such as an
@@ -3640,7 +4067,8 @@
 												building.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ConditionedBuildingVolume" type="Volume" minOccurs="0">
+									<xs:element name="ConditionedBuildingVolume" type="Volume"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[cu.ft.] Volume inside the building envelope of the conditioned spaces. This metric can be calculated as the volume of the building if
 												every space is conditioned or on a floor-by-floor basis. For spaces with vertical walls and horizontal ceilings and floors, this is calculated as the
@@ -3650,7 +4078,8 @@
 												return air plenums.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="FoundationType" minOccurs="0" type="FoundationType">
+									<xs:element name="FoundationType" minOccurs="0"
+										type="FoundationType">
 										<xs:annotation>
 											<xs:documentation>Primary foundation type of building</xs:documentation>
 										</xs:annotation>
@@ -3660,13 +4089,18 @@
 											<xs:documentation>Primary attic type of building</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="AverageAtticRValue" type="RValue" minOccurs="0"/>
+									<xs:element name="AverageAtticRValue" type="RValue"
+										minOccurs="0"/>
 									<xs:element name="AverageWallRValue" type="RValue" minOccurs="0"/>
-									<xs:element name="AverageFloorRValue" type="RValue" minOccurs="0"/>
+									<xs:element name="AverageFloorRValue" type="RValue"
+										minOccurs="0"/>
 									<xs:element name="AverageDuctRValue" type="RValue" minOccurs="0"/>
-									<xs:element minOccurs="0" name="GaragePresent" type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="GarageLocation" type="GarageLocation"/>
-									<xs:element minOccurs="0" name="SpaceAboveGarage" type="SpaceAboveGarage"/>
+									<xs:element minOccurs="0" name="GaragePresent"
+										type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="GarageLocation"
+										type="GarageLocation"/>
+									<xs:element minOccurs="0" name="SpaceAboveGarage"
+										type="SpaceAboveGarage"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -3675,7 +4109,8 @@
 						<xs:element name="AnnualEnergyUse" minOccurs="0">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType" maxOccurs="unbounded"/>
+									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"
+										maxOccurs="unbounded"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
@@ -3689,13 +4124,15 @@
 				<xs:complexType>
 					<xs:sequence minOccurs="0">
 						<xs:element name="ClimateZoneDOE" type="ClimateZoneDOE" minOccurs="0"/>
-						<xs:element name="ClimateZoneIECC" minOccurs="0" type="IECCClimateZoneType" maxOccurs="unbounded"/>
+						<xs:element name="ClimateZoneIECC" minOccurs="0" type="IECCClimateZoneType"
+							maxOccurs="unbounded"/>
 						<xs:element name="RadonZone" type="RadonZone" minOccurs="0"/>
 						<xs:element name="TermiteZone" type="TermiteZone" minOccurs="0"/>
 						<xs:element name="HurricaneZone" type="HPXMLBoolean" minOccurs="0"/>
 						<xs:element name="FloodZone" type="HPXMLBoolean" minOccurs="0"/>
 						<xs:element name="EarthquakeZone" type="EarthquakeZone" minOccurs="0"/>
-						<xs:element maxOccurs="unbounded" minOccurs="0" name="WeatherStation" type="WeatherStation">
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="WeatherStation"
+							type="WeatherStation">
 							<xs:annotation>
 								<xs:documentation>Weather location used in model simulation and/or utility bill regression analysis</xs:documentation>
 							</xs:annotation>
@@ -3749,13 +4186,15 @@
 												which is the purpose of this field.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Source" type="GreenBuildingVerificationSource">
+									<xs:element minOccurs="0" name="Source"
+										type="GreenBuildingVerificationSource">
 										<xs:annotation>
 											<xs:documentation>The source of the green data. May address photovoltaic characteristics, or a verified score, certification, label, etc. This may be a pick
 												list of options showing the source. i.e. Program Sponsor, Program Verifier, Public Record, Assessor, etc.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Status" type="GreenBuildingVerificationStatus">
+									<xs:element minOccurs="0" name="Status"
+										type="GreenBuildingVerificationStatus">
 										<xs:annotation>
 											<xs:documentation>Many verification programs include a multi-step process that may begin with plans and specs, involve testing and/or submission of building
 												specifications along the way and include a final verification step. When ratings are involved it is not uncommon for the final rating to be either
@@ -3846,12 +4285,14 @@
 			<xs:element name="Incentives" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="Incentive" type="IncentiveDetailsType"/>
+						<xs:element maxOccurs="unbounded" name="Incentive"
+							type="IncentiveDetailsType"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType" maxOccurs="2"/>
+			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType"
+				maxOccurs="2"/>
 			<xs:element maxOccurs="2" minOccurs="0" name="WaterSavingsInfo" type="WaterSavingsType"/>
 			<xs:element minOccurs="0" name="Measures">
 				<xs:complexType>
@@ -3867,8 +4308,10 @@
 	</xs:complexType>
 	<xs:complexType name="TotalCostType">
 		<xs:sequence>
-			<xs:element name="TotalCostHealthSafetyMeasures" type="TotalCostHealthSafetyMeasures" minOccurs="1"/>
-			<xs:element name="TotalCostQualEnergyMeasures" type="TotalCostQualEnergyMeasures" minOccurs="1"/>
+			<xs:element name="TotalCostHealthSafetyMeasures" type="TotalCostHealthSafetyMeasures"
+				minOccurs="1"/>
+			<xs:element name="TotalCostQualEnergyMeasures" type="TotalCostQualEnergyMeasures"
+				minOccurs="1"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
@@ -3905,7 +4348,8 @@
 			<xs:element minOccurs="0" name="Incentives">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="Incentive" type="IncentiveDetailsType"/>
+						<xs:element maxOccurs="unbounded" name="Incentive"
+							type="IncentiveDetailsType"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -3924,7 +4368,8 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element name="Quantity" type="Quantity"/>
-									<xs:element name="AnnualAmount" type="AnnualAmount" minOccurs="0"/>
+									<xs:element name="AnnualAmount" type="AnnualAmount"
+										minOccurs="0"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -3934,7 +4379,8 @@
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType" maxOccurs="2"/>
+			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType"
+				maxOccurs="2"/>
 			<xs:element maxOccurs="2" minOccurs="0" name="WaterSavingsInfo" type="WaterSavingsType"/>
 			<xs:element minOccurs="0" name="CustomerNotes" type="Notes"/>
 			<xs:element minOccurs="0" name="WorkscopeNotes" type="Notes"/>
@@ -3961,7 +4407,8 @@
 				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="ReplacedComponent" type="RemoteReference"/>
+						<xs:element maxOccurs="unbounded" name="ReplacedComponent"
+							type="RemoteReference"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -3969,7 +4416,8 @@
 			<xs:element minOccurs="0" name="InstalledComponents">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="1" name="InstalledComponent" type="RemoteReference" maxOccurs="unbounded"/>
+						<xs:element minOccurs="1" name="InstalledComponent" type="RemoteReference"
+							maxOccurs="unbounded"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -3986,7 +4434,8 @@
 				</xs:annotation>
 			</xs:element>
 			<xs:element minOccurs="0" name="EnergySavingsReported" type="GrossOrNet"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="FuelSavings" type="FuelSavingsType"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="FuelSavings"
+				type="FuelSavingsType"/>
 			<xs:element name="DemandSavings" minOccurs="0" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[kW] Demand savings from energy efficiency programs</xs:documentation>
@@ -4021,7 +4470,8 @@
 	<xs:complexType name="DuctLeakageMeasurementType">
 		<xs:sequence>
 			<xs:element minOccurs="0" name="DuctType" type="DuctType"/>
-			<xs:element name="LeakinessObservedVisualInspection" type="LeakinessObservedVisualInspection" minOccurs="0"/>
+			<xs:element name="LeakinessObservedVisualInspection"
+				type="LeakinessObservedVisualInspection" minOccurs="0"/>
 			<xs:element name="DuctLeakageTestMethod" type="DuctLeakageTestMethod" minOccurs="0"/>
 			<xs:element minOccurs="0" name="DuctLeakage">
 				<xs:complexType>
@@ -4032,7 +4482,8 @@
 							</xs:annotation>
 						</xs:element>
 						<xs:element name="Value" type="MeasuredDuctLeakage" minOccurs="0"/>
-						<xs:element minOccurs="0" name="TotalOrToOutside" type="DuctLeakageTotalOrToOutside"/>
+						<xs:element minOccurs="0" name="TotalOrToOutside"
+							type="DuctLeakageTotalOrToOutside"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -4100,7 +4551,8 @@
 		<xs:sequence>
 			<xs:element minOccurs="0" name="WeatherRegressionBeginDate" type="HPXMLDate"/>
 			<xs:element minOccurs="0" name="WeatherRegressionEndDate" type="HPXMLDate"/>
-			<xs:element minOccurs="0" name="CalibrationQualification" type="BPI2400CalibrationQualification">
+			<xs:element minOccurs="0" name="CalibrationQualification"
+				type="BPI2400CalibrationQualification">
 				<xs:annotation>
 					<xs:documentation>This identifies which data quality requirements (if any) were met by the bills for the relevant energy source and therefore which calibration metrics (if any) are
 						used to determine whether the calibrated model is accepted.</xs:documentation>
@@ -4126,55 +4578,65 @@
 					<xs:documentation>Weather Normalized Annual Baseload Usage</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingBiasError" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingBiasError"
+				type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Eqn. 3.2.3.A.i of BPI-2400. Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingAbsoluteError" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingAbsoluteError"
+				type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Eqn. 3.2.3.A.ii of BPI-2400. In either kWh for electricity or MMBTU for all other fuels.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingBiasError" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingBiasError"
+				type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingAbsoluteError" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingAbsoluteError"
+				type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>In either kWh for electricity or MMBTU for all other fuels.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadBiasError" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadBiasError"
+				type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadAbsoluteError" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadAbsoluteError"
+				type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>In either kWh for electricity or MMBTU for all other fuels.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SimplifiedModelCalibrationHeatingBiasError" nillable="true" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationHeatingBiasError"
+				nillable="true" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% =
 						0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SimplifiedModelCalibrationCoolingBiasError" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationCoolingBiasError"
+				type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% =
 						0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SimplifiedModelCalibrationBaseloadBiasError" nillable="true" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationBaseloadBiasError"
+				nillable="true" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% =
 						0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SimplifiedModelCalibrationTotalBiasError" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationTotalBiasError"
+				type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% =
 						0.1)</xs:documentation>
@@ -4195,7 +4657,8 @@
 							</xs:annotation>
 						</xs:element>
 						<xs:element name="UnitofMeasure" type="energyUnitType"/>
-						<xs:element minOccurs="0" name="MeteringConfiguration" type="MeteringConfiguration">
+						<xs:element minOccurs="0" name="MeteringConfiguration"
+							type="MeteringConfiguration">
 							<xs:annotation>
 								<xs:documentation>direct metering = tenants directly metered; master meter without sub-metering = tenants not sub metered; master meter with sub-metering = tenant
 									sub-metered by building owner</xs:documentation>
@@ -4208,7 +4671,8 @@
 										<xs:complexType>
 											<xs:sequence>
 												<xs:element name="EmissionType" type="EmissionType"/>
-												<xs:element name="EmissionUnits" type="EmissionUnits"/>
+												<xs:element name="EmissionUnits"
+												type="EmissionUnits"/>
 												<xs:element name="Emissions" type="HPXMLDouble"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
@@ -4218,8 +4682,10 @@
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
-						<xs:element minOccurs="0" name="FuelInterruptibility" type="FuelInterruptibility"/>
-						<xs:element minOccurs="0" name="SharedEnergySystem" type="SharedEnergySystem"/>
+						<xs:element minOccurs="0" name="FuelInterruptibility"
+							type="FuelInterruptibility"/>
+						<xs:element minOccurs="0" name="SharedEnergySystem"
+							type="SharedEnergySystem"/>
 						<xs:element minOccurs="0" name="IntervalType" type="IntervalType"/>
 						<xs:element minOccurs="0" name="ReadingTimeZone" type="HPXMLString"/>
 						<xs:element minOccurs="0" name="MarginalEnergyCostRate" type="HPXMLDouble">
@@ -4280,7 +4746,8 @@
 			<xs:element name="UnitofMeasure" type="energyUnitType"/>
 			<xs:element minOccurs="0" name="AnnualConsumption" type="HPXMLDouble"/>
 			<xs:element minOccurs="0" name="AnnualFuelCost" type="HPXMLDouble"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="ConsumptionByEndUse" type="EndUseInfoType"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ConsumptionByEndUse"
+				type="EndUseInfoType"/>
 			<xs:element minOccurs="0" name="BaseLoad" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Baseload power is the energy consumed for the day-to-day operation of a home that is not used as a response to outside weather (i.e. excludes heating and cooling)
@@ -4335,9 +4802,12 @@
 			<xs:element name="BusinessName" type="HPXMLString"/>
 			<xs:element name="BusinessType" type="BusinessType" minOccurs="0"/>
 			<xs:element name="BusinessSpecialization" type="BusinessSpecialization" minOccurs="0"/>
-			<xs:element name="Certification" type="BusinessCertification" minOccurs="0" maxOccurs="unbounded"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="BusinessContact" type="BusinessContactInfoType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="TelephoneInfo" type="TelephoneInfoType"/>
+			<xs:element name="Certification" type="BusinessCertification" minOccurs="0"
+				maxOccurs="unbounded"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="BusinessContact"
+				type="BusinessContactInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="TelephoneInfo"
+				type="TelephoneInfoType"/>
 			<xs:element minOccurs="0" maxOccurs="unbounded" name="EmailInfo" type="EmailInfoType"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
@@ -4379,7 +4849,8 @@
 			<xs:element name="SHGC" type="SHGC" minOccurs="0"/>
 			<xs:element minOccurs="0" name="VisibleTransmittance" type="Fraction"/>
 			<xs:element name="NFRCCertified" type="HPXMLBoolean" minOccurs="0"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="WindowThirdPartyCertification"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification"
+				type="WindowThirdPartyCertification"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="WindowFilm">
 				<xs:complexType>
 					<xs:sequence>
@@ -4475,12 +4946,14 @@
 								<xs:documentation>[in] Depth of overhang</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DistanceToTopOfWindow" type="LengthMeasurement">
+						<xs:element minOccurs="0" name="DistanceToTopOfWindow"
+							type="LengthMeasurement">
 							<xs:annotation>
 								<xs:documentation>[in] Vertical distance from overhang to top of window</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DistanceToBottomOfWindow" type="LengthMeasurement">
+						<xs:element minOccurs="0" name="DistanceToBottomOfWindow"
+							type="LengthMeasurement">
 							<xs:annotation>
 								<xs:documentation>[in] Vertical distance from overhang to bottom of window</xs:documentation>
 							</xs:annotation>
@@ -4492,6 +4965,7 @@
 			<xs:element minOccurs="0" name="WeatherStripping" type="HPXMLBoolean"/>
 			<xs:element minOccurs="0" name="Operable" type="HPXMLBoolean"/>
 			<xs:element minOccurs="0" name="LeakinessDescription" type="BuildingLeakiness"/>
+			<xs:element minOccurs="0" name="PerformanceClass" type="PerformanceClass"/>
 		</xs:sequence>
 	</xs:group>
 	<xs:complexType name="WindowFrameType">
@@ -4616,7 +5090,8 @@
 				</xs:annotation>
 			</xs:element>
 			<xs:element minOccurs="0" name="WindConditions" type="WindConditions"/>
-			<xs:element name="TypeOfInfiltrationMeasurement" type="TypeofInfiltrationMeasurement" minOccurs="0"/>
+			<xs:element name="TypeOfInfiltrationMeasurement" type="TypeofInfiltrationMeasurement"
+				minOccurs="0"/>
 			<xs:element name="TypeOfBlowerDoorTest" type="TypeofBlowerDoorTest" minOccurs="0"/>
 			<xs:element name="HousePressure" type="HousePressure" minOccurs="0">
 				<xs:annotation>
@@ -4658,8 +5133,10 @@
 	<xs:complexType name="MoistureControlInfoType">
 		<xs:sequence>
 			<xs:group ref="SystemInfo"/>
-			<xs:element name="ExteriorLocationsWaterIntrusionorDamage" type="ExteriorLocationsWaterIntrusionorDamage" minOccurs="0" maxOccurs="unbounded"/>
-			<xs:element name="InteriorLocationsofWaterLeaksorDamage" type="InteriorLocationsofWaterLeaksorDamage" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ExteriorLocationsWaterIntrusionorDamage"
+				type="ExteriorLocationsWaterIntrusionorDamage" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="InteriorLocationsofWaterLeaksorDamage"
+				type="InteriorLocationsofWaterLeaksorDamage" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -4760,7 +5237,8 @@
 			<xs:element name="WoodStud">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="ExpandedPolystyreneSheathing" type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="ExpandedPolystyreneSheathing"
+							type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Sheathing insulation should be specified in the Insulation element as well.</xs:documentation>
 							</xs:annotation>
@@ -4925,7 +5403,8 @@
 					<xs:documentation>Percent of rooms controlled by electronic zone valves with thermostats</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="HVACSystemsServed" type="LocalReference" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="HVACSystemsServed" type="LocalReference" minOccurs="0"
+				maxOccurs="unbounded"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -4957,9 +5436,11 @@
 					<xs:documentation>The year and month the duct system was sealed.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="DuctOutsideEnvelopeInsulatedaspartofRetrofit" type="HPXMLBoolean" minOccurs="0"/>
+			<xs:element name="DuctOutsideEnvelopeInsulatedaspartofRetrofit" type="HPXMLBoolean"
+				minOccurs="0"/>
 			<xs:element name="DuctSystemReplaced" type="HPXMLBoolean" minOccurs="0"/>
-			<xs:element name="SystemPumpandZoneValveCorrectionsMade" type="HPXMLBoolean" minOccurs="0"/>
+			<xs:element name="SystemPumpandZoneValveCorrectionsMade" type="HPXMLBoolean"
+				minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -4972,8 +5453,10 @@
 					<xs:documentation>Year and month of the last tune and repair for this HVAC equipment.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="NumberofCoilsReplaced" type="IntegerGreaterThanOrEqualToZero"/>
-			<xs:element minOccurs="0" name="NumberofAirHandlersReplaced" type="IntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="NumberofCoilsReplaced"
+				type="IntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="NumberofAirHandlersReplaced"
+				type="IntegerGreaterThanOrEqualToZero"/>
 			<xs:element minOccurs="0" name="AirFilter">
 				<xs:complexType>
 					<xs:sequence>
@@ -5026,8 +5509,10 @@
 	<xs:complexType name="WaterHeaterImprovementInfo">
 		<xs:sequence>
 			<xs:element name="JacketInstalledIndicator" type="HPXMLBoolean" minOccurs="0"/>
-			<xs:element name="DispositionofExistingSystem" type="DispositionofExistingSystem" minOccurs="0"/>
-			<xs:element name="RepairsDescription" type="HPXMLString" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="DispositionofExistingSystem" type="DispositionofExistingSystem"
+				minOccurs="0"/>
+			<xs:element name="RepairsDescription" type="HPXMLString" minOccurs="0"
+				maxOccurs="unbounded"/>
 			<xs:element name="PipeInsulated" type="PipeInsulated" minOccurs="0"/>
 			<xs:element name="LengthofPipeInsulated" type="LengthMeasurement" minOccurs="0">
 				<xs:annotation>
@@ -5082,7 +5567,8 @@
 									Building/BuildingDetails/ClimateAndRiskZones/WeatherStation</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element maxOccurs="unbounded" name="ModeledUsage" type="ModeledUsageType"/>
+						<xs:element maxOccurs="unbounded" name="ModeledUsage"
+							type="ModeledUsageType"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -5173,7 +5659,8 @@
 			<xs:element minOccurs="0" name="ConsumptionDetails">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="ConsumptionInfo" type="ConsumptionInfoType"/>
+						<xs:element maxOccurs="unbounded" name="ConsumptionInfo"
+							type="ConsumptionInfoType"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -5221,7 +5708,8 @@
 					<xs:documentation>[Pa] positive for supply side measurements, negative for return side.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="MeasurementLocation" type="AirHandlerStaticPressureMeasurementLocation"/>
+			<xs:element minOccurs="0" name="MeasurementLocation"
+				type="AirHandlerStaticPressureMeasurementLocation"/>
 			<xs:element minOccurs="0" name="LocationDescription" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="StaticPressureSource" type="StaticPressureSource"/>
 			<xs:element minOccurs="0" ref="extension"/>
@@ -5323,8 +5811,10 @@
 			<xs:sequence>
 				<xs:group ref="SystemInfo"/>
 				<xs:element name="IsConnected" type="HPXMLBoolean"/>
-				<xs:element maxOccurs="unbounded" minOccurs="0" name="CommunicatesWith" type="LocalReference"/>
-				<xs:element minOccurs="0" name="CommunicationProtocol" type="ConnectedDeviceCommunicationProtocol" maxOccurs="unbounded"/>
+				<xs:element maxOccurs="unbounded" minOccurs="0" name="CommunicatesWith"
+					type="LocalReference"/>
+				<xs:element minOccurs="0" name="CommunicationProtocol"
+					type="ConnectedDeviceCommunicationProtocol" maxOccurs="unbounded"/>
 				<xs:element minOccurs="0" name="DemandResponseCapability" type="HPXMLBoolean"/>
 				<xs:element minOccurs="0" name="OccupancySensor" type="HPXMLBoolean"/>
 				<xs:element minOccurs="0" ref="extension"/>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10"
-	targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.0">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.0">
 	<xs:include schemaLocation="HPXMLDataTypes.xsd"/>
 	<xs:element name="XMLTransactionHeaderInformation">
 		<xs:annotation>
@@ -39,14 +38,10 @@
 				systems, and have it identified in the two systems. Also, there is an id attribute to define a local id to be used internally. </xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType"
-				minOccurs="0"/>
-			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue"
-				minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType"
-				minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue"
-				minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType" minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue" minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType" minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="id" type="xs:ID" use="required">
 			<xs:annotation>
@@ -70,14 +65,10 @@
 				elements in other xml transactions.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType"
-				minOccurs="0"/>
-			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue"
-				minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType"
-				minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue"
-				minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType" minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue" minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType" minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="id" type="xs:IDREF">
 			<xs:annotation>
@@ -136,8 +127,7 @@
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="IndividualType" type="IndividualType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="Telephone"
-				type="TelephoneInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="Telephone" type="TelephoneInfoType"/>
 			<xs:element minOccurs="0" maxOccurs="unbounded" name="Email" type="EmailInfoType"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
@@ -154,11 +144,9 @@
 				<xs:element minOccurs="0" name="MeterNumber" type="HPXMLString"/>
 				<xs:element name="UtilityAccountNumber" type="HPXMLString" minOccurs="0"/>
 				<xs:element minOccurs="0" name="Permission" type="HPXMLBoolean"/>
-				<xs:element name="UtilityServiceTypeProvided" type="ConsumptionType" minOccurs="0"
-					maxOccurs="unbounded"/>
+				<xs:element name="UtilityServiceTypeProvided" type="ConsumptionType" minOccurs="0" maxOccurs="unbounded"/>
 				<xs:element minOccurs="0" name="BusinessInfo" type="BusinessInfoType"/>
-				<xs:element maxOccurs="unbounded" minOccurs="0" name="BusinessContactInfo"
-					type="BusinessContactInfoType"/>
+				<xs:element maxOccurs="unbounded" minOccurs="0" name="BusinessContactInfo" type="BusinessContactInfoType"/>
 				<xs:element ref="extension" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attribute name="dataSource" type="DataSource"/>
@@ -211,8 +199,7 @@
 				<xs:complexType>
 					<xs:sequence maxOccurs="1">
 						<xs:element name="InstallationType" type="InstallationType" minOccurs="0"/>
-						<xs:element name="InsulationMaterial" type="InsulationMaterial"
-							minOccurs="0"/>
+						<xs:element name="InsulationMaterial" type="InsulationMaterial" minOccurs="0"/>
 						<xs:element name="NominalRValue" type="RValue" minOccurs="0"/>
 						<xs:element name="Thickness" type="LengthMeasurement" minOccurs="0">
 							<xs:annotation>
@@ -242,8 +229,7 @@
 			<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 			<xs:element name="ModelYear" type="Year" minOccurs="0"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification"
-				type="ApplianceThirdPartyCertifications"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="ApplianceThirdPartyCertifications"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
@@ -271,8 +257,7 @@
 								drying cycle energy as well as energy consumed during Stand-by and Off modes.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element maxOccurs="unbounded" minOccurs="0" name="ControlType"
-						type="ClothesDryerControlType"> </xs:element>
+					<xs:element maxOccurs="unbounded" minOccurs="0" name="ControlType" type="ClothesDryerControlType"> </xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -291,8 +276,7 @@
 								Factor.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="IntegratedModifiedEnergyFactor" type="HPXMLDouble"
-						minOccurs="0">
+					<xs:element name="IntegratedModifiedEnergyFactor" type="HPXMLDouble" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>The energy performance metric for ENERGY STAR certified residential clothes washers as of March 7, 2015.</xs:documentation>
 						</xs:annotation>
@@ -352,14 +336,11 @@
 					<xs:element minOccurs="0" name="Type" type="DishwasherType"/>
 					<xs:element minOccurs="0" name="Fuel" type="FuelType"/>
 					<xs:element name="HeatDryDefaultOff" type="HPXMLBoolean" minOccurs="0"/>
-					<xs:element name="AuxillaryWaterHeaterDefaultOff" type="HPXMLBoolean"
-						minOccurs="0"/>
+					<xs:element name="AuxillaryWaterHeaterDefaultOff" type="HPXMLBoolean" minOccurs="0"/>
 					<xs:element minOccurs="0" name="RatedAnnualkWh" type="RatedAnnualkWh"/>
 					<xs:element minOccurs="0" name="EnergyFactor" type="EnergyFactor"/>
-					<xs:element minOccurs="0" name="RatedWaterGalPerCycle"
-						type="RatedWaterGalPerCycle"/>
-					<xs:element minOccurs="0" name="PlaceSettingCapacity"
-						type="IntegerGreaterThanZero"/>
+					<xs:element minOccurs="0" name="RatedWaterGalPerCycle" type="RatedWaterGalPerCycle"/>
+					<xs:element minOccurs="0" name="PlaceSettingCapacity" type="IntegerGreaterThanZero"/>
 					<xs:element minOccurs="0" name="Usage" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>loads/week</xs:documentation>
@@ -460,8 +441,7 @@
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element name="SoftwareProgramUsed" type="SoftwareProgramUsed" minOccurs="0"/>
-				<xs:element name="SoftwareProgramVersion" type="SoftwareProgramVersion"
-					minOccurs="0"/>
+				<xs:element name="SoftwareProgramVersion" type="SoftwareProgramVersion" minOccurs="0"/>
 				<xs:element ref="extension" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attribute name="dataSource" type="DataSource"/>
@@ -480,12 +460,9 @@
 			<xs:element name="Auditor">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="Qualification" type="AuditorQualification"
-							maxOccurs="unbounded"/>
-						<xs:element minOccurs="0" name="StateWhereQualificationHeld"
-							type="StateCode"/>
-						<xs:element minOccurs="0" name="YearsExperience"
-							type="IntegerGreaterThanOrEqualToZero"/>
+						<xs:element minOccurs="0" name="Qualification" type="AuditorQualification" maxOccurs="unbounded"/>
+						<xs:element minOccurs="0" name="StateWhereQualificationHeld" type="StateCode"/>
+						<xs:element minOccurs="0" name="YearsExperience" type="IntegerGreaterThanOrEqualToZero"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -494,10 +471,8 @@
 			<xs:element name="Implementer">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" minOccurs="0" name="Qualification"
-							type="ImplementerQualification"/>
-						<xs:element minOccurs="0" name="StateWhereQualificationHeld"
-							type="StateCode"/>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="Qualification" type="ImplementerQualification"/>
+						<xs:element minOccurs="0" name="StateWhereQualificationHeld" type="StateCode"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -519,8 +494,7 @@
 		<xs:sequence>
 			<xs:group maxOccurs="unbounded" ref="SystemInfo"/>
 			<xs:element name="BusinessInfo" type="BusinessInfoType"/>
-			<xs:element name="SubContractor" type="ContractorType" minOccurs="0"
-				maxOccurs="unbounded"/>
+			<xs:element name="SubContractor" type="ContractorType" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -534,8 +508,7 @@
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element name="SpaceName" type="HPXMLString" minOccurs="0"/>
-						<xs:element minOccurs="0" name="NumberOfBedrooms"
-							type="IntegerGreaterThanOrEqualToZero"/>
+						<xs:element minOccurs="0" name="NumberOfBedrooms" type="IntegerGreaterThanOrEqualToZero"/>
 						<xs:element minOccurs="0" name="FloorArea" type="SurfaceArea">
 							<xs:annotation>
 								<xs:documentation>[sq.ft.]</xs:documentation>
@@ -581,8 +554,7 @@
 			<xs:element name="AirInfiltration" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="AirInfiltrationMeasurement"
-							type="AirInfiltrationMeasurementType" maxOccurs="unbounded"> </xs:element>
+						<xs:element minOccurs="0" name="AirInfiltrationMeasurement" type="AirInfiltrationMeasurementType" maxOccurs="unbounded"> </xs:element>
 						<xs:element minOccurs="0" name="AirSealing" maxOccurs="unbounded">
 							<xs:complexType>
 								<xs:sequence>
@@ -591,14 +563,9 @@
 									<xs:element minOccurs="0" name="ComponentsAirSealed">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element maxOccurs="unbounded" minOccurs="0"
-												name="Attic" type="AtticComponentsAirSealed"/>
-												<xs:element maxOccurs="unbounded" minOccurs="0"
-												name="BasementCrawlspace"
-												type="BasementCrawlspaceComponentsAirSealed"/>
-												<xs:element maxOccurs="unbounded" minOccurs="0"
-												name="LivingSpace"
-												type="LivingSpaceComponentsAirSealed"/>
+												<xs:element maxOccurs="unbounded" minOccurs="0" name="Attic" type="AtticComponentsAirSealed"/>
+												<xs:element maxOccurs="unbounded" minOccurs="0" name="BasementCrawlspace" type="BasementCrawlspaceComponentsAirSealed"/>
+												<xs:element maxOccurs="unbounded" minOccurs="0" name="LivingSpace" type="LivingSpaceComponentsAirSealed"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -636,19 +603,14 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="1" name="AtticType" type="AtticType"/>
-									<xs:element minOccurs="0" name="VentilationRate"
-										type="VentilationType"/>
-									<xs:element minOccurs="0" name="AttachedToRoof"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToWall"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFrameFloor"
-										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="VentilationRate" type="VentilationType"/>
+									<xs:element minOccurs="0" name="AttachedToRoof" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFrameFloor" type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo"
-												type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -674,25 +636,17 @@
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
 									<xs:element name="FoundationType" type="FoundationType"/>
-									<xs:element minOccurs="0" name="VentilationRate"
-										type="VentilationType"/>
-									<xs:element minOccurs="0" name="ThermalBoundary"
-										type="FoundationThermalBoundary"/>
-									<xs:element minOccurs="0" name="AttachedToRimJoist"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToWall"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFoundationWall"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFrameFloor"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToSlab"
-										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="VentilationRate" type="VentilationType"/>
+									<xs:element minOccurs="0" name="ThermalBoundary" type="FoundationThermalBoundary"/>
+									<xs:element minOccurs="0" name="AttachedToRimJoist" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFoundationWall" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFrameFloor" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToSlab" type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo"
-												type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -724,32 +678,23 @@
 									<xs:element minOccurs="1" name="GarageType">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="AttachedtoHouse"
-												type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="Vented"
-												type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="Conditioned"
-												type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="AttachedtoHouse" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="Vented" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="AttachedToRoof"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToWall"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFoundationWall"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFrameFloor"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToSlab"
-										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToRoof" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFoundationWall" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFrameFloor" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToSlab" type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo"
-												type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -774,25 +719,21 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo"
-										type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Surface area of the roof itself</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation"
-										type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
 									<xs:element name="Azimuth" type="AzimuthType" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="RoofType" type="RoofType"/>
-									<xs:element minOccurs="0" name="RoofColor"
-										type="WallAndRoofColor"/>
-									<xs:element minOccurs="0" name="SolarAbsorptance"
-										type="SolarAbsorptance"/>
+									<xs:element minOccurs="0" name="RoofColor" type="WallAndRoofColor"/>
+									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
 									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
 									<xs:element minOccurs="0" name="Rafters" type="StudProperties"/>
 									<xs:element minOccurs="0" name="DeckType" type="DeckType"/>
@@ -801,12 +742,9 @@
 											<xs:documentation>Pitch of roof ?/12</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="RadiantBarrier" type="HPXMLBoolean"
-										minOccurs="0"/>
-									<xs:element name="RadiantBarrierLocation"
-										type="RadiantBarrierLocation" minOccurs="0"/>
-									<xs:element minOccurs="0" name="Insulation"
-										type="InsulationInfo"/>
+									<xs:element name="RadiantBarrier" type="HPXMLBoolean" minOccurs="0"/>
+									<xs:element name="RadiantBarrierLocation" type="RadiantBarrierLocation" minOccurs="0"/>
+									<xs:element minOccurs="0" name="Insulation" type="InsulationInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -824,40 +762,32 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element minOccurs="0" name="ExteriorAdjacentTo"
-										type="AdjacentTo"/>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo"
-										type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="ExteriorAdjacentTo" type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation"
-										type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
 									<xs:element name="Azimuth" type="AzimuthType" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Perimeter"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Perimeter" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="SolarAbsorptance"
-										type="SolarAbsorptance"/>
+									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
 									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
-									<xs:element minOccurs="0" name="Insulation"
-										type="InsulationInfo"/>
-									<xs:element minOccurs="0" name="FloorJoists"
-										type="StudProperties"/>
+									<xs:element minOccurs="0" name="Insulation" type="InsulationInfo"/>
+									<xs:element minOccurs="0" name="FloorJoists" type="StudProperties"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo"
-												type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -879,15 +809,11 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo"
-										minOccurs="0"> </xs:element>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo"
-										type="AdjacentTo"/>
-									<xs:element minOccurs="0" name="AtticWallType"
-										type="AtticWallType"/>
+									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo" minOccurs="0"> </xs:element>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="AtticWallType" type="AtticWallType"/>
 									<xs:element name="WallType" type="WallType" minOccurs="0"> </xs:element>
-									<xs:element minOccurs="0" name="Thickness"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[in] Thickness of the wall assembly</xs:documentation>
 										</xs:annotation>
@@ -897,8 +823,7 @@
 											<xs:documentation>[sq.ft.] Gross wall area</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation"
-										type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
 									<xs:element name="Azimuth" type="AzimuthType" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
@@ -907,16 +832,13 @@
 									<xs:element minOccurs="0" name="Studs" type="StudProperties"/>
 									<xs:element minOccurs="0" name="Siding" type="Siding"/>
 									<xs:element minOccurs="0" name="Color" type="WallAndRoofColor"/>
-									<xs:element minOccurs="0" name="SolarAbsorptance"
-										type="SolarAbsorptance"/>
+									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
 									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
-									<xs:element minOccurs="0" maxOccurs="1" name="Insulation"
-										type="InsulationInfo"/>
+									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo"
-												type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -938,10 +860,8 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo"
-										minOccurs="0"> </xs:element>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo"
-										type="AdjacentTo"/>
+									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo" minOccurs="0"> </xs:element>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="Type" type="FoundationWallType"/>
 									<xs:element minOccurs="0" name="Length" type="LengthMeasurement">
 										<xs:annotation>
@@ -958,47 +878,39 @@
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation"
-										type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
 									<xs:element name="Azimuth" type="AzimuthType" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Thickness"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[in] Thickness of foundation wall excluding interior framing.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="DepthBelowGrade"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="DepthBelowGrade" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Depth below grade of foundation wall</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AdjacentToFoundation"
-										type="LocalReference">
+									<xs:element minOccurs="0" name="AdjacentToFoundation" type="LocalReference">
 										<xs:annotation>
 											<xs:documentation>If this foundation wall is adjacent to another foundation, use this reference to indicate which one.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="InteriorStuds"
-										type="StudProperties"/>
-									<xs:element minOccurs="0" name="DistanceToTopOfInsulation"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="InteriorStuds" type="StudProperties"/>
+									<xs:element minOccurs="0" name="DistanceToTopOfInsulation" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Vertical distance from top of foundation wall to top of insulation.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="DistanceToBottomOfInsulation"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="DistanceToBottomOfInsulation" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Vertical distance from top of foundation wall to bottom of insulation.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element maxOccurs="1" minOccurs="0" name="Insulation"
-										type="InsulationInfo"/>
+									<xs:element maxOccurs="1" minOccurs="0" name="Insulation" type="InsulationInfo"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1020,23 +932,17 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo"
-										minOccurs="0"> </xs:element>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo"
-										type="AdjacentTo"/>
-									<xs:element minOccurs="0" name="FloorJoists"
-										type="StudProperties"/>
-									<xs:element minOccurs="0" name="FloorTrusses"
-										type="StudProperties"/>
-									<xs:element minOccurs="0" name="FloorCovering"
-										type="FloorCovering"/>
+									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo" minOccurs="0"> </xs:element>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="FloorJoists" type="StudProperties"/>
+									<xs:element minOccurs="0" name="FloorTrusses" type="StudProperties"/>
+									<xs:element minOccurs="0" name="FloorCovering" type="FloorCovering"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" maxOccurs="1" name="Insulation"
-										type="InsulationInfo"> </xs:element>
+									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"> </xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1057,64 +963,51 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo"
-										type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Area of the slab</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Thickness"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[in] Thickness of foundation slab.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Perimeter"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Perimeter" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Length of slab perimeter.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="ExposedPerimeter"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="ExposedPerimeter" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Perimeter of the slab exposed to ambient conditions</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="PerimeterInsulationDepth"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="PerimeterInsulationDepth" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Depth from grade to bottom of vertical slab perimeter insulation</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="UnderSlabInsulationWidth"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="UnderSlabInsulationWidth" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Width from slab edge inward of horizontal under-slab insulation</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0"
-										name="UnderSlabInsulationSpansEntireSlab"
-										type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="OnGradeExposedPerimeter"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="UnderSlabInsulationSpansEntireSlab" type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="OnGradeExposedPerimeter" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Perimeter of slab measured in feet that is on-grade (2 ft. below grade or less) and exposed to ambient conditions.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="DepthBelowGrade"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="DepthBelowGrade" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Depth from the top of the slab surface to grade</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FloorCovering"
-										type="FloorCovering"/>
-									<xs:element maxOccurs="1" minOccurs="0"
-										name="PerimeterInsulation" type="InsulationInfo"/>
-									<xs:element minOccurs="0" name="UnderSlabInsulation"
-										type="InsulationInfo"/>
+									<xs:element minOccurs="0" name="FloorCovering" type="FloorCovering"/>
+									<xs:element maxOccurs="1" minOccurs="0" name="PerimeterInsulation" type="InsulationInfo"/>
+									<xs:element minOccurs="0" name="UnderSlabInsulation" type="InsulationInfo"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1135,15 +1028,12 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="WindowInfo"/>
-									<xs:element minOccurs="0" name="WindowtoWallRatio"
-										type="Fraction"/>
-									<xs:element minOccurs="0" name="AttachedToWall"
-										type="LocalReference"/>
+									<xs:element minOccurs="0" name="WindowtoWallRatio" type="Fraction"/>
+									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo"
-												type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -1174,13 +1064,11 @@
 											<xs:documentation>Pitch of skylight ?/12</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AttachedToRoof"
-										type="LocalReference"/>
+									<xs:element minOccurs="0" name="AttachedToRoof" type="LocalReference"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo"
-												type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -1201,10 +1089,8 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="AttachedToWall"
-										type="LocalReference"/>
-									<xs:element minOccurs="0" name="Quantity"
-										type="IntegerGreaterThanZero"/>
+									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference"/>
+									<xs:element minOccurs="0" name="Quantity" type="IntegerGreaterThanZero"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Total door surface area for this group of doors</xs:documentation>
@@ -1215,27 +1101,19 @@
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation"
-										type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
 									<xs:element minOccurs="0" name="DoorType" type="DoorType"/>
-									<xs:element name="DoorMaterial" type="DoorMaterial"
-										minOccurs="0"/>
-									<xs:element minOccurs="0" name="WeatherStripping"
-										type="HPXMLBoolean"/>
+									<xs:element name="DoorMaterial" type="DoorMaterial" minOccurs="0"/>
+									<xs:element minOccurs="0" name="WeatherStripping" type="HPXMLBoolean"/>
 									<xs:element name="StormDoor" type="HPXMLBoolean" minOccurs="0"/>
 									<xs:element name="RValue" type="RValue" minOccurs="0"/>
-									<xs:element minOccurs="0" name="LeakinessDescription"
-										type="BuildingLeakiness"/>
-									<xs:element minOccurs="0" name="PerformanceClass"
-										type="PerformanceClass"/>
-									<xs:element maxOccurs="unbounded" minOccurs="0"
-										name="ThirdPartyCertification"
-										type="DoorThirdPartyCertifications"/>
+									<xs:element minOccurs="0" name="LeakinessDescription" type="BuildingLeakiness"/>
+									<xs:element minOccurs="0" name="PerformanceClass" type="PerformanceClass"/>
+									<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="DoorThirdPartyCertifications"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo"
-												type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -1267,28 +1145,21 @@
 										</xs:annotation>
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0"
-												name="PrimaryHeatingSystem" type="LocalReference"/>
-												<xs:element minOccurs="0"
-												name="PrimaryCoolingSystem" type="LocalReference"
-												/>
+												<xs:element minOccurs="0" name="PrimaryHeatingSystem" type="LocalReference"/>
+												<xs:element minOccurs="0" name="PrimaryCoolingSystem" type="LocalReference"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" maxOccurs="unbounded"
-										name="HeatingSystem" type="HeatingSystemInfoType"/>
-									<xs:element minOccurs="0" maxOccurs="unbounded"
-										name="CoolingSystem" type="CoolingSystemInfoType"/>
-									<xs:element minOccurs="0" maxOccurs="unbounded" name="HeatPump"
-										type="HeatPumpInfoType"/>
+									<xs:element minOccurs="0" maxOccurs="unbounded" name="HeatingSystem" type="HeatingSystemInfoType"/>
+									<xs:element minOccurs="0" maxOccurs="unbounded" name="CoolingSystem" type="CoolingSystemInfoType"/>
+									<xs:element minOccurs="0" maxOccurs="unbounded" name="HeatPump" type="HeatPumpInfoType"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
-						<xs:element maxOccurs="unbounded" minOccurs="0" name="HVACControl"
-							type="HVACControlType"> </xs:element>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="HVACControl" type="HVACControlType"> </xs:element>
 						<xs:element maxOccurs="unbounded" minOccurs="0" name="HVACDistribution">
 							<xs:complexType>
 								<xs:sequence>
@@ -1297,45 +1168,37 @@
 									<xs:element minOccurs="0" name="DistributionSystemType">
 										<xs:complexType>
 											<xs:choice>
-												<xs:element name="AirDistribution"
-												type="AirDistributionInfo"/>
-												<xs:element name="HydronicDistribution"
-												type="HydronicDistributionInfo"/>
+												<xs:element name="AirDistribution" type="AirDistributionInfo"/>
+												<xs:element name="HydronicDistribution" type="HydronicDistributionInfo"/>
 												<xs:element name="Other" type="HPXMLString">
-												<xs:annotation>
-												<xs:documentation>describe</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>describe</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 											</xs:choice>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="ConditionedFloorAreaServed"
-										type="SurfaceArea">
+									<xs:element minOccurs="0" name="ConditionedFloorAreaServed" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Conditioned floor area that this distribution system serves.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0"
-										name="AnnualHeatingDistributionSystemEfficiency"
-										type="HPXMLDouble">
+									<xs:element minOccurs="0" name="AnnualHeatingDistributionSystemEfficiency" type="HPXMLDouble">
 										<xs:annotation>
 											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for heating, the DSE may be approximated by equation
 												3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use
 												History.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0"
-										name="AnnualCoolingDistributionSystemEfficiency"
-										type="HPXMLDouble">
+									<xs:element minOccurs="0" name="AnnualCoolingDistributionSystemEfficiency" type="HPXMLDouble">
 										<xs:annotation>
 											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for cooling, the DSE may be approximated by equation
 												3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use
 												History.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HVACDistributionImprovement"
-										type="HVACDistributionImprovementInfo"/>
+									<xs:element minOccurs="0" name="HVACDistributionImprovement" type="HVACDistributionImprovementInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1344,10 +1207,8 @@
 						<xs:element minOccurs="0" name="Maintenance">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element minOccurs="0" name="Schedule"
-										type="HVACMaintenanceSchedule"/>
-									<xs:element minOccurs="0" name="ACReplacedinLastTenYears"
-										type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="Schedule" type="HVACMaintenanceSchedule"/>
+									<xs:element minOccurs="0" name="ACReplacedinLastTenYears" type="HPXMLBoolean"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1356,8 +1217,7 @@
 						<xs:element name="AnnualEnergyUse" minOccurs="0">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"
-										maxOccurs="unbounded"/>
+									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType" maxOccurs="unbounded"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
@@ -1378,126 +1238,95 @@
 											<xs:sequence>
 												<xs:group ref="SystemInfo"/>
 												<xs:element minOccurs="0" ref="ConnectedDevice"/>
-												<xs:element minOccurs="0" name="Manufacturer"
-												type="HPXMLString"/>
-												<xs:element minOccurs="0" name="SerialNumber"
-												type="HPXMLString"/>
-												<xs:element minOccurs="0" name="FanType"
-												type="VentilationFanType"/>
-												<xs:element minOccurs="0" name="RatedFlowRate"
-												type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>[CFM] as rated by manufacturer</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
+												<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
+												<xs:element minOccurs="0" name="FanType" type="VentilationFanType"/>
+												<xs:element minOccurs="0" name="RatedFlowRate" type="HPXMLDouble">
+													<xs:annotation>
+														<xs:documentation>[CFM] as rated by manufacturer</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="CalculatedFlowRate"
-												type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>[CFM] as calculated using duct size, prescriptive approach</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="CalculatedFlowRate" type="HPXMLDouble">
+													<xs:annotation>
+														<xs:documentation>[CFM] as calculated using duct size, prescriptive approach</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="TestedFlowRate"
-												type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>[CFM] as tested by assessor/auditor/inspector</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="TestedFlowRate" type="HPXMLDouble">
+													<xs:annotation>
+														<xs:documentation>[CFM] as tested by assessor/auditor/inspector</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="HoursInOperation"
-												type="HoursPerDay">
-												<xs:annotation>
-												<xs:documentation>24 = continuous, less than 24 = intermittent</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="HoursInOperation" type="HoursPerDay">
+													<xs:annotation>
+														<xs:documentation>24 = continuous, less than 24 = intermittent</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="DeliveredVentilation" type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>[CFM]</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="DeliveredVentilation" type="HPXMLDouble">
+													<xs:annotation>
+														<xs:documentation>[CFM]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="FanControlProperlyLabeled"
-												type="BooleanWithNA"/>
-												<xs:element minOccurs="0" name="ProperlyVented"
-												type="BooleanWithNA"/>
-												<xs:element minOccurs="0" name="FanLocation"
-												type="VentilationFanLocation"/>
-												<xs:element minOccurs="0"
-												name="UsedForLocalVentilation" type="HPXMLBoolean"/>
-												<xs:element minOccurs="0"
-												name="UsedForWholeBuildingVentilation"
-												type="HPXMLBoolean"/>
-												<xs:element minOccurs="0"
-												name="UsedForSeasonalCoolingLoadReduction"
-												type="HPXMLBoolean"/>
-												<xs:element minOccurs="0"
-												name="UsedForGarageVentilation"
-												type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="RatedNoise"
-												type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>[sones] from manufacturer's info</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="FanControlProperlyLabeled" type="BooleanWithNA"/>
+												<xs:element minOccurs="0" name="ProperlyVented" type="BooleanWithNA"/>
+												<xs:element minOccurs="0" name="FanLocation" type="VentilationFanLocation"/>
+												<xs:element minOccurs="0" name="UsedForLocalVentilation" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="UsedForWholeBuildingVentilation" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="UsedForSeasonalCoolingLoadReduction" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="UsedForGarageVentilation" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="RatedNoise" type="HPXMLDouble">
+													<xs:annotation>
+														<xs:documentation>[sones] from manufacturer's info</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="TestedNoise"
-												type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>[sones] as tested in field</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="TestedNoise" type="HPXMLDouble">
+													<xs:annotation>
+														<xs:documentation>[sones] as tested in field</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="TotalRecoveryEfficiency" type="Fraction">
-												<xs:annotation>
-												<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by electric
+												<xs:element minOccurs="0" name="TotalRecoveryEfficiency" type="Fraction">
+													<xs:annotation>
+														<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by electric
 															consumption, case heat loss or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential
 															total energy that could be recovered plus the exhaust fan energy. Values for some products can be found at the Home Ventilating Institute
 															(hvi.org).</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="SensibleRecoveryEfficiency" type="Fraction">
-												<xs:annotation>
-												<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by electric consumption, case heat loss or heat gain,
+												<xs:element minOccurs="0" name="SensibleRecoveryEfficiency" type="Fraction">
+													<xs:annotation>
+														<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by electric consumption, case heat loss or heat gain,
 															air leakage, airflow mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test),
 															as a percent of the potential sensible energy that could be recovered plus the exhaust fan energy. Values for some products can be found at
 															the Home Ventilating Institute (hvi.org).</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="AdjustedTotalRecoveryEfficiency"
-												type="Fraction">
-												<xs:annotation>
-												<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by case heat loss
+												<xs:element minOccurs="0" name="AdjustedTotalRecoveryEfficiency" type="Fraction">
+													<xs:annotation>
+														<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by case heat loss
 															or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential total energy that could be
 															recovered. This value is used to predict and compare Cooling Season Performance for the HRV/ERV unit. This value should be used for energy
 															modeling when wattage for air movement is separately accounted for in the energy model. Values for some products can be found at the Home
 															Ventilating Institute (hvi.org).</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="AdjustedSensibleRecoveryEfficiency"
-												type="Fraction">
-												<xs:annotation>
-												<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by case heat loss or heat gain, air leakage, airflow
+												<xs:element minOccurs="0" name="AdjustedSensibleRecoveryEfficiency" type="Fraction">
+													<xs:annotation>
+														<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by case heat loss or heat gain, air leakage, airflow
 															mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test), as a percent of the
 															potential sensible energy that could be recovered. This value should be used for energy modeling when wattage for air movement is separately
 															accounted for in the energy model. Values for some products can be found at the Home Ventilating Institute (hvi.org).</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="FanPower"
-												type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>[W]</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="FanPower" type="HPXMLDouble">
+													<xs:annotation>
+														<xs:documentation>[W]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element maxOccurs="unbounded" minOccurs="0"
-												name="ThirdPartyCertification"
-												type="VentilationFanThirdPartyCertification"/>
-												<xs:element name="AttachedToHVACDistributionSystem"
-												type="LocalReference" minOccurs="0" maxOccurs="1">
-												<xs:annotation>
-												<xs:documentation>For central fan integrated supply mechanical ventilation, specifies the HVAC distribution system it is attached
+												<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="VentilationFanThirdPartyCertification"/>
+												<xs:element name="AttachedToHVACDistributionSystem" type="LocalReference" minOccurs="0" maxOccurs="1">
+													<xs:annotation>
+														<xs:documentation>For central fan integrated supply mechanical ventilation, specifies the HVAC distribution system it is attached
 															to.</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -1520,8 +1349,7 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="VentSystemType"
-										type="VentSystem"/>
+									<xs:element minOccurs="0" name="VentSystemType" type="VentSystem"/>
 									<xs:element minOccurs="0" ref="AttachedToZone"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
@@ -1541,44 +1369,36 @@
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
 									<xs:element minOccurs="0" ref="AttachedToZone"/>
-									<xs:element minOccurs="0" name="AttachedToCAZ"
-										type="LocalReference"/>
+									<xs:element minOccurs="0" name="AttachedToCAZ" type="LocalReference"/>
 									<xs:element name="FuelType" type="FuelType" minOccurs="0"/>
-									<xs:element name="WaterHeaterType" type="WaterHeaterType"
-										minOccurs="0"/>
+									<xs:element name="WaterHeaterType" type="WaterHeaterType" minOccurs="0"/>
 									<xs:element name="Location" type="UnitLocation" minOccurs="0"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
 									<xs:element name="ModelYear" type="Year" minOccurs="0"/>
-									<xs:element name="Manufacturer" type="Manufacturer"
-										minOccurs="0"/>
+									<xs:element name="Manufacturer" type="Manufacturer" minOccurs="0"/>
 									<xs:element name="ModelNumber" type="Model" minOccurs="0"/>
 									<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
-									<xs:element minOccurs="0" name="PerformanceAdjustment"
-										type="Fraction"/>
-									<xs:element minOccurs="0" name="ThirdPartyCertification"
-										type="DHWThirdPartyCertification" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction"/>
+									<xs:element minOccurs="0" name="ThirdPartyCertification" type="DHWThirdPartyCertification" maxOccurs="unbounded"/>
 									<xs:element name="TankVolume" type="Volume" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[gal]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FractionDHWLoadServed"
-										type="Fraction"/>
+									<xs:element minOccurs="0" name="FractionDHWLoadServed" type="Fraction"/>
 									<xs:element name="HeatingCapacity" type="Capacity" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[Btuh]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="EnergyFactor" type="EnergyFactor"
-										minOccurs="0">
+									<xs:element name="EnergyFactor" type="EnergyFactor" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>The amount of energy delivered as heated water in a day divided by the total daily energy consumption of a residential water heater, as
 												determined following standardized DOE testing procedure.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="UniformEnergyFactor" type="EnergyFactor"
-										minOccurs="0">
+									<xs:element name="UniformEnergyFactor" type="EnergyFactor" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>DOE’s new metric for communicating the energy efficiency of a residential water heater, which replaces the Energy Factor (EF) metric. More
 												efficient water heaters have a higher Uniform Energy Factor (UEF). UEF is determined by the Department of Energy’s test method outlined in 10 CFR Part
@@ -1597,96 +1417,74 @@
 												nominal temperature rise of 77°F during steady state operation.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="RecoveryEfficiency" type="RecoveryEfficiency"
-										minOccurs="0">
+									<xs:element name="RecoveryEfficiency" type="RecoveryEfficiency" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>The ratio of energy delivered to heat cold water compared to the energy consumed by the water heater, as determined following standardized
 												DOE testing procedure.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ThermalEfficiency" type="ThermalEfficiency"
-										minOccurs="0"/>
+									<xs:element name="ThermalEfficiency" type="ThermalEfficiency" minOccurs="0"/>
 									<xs:element minOccurs="0" name="WaterHeaterInsulation">
 										<xs:complexType>
 											<xs:sequence>
 												<xs:element minOccurs="0" name="Jacket">
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element minOccurs="0"
-												name="InsulationMaterial"
-												type="InsulationMaterial"/>
-												<xs:element name="JacketRValue" type="RValue"
-												minOccurs="0"/>
-												<xs:element minOccurs="0" name="Thickness"
-												type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>[in]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												<xs:attribute name="dataSource" type="DataSource"
-												/>
-												</xs:complexType>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element minOccurs="0" name="InsulationMaterial" type="InsulationMaterial"/>
+															<xs:element name="JacketRValue" type="RValue" minOccurs="0"/>
+															<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+																<xs:annotation>
+																	<xs:documentation>[in]</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+														<xs:attribute name="dataSource" type="DataSource"/>
+													</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="TankWall">
-												<xs:annotation>
-												<xs:documentation>Refers to the insulation in the tank wall itself. This information is sometimes available on the water heater's name plate or
+													<xs:annotation>
+														<xs:documentation>Refers to the insulation in the tank wall itself. This information is sometimes available on the water heater's name plate or
 															the units specification sheet, or can be estimated by removing the water heater's access plate.</xs:documentation>
-												</xs:annotation>
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element minOccurs="0"
-												name="InsulationMaterial"
-												type="InsulationMaterial"/>
-												<xs:element name="TankWallRValue" type="RValue"
-												minOccurs="0"/>
-												<xs:element minOccurs="0" name="Thickness"
-												type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>[in]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												<xs:attribute name="dataSource" type="DataSource"
-												/>
-												</xs:complexType>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element minOccurs="0" name="InsulationMaterial" type="InsulationMaterial"/>
+															<xs:element name="TankWallRValue" type="RValue" minOccurs="0"/>
+															<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+																<xs:annotation>
+																	<xs:documentation>[in]</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+														<xs:attribute name="dataSource" type="DataSource"/>
+													</xs:complexType>
 												</xs:element>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element name="MeetsACCA5QIHVACSpecification"
-										type="HPXMLBoolean" minOccurs="0"/>
-									<xs:element name="HotWaterTemperature" type="Temperature"
-										minOccurs="0">
+									<xs:element name="MeetsACCA5QIHVACSpecification" type="HPXMLBoolean" minOccurs="0"/>
+									<xs:element name="HotWaterTemperature" type="Temperature" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg F]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HasMixingValve"
-										type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="UsesDesuperheater"
-										type="HPXMLBoolean">
+									<xs:element minOccurs="0" name="HasMixingValve" type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="UsesDesuperheater" type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Indicates whether this water heater uses a desuperheater. The attached heat pump or air conditioner can be referenced in the
 												RelatedHVACSystem element.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HasSharedCombustionVentilation"
-										type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="CombustionVentilationOrphaned"
-										type="HPXMLBoolean"/>
-									<xs:element name="CombustionVentingSystem" minOccurs="0"
-										type="LocalReference"> </xs:element>
-									<xs:element minOccurs="0" name="AutomaticVentDamper"
-										type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="HasSharedCombustionVentilation" type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="CombustionVentilationOrphaned" type="HPXMLBoolean"/>
+									<xs:element name="CombustionVentingSystem" minOccurs="0" type="LocalReference"> </xs:element>
+									<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
 									<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
-										type="HPXMLBoolean"/>
-									<xs:element name="RelatedHVACSystem" type="LocalReference"
-										minOccurs="0">
+									<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
+									<xs:element name="RelatedHVACSystem" type="LocalReference" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>Reference a HeatingSystem, HeatPump, or CoolingSystem.</xs:documentation>
 										</xs:annotation>
@@ -1694,15 +1492,13 @@
 									<xs:element minOccurs="0" name="Installation">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="Standard"
-												type="HVACInstallationStandard"/>
+												<xs:element minOccurs="0" name="Standard" type="HVACInstallationStandard"/>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="WaterHeaterImprovement"
-										type="WaterHeaterImprovementInfo"/>
+									<xs:element minOccurs="0" name="WaterHeaterImprovement" type="WaterHeaterImprovementInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1716,10 +1512,8 @@
 									<xs:element minOccurs="0" name="Model" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
-									<xs:element minOccurs="0" name="ControlTechnology"
-										type="DHWControllerTechnology"/>
-									<xs:element minOccurs="0" name="TemperatureControl"
-										type="DHWTemperatureControl"/>
+									<xs:element minOccurs="0" name="ControlTechnology" type="DHWControllerTechnology"/>
+									<xs:element minOccurs="0" name="TemperatureControl" type="DHWTemperatureControl"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1729,8 +1523,7 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="AttachedToWaterHeatingSystem"
-										type="LocalReference">
+									<xs:element minOccurs="0" name="AttachedToWaterHeatingSystem" type="LocalReference">
 										<xs:annotation>
 											<xs:documentation>The water heating system that this distribution system serves.</xs:documentation>
 										</xs:annotation>
@@ -1739,74 +1532,61 @@
 										<xs:complexType>
 											<xs:choice>
 												<xs:element name="Standard">
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element minOccurs="0" name="PipingLength"
-												type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>Measured length of hot water piping from the hot water heater to the farthest hot water fixture, measured
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element minOccurs="0" name="PipingLength" type="LengthMeasurement">
+																<xs:annotation>
+																	<xs:documentation>Measured length of hot water piping from the hot water heater to the farthest hot water fixture, measured
 																		longitudinally from plans, assuming the hot water piping does not run diagonally, plus 10 feet of piping for each floor level,
 																		plus 5 feet of piping for unconditioned basements. [ft]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												<xs:attribute name="dataSource" type="DataSource"
-												/>
-												</xs:complexType>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+														<xs:attribute name="dataSource" type="DataSource"/>
+													</xs:complexType>
 												</xs:element>
 												<xs:element name="Recirculation">
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element minOccurs="0" name="ControlType"
-												type="RecirculationControlType"/>
-												<xs:element minOccurs="0"
-												name="RecirculationPipingLoopLength"
-												type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>Hot water recirculation loop piping length including both supply and return sides of the loop, measured
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element minOccurs="0" name="ControlType" type="RecirculationControlType"/>
+															<xs:element minOccurs="0" name="RecirculationPipingLoopLength" type="LengthMeasurement">
+																<xs:annotation>
+																	<xs:documentation>Hot water recirculation loop piping length including both supply and return sides of the loop, measured
 																		longitudinally from plans, assuming the hot water piping does not run diagonally. [ft]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0"
-												name="BranchPipingLoopLength"
-												type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>Length of the branch hot water piping from the recirculation loop to the farthest hot water fixture from the
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" name="BranchPipingLoopLength" type="LengthMeasurement">
+																<xs:annotation>
+																	<xs:documentation>Length of the branch hot water piping from the recirculation loop to the farthest hot water fixture from the
 																		recirculation loop, measured longitudinally from plans, assuming the branch hot water piping does not run diagonally, plus 20
 																		feet of piping for each floor level greater than one plus 10 feet of piping for unconditioned basements. [ft]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" name="PumpPower"
-												type="Power">
-												<xs:annotation>
-												<xs:documentation>[W]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												<xs:attribute name="dataSource" type="DataSource"
-												/>
-												</xs:complexType>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" name="PumpPower" type="Power">
+																<xs:annotation>
+																	<xs:documentation>[W]</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+														<xs:attribute name="dataSource" type="DataSource"/>
+													</xs:complexType>
 												</xs:element>
 											</xs:choice>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="PipeInsulation"
-										type="PipeInsulationType"/>
+									<xs:element minOccurs="0" name="PipeInsulation" type="PipeInsulationType"/>
 									<xs:element minOccurs="0" name="DrainWaterHeatRecovery">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="FacilitiesConnected"
-												type="DrainWaterHeatRecoveryFacilitiesConnected"/>
-												<xs:element minOccurs="0" name="EqualFlow"
-												type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="Efficiency"
-												type="Fraction">
-												<xs:annotation>
-												<xs:documentation>Efficiency percent expressed as a fraction from 0-1.</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="FacilitiesConnected" type="DrainWaterHeatRecoveryFacilitiesConnected"/>
+												<xs:element minOccurs="0" name="EqualFlow" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="Efficiency" type="Fraction">
+													<xs:annotation>
+														<xs:documentation>Efficiency percent expressed as a fraction from 0-1.</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -1823,15 +1603,11 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:choice minOccurs="0">
-										<xs:element name="AttachedToWaterHeatingSystem"
-											type="LocalReference"/>
-										<xs:element name="AttachedToHotWaterDistribution"
-											type="LocalReference"/>
+										<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference"/>
+										<xs:element name="AttachedToHotWaterDistribution" type="LocalReference"/>
 									</xs:choice>
-									<xs:element minOccurs="1" name="WaterFixtureType"
-										type="WaterFixtureType"/>
-									<xs:element minOccurs="0" name="Quantity"
-										type="IntegerGreaterThanZero">
+									<xs:element minOccurs="1" name="WaterFixtureType" type="WaterFixtureType"/>
+									<xs:element minOccurs="0" name="Quantity" type="IntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Number of similar water fixtures.</xs:documentation>
 										</xs:annotation>
@@ -1846,28 +1622,22 @@
 											<xs:documentation>Is the fixture considered low-flow?</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FaucetAerator"
-										type="HPXMLBoolean">
+									<xs:element minOccurs="0" name="FaucetAerator" type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Does this faucet have an aerator?</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="MinutesPerDay"
-										type="MinutesPerDay">
+									<xs:element minOccurs="0" name="MinutesPerDay" type="MinutesPerDay">
 										<xs:annotation>
 											<xs:documentation>[minutes] Number of minutes per day a water fixture operates.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0"
-										name="TemperatureInitiatedShowerFlowRestrictionValve"
-										type="HPXMLBoolean">
+									<xs:element minOccurs="0" name="TemperatureInitiatedShowerFlowRestrictionValve" type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Does the shower have a device that restricts the flow of water automatically once it has reached temperature?</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element maxOccurs="unbounded" minOccurs="0"
-										name="ThirdPartyCertification"
-										type="WaterFixtureThirdPartyCertification">
+									<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="WaterFixtureThirdPartyCertification">
 										<xs:annotation>
 											<xs:documentation>Independent organization has verified that product or appliance meets or exceeds the standard in question.</xs:documentation>
 										</xs:annotation>
@@ -1900,36 +1670,28 @@
 									<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="ModelNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" ref="AttachedToZone"/>
-									<xs:element name="SystemType" minOccurs="0"
-										type="SolarThermalSystemType"/>
-									<xs:element name="CollectorArea" type="SurfaceArea"
-										minOccurs="0">
+									<xs:element name="SystemType" minOccurs="0" type="SolarThermalSystemType"/>
+									<xs:element name="CollectorArea" type="SurfaceArea" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorLoopType"
-										type="SolarThermalCollectorLoopType"/>
-									<xs:element minOccurs="0" name="CollectorType"
-										type="SolarThermalCollectorType"/>
-									<xs:element minOccurs="0" name="CollectorOrientation"
-										type="OrientationType"/>
-									<xs:element minOccurs="0" name="CollectorAzimuth"
-										type="AzimuthType"/>
+									<xs:element minOccurs="0" name="CollectorLoopType" type="SolarThermalCollectorLoopType"/>
+									<xs:element minOccurs="0" name="CollectorType" type="SolarThermalCollectorType"/>
+									<xs:element minOccurs="0" name="CollectorOrientation" type="OrientationType"/>
+									<xs:element minOccurs="0" name="CollectorAzimuth" type="AzimuthType"/>
 									<xs:element minOccurs="0" name="CollectorTilt" type="Tilt">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorRatedOpticalEfficiency"
-										type="CollectorRatedOpticalEfficiency">
+									<xs:element minOccurs="0" name="CollectorRatedOpticalEfficiency" type="CollectorRatedOpticalEfficiency">
 										<xs:annotation>
 											<xs:documentation>Often referred to as Fr-tau-alpha (FRta), this describes the optical efficiency portion of the overall collector efficiency. In the OG-100
 												SRCC Certified Solar Thermal Collector Directory, this is the y-intercept of the efficiency curve.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorRatedThermalLosses"
-										type="CollectorRatedThermalLosses">
+									<xs:element minOccurs="0" name="CollectorRatedThermalLosses" type="CollectorRatedThermalLosses">
 										<xs:annotation>
 											<xs:documentation>Often referred to as Fr-Ul (FRUl), this describes the collector thermal losses portion of the overall collector efficiency. In the OG-100
 												SRCC Certified Solar Thermal Collector Directory, this is the slope of the efficiency curve.</xs:documentation>
@@ -1940,18 +1702,15 @@
 											<xs:documentation>[gal]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="ConnectedTo"
-										type="LocalReference"/>
-									<xs:element minOccurs="0" name="SolarFraction"
-										type="SolarFraction">
+									<xs:element minOccurs="0" name="ConnectedTo" type="LocalReference"/>
+									<xs:element minOccurs="0" name="SolarFraction" type="SolarFraction">
 										<xs:annotation>
 											<xs:documentation>The Solar Fraction is the portion of the total conventional hot water heating load (delivered energy and tank standby losses). The higher
 												the solar fraction, the greater the solar contribution to water heating, which reduces the energy required by the backup water heater. This value can be
 												found in the OG-300 SRCC Certified Solar Water Heating System Directory.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="SolarEnergyFactor"
-										type="SolarThermalSystemEnergyFactor">
+									<xs:element minOccurs="0" name="SolarEnergyFactor" type="SolarThermalSystemEnergyFactor">
 										<xs:annotation>
 											<xs:documentation>The Solar Energy Factor is defined as the energy delivered by the system divided by the electrical or gas energy put into the system. The
 												higher the number, the more energy efficient. This value can be found in the OG-300 SRCC Certified Solar Water Heating System
@@ -1975,15 +1734,11 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
-									<xs:element minOccurs="0" name="Location"
-										type="PVSystemLocation"/>
-									<xs:element minOccurs="0" name="Ownership"
-										type="PVSystemOwnership"/>
+									<xs:element minOccurs="0" name="Location" type="PVSystemLocation"/>
+									<xs:element minOccurs="0" name="Ownership" type="PVSystemOwnership"/>
 									<xs:element minOccurs="0" name="ModuleType" type="PVModuleType"> </xs:element>
-									<xs:element maxOccurs="1" minOccurs="0" name="Tracking"
-										type="PVTracking"> </xs:element>
-									<xs:element minOccurs="0" name="ArrayOrientation"
-										type="OrientationType"/>
+									<xs:element maxOccurs="1" minOccurs="0" name="Tracking" type="PVTracking"> </xs:element>
+									<xs:element minOccurs="0" name="ArrayOrientation" type="OrientationType"/>
 									<xs:element minOccurs="0" name="ArrayAzimuth" type="AzimuthType">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
@@ -1999,36 +1754,28 @@
 											<xs:documentation>[DC Watts] Peak power as supplied by the manufacturer</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorArea"
-										type="SurfaceArea">
+									<xs:element minOccurs="0" name="CollectorArea" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberOfPanels"
-										type="IntegerGreaterThanZero"/>
-									<xs:element minOccurs="0" name="InverterEfficiency"
-										type="Fraction"/>
-									<xs:element minOccurs="0" name="SystemLossesFraction"
-										type="Fraction">
+									<xs:element minOccurs="0" name="NumberOfPanels" type="IntegerGreaterThanZero"/>
+									<xs:element minOccurs="0" name="InverterEfficiency" type="Fraction"/>
+									<xs:element minOccurs="0" name="SystemLossesFraction" type="Fraction">
 										<xs:annotation>
 											<xs:documentation>System losses can be due to soiling, shading, snow, mismatch, wiring, electrical connections, light-induced degradation, nameplate rating
 												inaccuracies, age, and availability.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="YearInverterManufactured"
-										type="Year"/>
-									<xs:element minOccurs="0" name="YearModulesManufactured"
-										type="Year"/>
+									<xs:element minOccurs="0" name="YearInverterManufactured" type="Year"/>
+									<xs:element minOccurs="0" name="YearModulesManufactured" type="Year"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
-									<xs:element minOccurs="0" name="AnnualOutput"
-										type="RatedAnnualkWh">
+									<xs:element minOccurs="0" name="AnnualOutput" type="RatedAnnualkWh">
 										<xs:annotation>
 											<xs:documentation>[kWh] Projected Annual Output for a typical meteorological year as determined by PVWatts or similar. </xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="LevelizedCostOfElectricity"
-										type="Cost">
+									<xs:element minOccurs="0" name="LevelizedCostOfElectricity" type="Cost">
 										<xs:annotation>
 											<xs:documentation>[$] The LCOE is the total cost of installing and operating a project expressed in dollars per kilowatt-hour of electricity generated by
 												the system over its life. Can be calculated with System Advisor Model, a similar software, or through a simplified calculation at
@@ -2051,30 +1798,25 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="Manufacturer"
-										type="Manufacturer"/>
+									<xs:element minOccurs="0" name="Manufacturer" type="Manufacturer"/>
 									<xs:element minOccurs="0" name="ModelNumber" type="Model"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
 									<xs:element minOccurs="0" name="Location" type="BatteryLocation"/>
-									<xs:element minOccurs="0" name="GridConnected"
-										type="HPXMLBoolean">
+									<xs:element minOccurs="0" name="GridConnected" type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Has the ability to feed electricity back on to the grid.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="BatteryType" type="BatteryType"/>
-									<xs:element minOccurs="0" name="CoolingStrategy"
-										type="BatteryCoolingStrategy"/>
-									<xs:element minOccurs="0" name="NominalCapacity"
-										type="BatteryCapacity">
+									<xs:element minOccurs="0" name="CoolingStrategy" type="BatteryCoolingStrategy"/>
+									<xs:element minOccurs="0" name="NominalCapacity" type="BatteryCapacity">
 										<xs:annotation>
 											<xs:documentation>[Ah] The total Ampere hours available when the battery is discharged starting from 100% state of charge until it reaches the cut-off
 												voltage. Capacity is computed by multiplying the discharge current (Amps) by the discharge time (hours).</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="UsableCapacity"
-										type="BatteryCapacity">
+									<xs:element minOccurs="0" name="UsableCapacity" type="BatteryCapacity">
 										<xs:annotation>
 											<xs:documentation>[Ah] The stored energy that can actually be used. In most cases usable capacity is less than the nominal capacity.</xs:documentation>
 										</xs:annotation>
@@ -2089,15 +1831,13 @@
 											<xs:documentation>[W] The peak power that the battery can generate for a short period of time.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NominalVoltage"
-										type="HPXMLDecimal">
+									<xs:element minOccurs="0" name="NominalVoltage" type="HPXMLDecimal">
 										<xs:annotation>
 											<xs:documentation>[V] The nominal voltage is the battery voltage when the state of charge is 0.5 (midway between being fully charged, and fully discharged)
 												with a 0.2C discharge current.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RoundTripEfficiency"
-										type="Fraction">
+									<xs:element minOccurs="0" name="RoundTripEfficiency" type="Fraction">
 										<xs:annotation>
 											<xs:documentation>Not all the power that is used to charge the battery is available during discharge. Round trip efficiency is the ratio of the energy put
 												in to the energy retrieved from storage.</xs:documentation>
@@ -2119,22 +1859,15 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="NumberofUnits"
-										type="IntegerGreaterThanOrEqualToZero"/>
-									<xs:element minOccurs="0" name="Manufacturer"
-										type="Manufacturer"/>
-									<xs:element maxOccurs="1" minOccurs="0" name="ModelNumber"
-										type="Model"/>
+									<xs:element minOccurs="0" name="NumberofUnits" type="IntegerGreaterThanOrEqualToZero"/>
+									<xs:element minOccurs="0" name="Manufacturer" type="Manufacturer"/>
+									<xs:element maxOccurs="1" minOccurs="0" name="ModelNumber" type="Model"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
-									<xs:element minOccurs="0" name="ChargingLevel"
-										type="EVChargingLevel"/>
-									<xs:element minOccurs="0" name="ChargingConnector"
-										type="EVChargingConnector"/>
-									<xs:element maxOccurs="1" minOccurs="0" name="ModelYear"
-										type="Year"/>
-									<xs:element minOccurs="0" name="ACPowerSourceVoltage"
-										type="Voltage">
+									<xs:element minOccurs="0" name="ChargingLevel" type="EVChargingLevel"/>
+									<xs:element minOccurs="0" name="ChargingConnector" type="EVChargingConnector"/>
+									<xs:element maxOccurs="1" minOccurs="0" name="ModelYear" type="Year"/>
+									<xs:element minOccurs="0" name="ACPowerSourceVoltage" type="Voltage">
 										<xs:annotation>
 											<xs:documentation>[V] Voltage of the AC power source</xs:documentation>
 										</xs:annotation>
@@ -2172,17 +1905,14 @@
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" name="Model" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
-									<xs:element minOccurs="0" name="ThirdPartyCertification"
-										maxOccurs="unbounded" type="WindThirdPartyCertification"/>
-									<xs:element minOccurs="0" name="AWEARatedAnnualEnergy"
-										type="RatedAnnualkWh">
+									<xs:element minOccurs="0" name="ThirdPartyCertification" maxOccurs="unbounded" type="WindThirdPartyCertification"/>
+									<xs:element minOccurs="0" name="AWEARatedAnnualEnergy" type="RatedAnnualkWh">
 										<xs:annotation>
 											<xs:documentation>[kWh] the calculated total energy that would be produced during a one-year period with an average wind speed of 5 m/s (11.2
 												mph)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AWEARatedSoundLevel"
-										type="HPXMLDouble">
+									<xs:element minOccurs="0" name="AWEARatedSoundLevel" type="HPXMLDouble">
 										<xs:annotation>
 											<xs:documentation>[dBA] the sound pressure level not exceeded by the wind turbine 95% of the time at a distance of 60 meters from the rotor with an average
 												wind speed of 5 m/s (11.2 mph). </xs:documentation>
@@ -2199,20 +1929,17 @@
 											<xs:documentation>[kW] the highest point on the certified power curve.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RotorDiameter"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="RotorDiameter" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HubHeight"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="HubHeight" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="LevelizedCostOfElectricity"
-										type="Cost">
+									<xs:element minOccurs="0" name="LevelizedCostOfElectricity" type="Cost">
 										<xs:annotation>
 											<xs:documentation>[$] The LCOE is the total cost of installing and operating a project expressed in dollars per kilowatt-hour of electricity generated by
 												the system over its life. Can be calculated with System Advisor Model, a similar software, or through a simplified calculation at
@@ -2234,19 +1961,13 @@
 	</xs:complexType>
 	<xs:complexType name="Appliances">
 		<xs:sequence>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="ClothesWasher"
-				type="ClothesWasherInfoType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="ClothesDryer"
-				type="ClothesDryerInfoType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="Dishwasher"
-				type="DishwasherInfoType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="Refrigerator"
-				type="RefrigeratorInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="ClothesWasher" type="ClothesWasherInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="ClothesDryer" type="ClothesDryerInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="Dishwasher" type="DishwasherInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="Refrigerator" type="RefrigeratorInfoType"/>
 			<xs:element minOccurs="0" maxOccurs="unbounded" name="Freezer" type="FreezerInfoType"/>
-			<xs:element name="Dehumidifier" maxOccurs="unbounded" minOccurs="0"
-				type="DehumidifierInfoType"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="CookingRange"
-				type="CookingRangeInfoType"/>
+			<xs:element name="Dehumidifier" maxOccurs="unbounded" minOccurs="0" type="DehumidifierInfoType"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="CookingRange" type="CookingRangeInfoType"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="Oven" type="OvenInfoType"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
@@ -2289,15 +2010,13 @@
 								<xs:documentation>[W] per unit</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element maxOccurs="unbounded" minOccurs="0"
-							name="ThirdPartyCertification" type="LightingThirdPartyCertification"/>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="LightingThirdPartyCertification"/>
 						<xs:element name="AverageHoursPerDay" type="HoursPerDay" minOccurs="0">
 							<xs:annotation>
 								<xs:documentation>[h]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="LightingDailyHours"
-							type="LightingDailyHours">
+						<xs:element minOccurs="0" name="LightingDailyHours" type="LightingDailyHours">
 							<xs:annotation>
 								<xs:documentation>[h]</xs:documentation>
 							</xs:annotation>
@@ -2317,9 +2036,7 @@
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element minOccurs="0" ref="ConnectedDevice"/>
-						<xs:element maxOccurs="unbounded" minOccurs="0"
-							name="ThirdPartyCertification"
-							type="LightingFixtureThirdPartyCertification"/>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="LightingFixtureThirdPartyCertification"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -2330,12 +2047,9 @@
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element minOccurs="0" ref="ConnectedDevice"/>
-						<xs:element minOccurs="0" name="AttachedToLightingGroup"
-							type="LocalReference"/>
-						<xs:element name="LightingControlType" type="LightingControls" minOccurs="0"
-							> </xs:element>
-						<xs:element name="NumberofLightingControls"
-							type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+						<xs:element minOccurs="0" name="AttachedToLightingGroup" type="LocalReference"/>
+						<xs:element name="LightingControlType" type="LightingControls" minOccurs="0"> </xs:element>
+						<xs:element name="NumberofLightingControls" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
 						<xs:element name="Location" type="LightingLocation" minOccurs="0"> </xs:element>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
@@ -2370,8 +2084,7 @@
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
-						<xs:element minOccurs="0" name="ThirdPartyCertification"
-							type="ApplianceThirdPartyCertifications" maxOccurs="unbounded"/>
+						<xs:element minOccurs="0" name="ThirdPartyCertification" type="ApplianceThirdPartyCertifications" maxOccurs="unbounded"/>
 						<xs:element minOccurs="0" name="Quantity" type="IntegerGreaterThanZero">
 							<xs:annotation>
 								<xs:documentation>Number of similar ceiling fans.</xs:documentation>
@@ -2433,8 +2146,7 @@
 									<xs:element name="Sodium">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="Pressure"
-												type="SodiumLight_Pressure"> </xs:element>
+												<xs:element minOccurs="0" name="Pressure" type="SodiumLight_Pressure"> </xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
@@ -2478,8 +2190,7 @@
 								<xs:documentation>[gal] Volume of pool.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="MonthsPerYearofOperation"
-							type="MonthsPerYear">
+						<xs:element minOccurs="0" name="MonthsPerYearofOperation" type="MonthsPerYear">
 							<xs:annotation>
 								<xs:documentation>Months per year pool is in operation.</xs:documentation>
 							</xs:annotation>
@@ -2489,8 +2200,7 @@
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="SuctionPipeDiameter"
-							type="LengthMeasurement">
+						<xs:element minOccurs="0" name="SuctionPipeDiameter" type="LengthMeasurement">
 							<xs:annotation>
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
@@ -2512,109 +2222,91 @@
 											<xs:sequence>
 												<xs:group ref="SystemInfo"/>
 												<xs:element minOccurs="0" ref="ConnectedDevice"/>
-												<xs:element minOccurs="0" name="Type"
-												type="PoolPumpType"/>
-												<xs:element minOccurs="0" name="Manufacturer"
-												type="HPXMLString">
-												<xs:annotation>
-												<xs:documentation>Manufacturer of pool pump.</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="Type" type="PoolPumpType"/>
+												<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString">
+													<xs:annotation>
+														<xs:documentation>Manufacturer of pool pump.</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="SerialNumber"
-												type="HPXMLString">
-												<xs:annotation>
-												<xs:documentation>Serial number of pool pump.</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString">
+													<xs:annotation>
+														<xs:documentation>Serial number of pool pump.</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="ModelNumber"
-												type="HPXMLString">
-												<xs:annotation>
-												<xs:documentation>Model number of pool pump.</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="ModelNumber" type="HPXMLString">
+													<xs:annotation>
+														<xs:documentation>Model number of pool pump.</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="ThirdPartyCertification"
-												type="PoolPump3rdPartyCertification"
-												maxOccurs="unbounded">
-												<xs:annotation>
-												<xs:documentation>Independent organization has verified that product or appliance meets or exceeds the standard in question (ENERGY STAR, CEE,
+												<xs:element minOccurs="0" name="ThirdPartyCertification" type="PoolPump3rdPartyCertification" maxOccurs="unbounded">
+													<xs:annotation>
+														<xs:documentation>Independent organization has verified that product or appliance meets or exceeds the standard in question (ENERGY STAR, CEE,
 															or other)</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="EnergyFactor"
-												type="Efficiency">
-												<xs:annotation>
-												<xs:documentation>[gal/Wh] The measure of overall pool filter pump efficiency in units of gallons per watt-hour, as determined using the
+												<xs:element minOccurs="0" name="EnergyFactor" type="Efficiency">
+													<xs:annotation>
+														<xs:documentation>[gal/Wh] The measure of overall pool filter pump efficiency in units of gallons per watt-hour, as determined using the
 															applicable test method in Section 4.1.2. Energy factor is analogous to other energy factors such as miles per gallon. Energy factor (EF) is
 															calculated as: EF (gal/Wh) = flow rate (gpm) * 60 ÷ power (watts) (ANSI/APSP/ICC-15 2011).</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="SpeedSetting"
-												type="PoolPumpSpeedSetting">
-												<xs:annotation>
-												<xs:documentation>The speed setting at which the Energy Factor was measured (ENERGY STAR, 2013).</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="SpeedSetting" type="PoolPumpSpeedSetting">
+													<xs:annotation>
+														<xs:documentation>The speed setting at which the Energy Factor was measured (ENERGY STAR, 2013).</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="RatedHorsepower"
-												type="Power">
-												<xs:annotation>
-												<xs:documentation>The motor power output designed by the manufacturer for a rated RPM, voltage and frequency. May be less than total horsepower
+												<xs:element minOccurs="0" name="RatedHorsepower" type="Power">
+													<xs:annotation>
+														<xs:documentation>The motor power output designed by the manufacturer for a rated RPM, voltage and frequency. May be less than total horsepower
 															where the service factor is greater than 1.0, or equal to total horsepower where the service factor = 1.0 (ANSI/APSP/ICC-15
 															2011).</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="TotalHorsepower"
-												type="Power">
-												<xs:annotation>
-												<xs:documentation>The total horsepower, or product of the rated horsepower and the service factor of a motor used on a pool pump (also known as
+												<xs:element minOccurs="0" name="TotalHorsepower" type="Power">
+													<xs:annotation>
+														<xs:documentation>The total horsepower, or product of the rated horsepower and the service factor of a motor used on a pool pump (also known as
 															SFHP) based on the maximum continuous duty motor power output rating allowable for the nameplate ambient rating and motor insulation class
 															(e.g., total horsepower = rated horsepower * service factor) (ANSI/APSP/ICC-15 2011).</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="ServiceFactor"
-												type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>A multiplier applied to the rated horsepower of a pump motor to indicate the percent above nameplate horsepower at which the
+												<xs:element minOccurs="0" name="ServiceFactor" type="HPXMLDouble">
+													<xs:annotation>
+														<xs:documentation>A multiplier applied to the rated horsepower of a pump motor to indicate the percent above nameplate horsepower at which the
 															motor can operate continuously without exceeding its allowable insulation class temperature limit, provided that other design parameters,
 															such rated voltage, frequency and ambient temperature, are within limits. A 1.5 hp pump with a 1.65 service factor produces 2.475 hp (total
 															horsepower) at the maximum service factor point (ANSI/APSP/ICC-15 2011).</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element maxOccurs="unbounded" minOccurs="0"
-												name="PumpSpeed">
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element minOccurs="0" name="Power"
-												type="Power">
-												<xs:annotation>
-												<xs:documentation>[W]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" name="MotorNominalSpeed"
-												type="Speed">
-												<xs:annotation>
-												<xs:documentation>[Rev/min] The number of revolutions of the motor shaft in a given unit of time, expressed as revolutions per
+												<xs:element maxOccurs="unbounded" minOccurs="0" name="PumpSpeed">
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element minOccurs="0" name="Power" type="Power">
+																<xs:annotation>
+																	<xs:documentation>[W]</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" name="MotorNominalSpeed" type="Speed">
+																<xs:annotation>
+																	<xs:documentation>[Rev/min] The number of revolutions of the motor shaft in a given unit of time, expressed as revolutions per
 																		minute (RPM) (ENERGY STAR, 2013).</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" name="FlowRate"
-												type="FlowRate">
-												<xs:annotation>
-												<xs:documentation>[gal/min] The volume of water flowing through the filtration system in a given time, usually measured in gallons
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" name="FlowRate" type="FlowRate">
+																<xs:annotation>
+																	<xs:documentation>[gal/min] The volume of water flowing through the filtration system in a given time, usually measured in gallons
 																		per minute (gpm) (ANSI/APSP/ICC-15 2011).</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" name="HoursPerDay"
-												type="HoursPerDay">
-												<xs:annotation>
-												<xs:documentation>[hours] Number of hours per day a pool pump operates at a particular speed setting.</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												<xs:attribute name="dataSource" type="DataSource"
-												/>
-												</xs:complexType>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" name="HoursPerDay" type="HoursPerDay">
+																<xs:annotation>
+																	<xs:documentation>[hours] Number of hours per day a pool pump operates at a particular speed setting.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+														<xs:attribute name="dataSource" type="DataSource"/>
+													</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -2682,10 +2374,8 @@
 						<xs:element minOccurs="0" ref="ConnectedDevice"/>
 						<xs:element minOccurs="0" name="ControlsPlugLoad" type="LocalReference"/>
 						<xs:element minOccurs="0" ref="AttachedToSpace"/>
-						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero"
-							minOccurs="0"/>
-						<xs:element name="PlugLoadControlType" minOccurs="0"
-							type="PlugLoadControlType"/>
+						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+						<xs:element name="PlugLoadControlType" minOccurs="0" type="PlugLoadControlType"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -2699,8 +2389,7 @@
 						<xs:element minOccurs="0" ref="AttachedToSpace"/>
 						<xs:element name="PlugLoadType" type="PlugLoadType" minOccurs="0"/>
 						<xs:element minOccurs="0" name="Location" type="PlugLoadLocation"/>
-						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero"
-							minOccurs="0"/>
+						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
 						<xs:element minOccurs="0" name="Load">
 							<xs:complexType>
 								<xs:sequence>
@@ -2733,14 +2422,10 @@
 			<xs:element name="Ventilation" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="WholeBuildingVentilationDesign"
-							type="WholeBldgVentDesignInfo"/>
-						<xs:element minOccurs="0" name="SpotVentilationDesign"
-							type="SpotVentDesignInfo"/>
-						<xs:element minOccurs="0" name="OtherVentilationIssues"
-							type="OtherVentIssues"/>
-						<xs:element minOccurs="0" name="VentilationImprovement"
-							type="VentilationImprovementInfo"/>
+						<xs:element minOccurs="0" name="WholeBuildingVentilationDesign" type="WholeBldgVentDesignInfo"/>
+						<xs:element minOccurs="0" name="SpotVentilationDesign" type="SpotVentDesignInfo"/>
+						<xs:element minOccurs="0" name="OtherVentilationIssues" type="OtherVentIssues"/>
+						<xs:element minOccurs="0" name="VentilationImprovement" type="VentilationImprovementInfo"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -2749,10 +2434,8 @@
 			<xs:element name="MoistureControl" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="MoistureControlInfo"
-							type="MoistureControlInfoType"> </xs:element>
-						<xs:element minOccurs="0" name="MoistureControlImprovement"
-							type="MoistureControlImprovementInfo"/>
+						<xs:element maxOccurs="unbounded" name="MoistureControlInfo" type="MoistureControlInfoType"> </xs:element>
+						<xs:element minOccurs="0" name="MoistureControlImprovement" type="MoistureControlImprovementInfo"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -2761,26 +2444,22 @@
 			<xs:element minOccurs="0" name="CombustionAppliances">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="CombustionApplianceZone"
-							maxOccurs="unbounded">
+						<xs:element minOccurs="0" name="CombustionApplianceZone" maxOccurs="unbounded">
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element name="CAZDepressurizationLimit"
-										type="CAZDepressurizationLimit" minOccurs="0">
+									<xs:element name="CAZDepressurizationLimit" type="CAZDepressurizationLimit" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>Pulled from industry standards by users (e.g. BPI Gold Sheet) or via software program</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="BaselineTest" type="CAZTestConfiguration"
-										minOccurs="0">
+									<xs:element name="BaselineTest" type="CAZTestConfiguration" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>Baseline pressure is read under the following conditions: no items running, all fans off, all exterior doors closed, and all interior
 												doors are opened.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="PoorCaseTest"
-										type="CAZTestConfiguration">
+									<xs:element minOccurs="0" name="PoorCaseTest" type="CAZTestConfiguration">
 										<xs:annotation>
 											<xs:documentation>The poor case CAZ depressurization test is configured by determining the largest combustion appliance zone depressurization attainable at
 												the time of testing due to the combined effects of door position, exhaust appliance operation, and air handler fan operation. A base pressure must be
@@ -2788,123 +2467,102 @@
 												depressurization attained at the time of testing and the base pressure.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="NetPressureChange" type="NetPressureChange"
-										minOccurs="0">
+									<xs:element name="NetPressureChange" type="NetPressureChange" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>With respect to the baseline pressure (e.g. no fans running, all exterior doors closed, and all interior doors opened)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="DepressurizationFindingPoorCase"
-										type="DepressurizationFindingPoorCase" minOccurs="0"/>
-									<xs:element name="AmountAmbientCOinCAZduringTesting"
-										type="HPXMLDouble" minOccurs="0">
+									<xs:element name="DepressurizationFindingPoorCase" type="DepressurizationFindingPoorCase" minOccurs="0"/>
+									<xs:element name="AmountAmbientCOinCAZduringTesting" type="HPXMLDouble" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>parts per million (ppm)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="AmbientCOinCAZExceeded35ppmduringTesting"
-										type="HPXMLBoolean" minOccurs="0"/>
-									<xs:element minOccurs="0" name="CombustionApplianceTest"
-										maxOccurs="unbounded">
+									<xs:element name="AmbientCOinCAZExceeded35ppmduringTesting" type="HPXMLBoolean" minOccurs="0"/>
+									<xs:element minOccurs="0" name="CombustionApplianceTest" maxOccurs="unbounded">
 										<xs:complexType>
 											<xs:sequence minOccurs="0">
-												<xs:element name="CAZAppliance"
-												type="RemoteReference">
-												<xs:annotation>
-												<xs:documentation>The ID of the system tested</xs:documentation>
-												</xs:annotation>
+												<xs:element name="CAZAppliance" type="RemoteReference">
+													<xs:annotation>
+														<xs:documentation>The ID of the system tested</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="CombustionVentingSystem"
-												type="RemoteReference"/>
-												<xs:element name="FlueVisualCondition"
-												type="FlueCondition" minOccurs="0"/>
-												<xs:element minOccurs="0" name="FlueConditionNotes"
-												type="HPXMLString"/>
-												<xs:element name="OutsideTemperatureFlueDraftTest"
-												type="Temperature" minOccurs="0">
-												<xs:annotation>
-												<xs:documentation>[deg F]</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="CombustionVentingSystem" type="RemoteReference"/>
+												<xs:element name="FlueVisualCondition" type="FlueCondition" minOccurs="0"/>
+												<xs:element minOccurs="0" name="FlueConditionNotes" type="HPXMLString"/>
+												<xs:element name="OutsideTemperatureFlueDraftTest" type="Temperature" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>[deg F]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="FlueDraftTest">
-												<xs:annotation>
-												<xs:documentation>[Pa]</xs:documentation>
-												</xs:annotation>
-												<xs:complexType>
-												<xs:complexContent>
-												<xs:extension base="CAZApplianceReading">
-												<xs:sequence>
-												<xs:element ref="extension" minOccurs="0"/>
-												</xs:sequence>
-												</xs:extension>
-												</xs:complexContent>
-												</xs:complexType>
+													<xs:annotation>
+														<xs:documentation>[Pa]</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:complexContent>
+															<xs:extension base="CAZApplianceReading">
+																<xs:sequence>
+																	<xs:element ref="extension" minOccurs="0"/>
+																</xs:sequence>
+															</xs:extension>
+														</xs:complexContent>
+													</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="SpillageTest">
-												<xs:annotation>
-												<xs:documentation>[seconds]</xs:documentation>
-												</xs:annotation>
-												<xs:complexType>
-												<xs:complexContent>
-												<xs:extension base="CAZApplianceReading">
-												<xs:sequence>
-												<xs:element ref="extension" minOccurs="0"/>
-												</xs:sequence>
-												</xs:extension>
-												</xs:complexContent>
-												</xs:complexType>
+													<xs:annotation>
+														<xs:documentation>[seconds]</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:complexContent>
+															<xs:extension base="CAZApplianceReading">
+																<xs:sequence>
+																	<xs:element ref="extension" minOccurs="0"/>
+																</xs:sequence>
+															</xs:extension>
+														</xs:complexContent>
+													</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="CarbonMonoxideTest">
-												<xs:annotation>
-												<xs:documentation>[ppm]</xs:documentation>
-												</xs:annotation>
-												<xs:complexType>
-												<xs:complexContent>
-												<xs:extension base="CAZApplianceReading">
-												<xs:sequence>
-												<xs:element
-												name="MaxAmbientCOinLivingSpaceDuringAudit"
-												minOccurs="0" type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>Monitored throughout assessment, not just appliance testing</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>[ppm]</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:complexContent>
+															<xs:extension base="CAZApplianceReading">
+																<xs:sequence>
+																	<xs:element name="MaxAmbientCOinLivingSpaceDuringAudit" minOccurs="0" type="HPXMLDouble">
+																		<xs:annotation>
+																			<xs:documentation>Monitored throughout assessment, not just appliance testing</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element minOccurs="0" name="AmbientCOActionDuringCAZTesting" type="HPXMLString">
+																		<xs:annotation>
+																			<xs:documentation>BPI Gold Sheet is one example that shows action levels based upon decision logic</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element minOccurs="0" ref="extension"/>
+																</xs:sequence>
+															</xs:extension>
+														</xs:complexContent>
+													</xs:complexType>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="AmbientCOActionDuringCAZTesting"
-												type="HPXMLString">
-												<xs:annotation>
-												<xs:documentation>BPI Gold Sheet is one example that shows action levels based upon decision logic</xs:documentation>
-												</xs:annotation>
+												<xs:element name="StackTemperature" type="Temperature" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>[deg F] after 10 minutes run time</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												</xs:extension>
-												</xs:complexContent>
-												</xs:complexType>
-												</xs:element>
-												<xs:element name="StackTemperature"
-												type="Temperature" minOccurs="0">
-												<xs:annotation>
-												<xs:documentation>[deg F] after 10 minutes run time</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element name="FuelLeaks" minOccurs="0"
-												maxOccurs="unbounded">
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element name="FuelType" type="FuelType"/>
-												<xs:element name="LeaksIdentified"
-												type="HPXMLBoolean"/>
-												<xs:element name="LeaksAddressed"
-												type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="Notes"
-												type="HPXMLString"/>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												<xs:attribute name="dataSource" type="DataSource"
-												/>
-												</xs:complexType>
+												<xs:element name="FuelLeaks" minOccurs="0" maxOccurs="unbounded">
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="FuelType" type="FuelType"/>
+															<xs:element name="LeaksIdentified" type="HPXMLBoolean"/>
+															<xs:element name="LeaksAddressed" type="HPXMLBoolean"/>
+															<xs:element minOccurs="0" name="Notes" type="HPXMLString"/>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+														<xs:attribute name="dataSource" type="DataSource"/>
+													</xs:complexType>
 												</xs:element>
 												<xs:element ref="extension" minOccurs="0"/>
 											</xs:sequence>
@@ -2926,8 +2584,7 @@
 					<xs:sequence>
 						<xs:element name="StoveID" type="SystemIdentifiersInfoType"/>
 						<xs:element minOccurs="0" name="StoveFuel" type="FuelType"/>
-						<xs:element name="HeatingStoveProperlyVented" type="HPXMLBoolean"
-							minOccurs="0"/>
+						<xs:element name="HeatingStoveProperlyVented" type="HPXMLBoolean" minOccurs="0"/>
 						<xs:element name="COReading" type="COReading" minOccurs="0"/>
 						<xs:element minOccurs="0" name="TimeofCOReading" type="HPXMLDateTime"/>
 						<xs:element name="GasLeaksIdentified" type="HPXMLBoolean" minOccurs="0"/>
@@ -2955,8 +2612,7 @@
 								<xs:documentation>Did the contracted scope of work include window replacement?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="LeadSafeCertificationNumber"
-							type="HPXMLString">
+						<xs:element minOccurs="0" name="LeadSafeCertificationNumber" type="HPXMLString">
 							<xs:annotation>
 								<xs:documentation>Certification Number of the EPA Lead-Safe Certified firm that performed the work.</xs:documentation>
 							</xs:annotation>
@@ -2974,34 +2630,27 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="StartDateTime"
-										type="HPXMLDateTime"/>
-									<xs:element minOccurs="0" name="EndDateTime"
-										type="HPXMLDateTime"/>
-									<xs:element minOccurs="0" name="TestLocation"
-										type="RadonTestLocation"/>
-									<xs:element name="RadonTestResults" type="HPXMLDouble"
-										minOccurs="0">
+									<xs:element minOccurs="0" name="StartDateTime" type="HPXMLDateTime"/>
+									<xs:element minOccurs="0" name="EndDateTime" type="HPXMLDateTime"/>
+									<xs:element minOccurs="0" name="TestLocation" type="RadonTestLocation"/>
+									<xs:element name="RadonTestResults" type="HPXMLDouble" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>in pCi/L</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RadonTestMethod"
-										type="RadonTestTypes"/>
+									<xs:element minOccurs="0" name="RadonTestMethod" type="RadonTestTypes"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
-						<xs:element minOccurs="0" name="EducationMaterialProvided"
-							type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="EducationMaterialProvided" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Was the homeowner provided with educational material?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element minOccurs="0" name="ActionsTaken" type="HPXMLString"/>
-						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecs"
-							type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecs" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>If moisture management of a crawlspace (e.g., installation of polyethylene sheeting) or radon mitigation measures were a part of the scope of
 									work,were measures installed to be compliant with one of the following: - Specifications of EPA’s Indoor airPLUS program - Techniques detailed in EPA's
@@ -3022,14 +2671,12 @@
 			<xs:element minOccurs="0" name="SourcePollutants">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="UnventedCombustionAppliancesinLivingArea"
-							type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="UnventedCombustionAppliancesinLivingArea" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Are there unvented combustion heating or hearth appliances present in the living area?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="ConformanceWithANSIZ21_11_2"
-							type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="ConformanceWithANSIZ21_11_2" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>If yes, does the appliance conform with ANSI Z21.11.2? </xs:documentation>
 							</xs:annotation>
@@ -3044,8 +2691,7 @@
 								<xs:documentation>Does home have attached garage?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="GarageContinuousAirBarrier"
-							type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="GarageContinuousAirBarrier" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>If yes, is there a continuous air barrier between garage and living space?</xs:documentation>
 							</xs:annotation>
@@ -3073,8 +2719,7 @@
 								<xs:documentation>Evidence of pesticide, insecticide use?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="IndustryStandardCompliance"
-							type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="IndustryStandardCompliance" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Do measures comply with industry standards to prevent pest entry? NOTE: This is for ALL measures that may create entry points for vermin. For example,
 									air sealing measures identified to reduce infiltration should have proper sealants - even if those measures were not recommended/installed for pest control
@@ -3104,11 +2749,9 @@
 								<xs:documentation>Was asbestos found?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="TypeofBlowerDoorTest"
-							type="TypeofBlowerDoorTest"/>
+						<xs:element minOccurs="0" name="TypeofBlowerDoorTest" type="TypeofBlowerDoorTest"/>
 						<xs:element minOccurs="0" name="ActionsTaken" type="HPXMLString"/>
-						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecifications"
-							type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecifications" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -3240,8 +2883,7 @@
 				</xs:element>
 				<xs:element name="RequiredVentilationRateUnits" type="VentilationRateUnits"/>
 			</xs:sequence>
-			<xs:element minOccurs="0" name="VentilationImprovementRecommendation"
-				type="Recommendation"/>
+			<xs:element minOccurs="0" name="VentilationImprovementRecommendation" type="Recommendation"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -3337,8 +2979,7 @@
 					<xs:documentation>should be represented as a fraction (ie 0.5 instead of 50%)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="EndUseSavings"
-				type="EndUseInfoType"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="EndUseSavings" type="EndUseInfoType"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -3374,19 +3015,16 @@
 			<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification"
-				type="HVACThirdPartyCertification"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="HVACThirdPartyCertification"/>
 			<xs:element minOccurs="0" name="HasSharedCombustionVentilation" type="HPXMLBoolean"/>
 			<xs:element minOccurs="0" name="CombustionVentingSystem" type="LocalReference"/>
-			<xs:element name="DistributionSystem" type="LocalReference" minOccurs="0"
-				maxOccurs="unbounded"/>
+			<xs:element name="DistributionSystem" type="LocalReference" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element minOccurs="0" name="Installation">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element minOccurs="0" name="Standard" type="HVACInstallationStandard"/>
 						<xs:element minOccurs="0" name="SizingCalculation" type="HVACSizingCalcs"/>
-						<xs:element minOccurs="0" name="EnvelopeImprovementsUsedinSizing"
-							type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="EnvelopeImprovementsUsedinSizing" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Air sealing and insulation implemented prior to replacement and used in calculations for sizing new / replacement system?</xs:documentation>
 							</xs:annotation>
@@ -3419,8 +3057,7 @@
 							<xs:documentation>[Btuh] Input Heating Capacity</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="AnnualHeatingEfficiency"
-						type="HeatingEfficiencyType" maxOccurs="unbounded"> </xs:element>
+					<xs:element minOccurs="0" name="AnnualHeatingEfficiency" type="HeatingEfficiencyType" maxOccurs="unbounded"> </xs:element>
 					<xs:element name="FractionHeatLoadServed" type="Fraction" minOccurs="0"/>
 					<xs:element minOccurs="0" name="FloorAreaServed" type="SurfaceArea">
 						<xs:annotation>
@@ -3449,8 +3086,7 @@
 						<xs:element minOccurs="0" name="PowerBurner" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
-						<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
-							type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="RetentionHead" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
@@ -3470,8 +3106,7 @@
 						<xs:element minOccurs="0" name="RotaryCup" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
-						<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
-							type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="RetentionHead" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
@@ -3481,8 +3116,7 @@
 			<xs:element name="ElectricResistance">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="ElectricDistribution" type="ElectricDistributionType"
-							minOccurs="0"/>
+						<xs:element name="ElectricDistribution" type="ElectricDistributionType" minOccurs="0"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -3498,8 +3132,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
-						<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
-							type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -3515,8 +3148,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
-						<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
-							type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -3595,15 +3227,13 @@
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="BackupSystemFuel" type="FuelType" minOccurs="0"/>
-					<xs:element name="BackupAnnualHeatingEfficiency" minOccurs="0"
-						type="HeatingEfficiencyType" maxOccurs="unbounded"> </xs:element>
+					<xs:element name="BackupAnnualHeatingEfficiency" minOccurs="0" type="HeatingEfficiencyType" maxOccurs="unbounded"> </xs:element>
 					<xs:element minOccurs="0" name="BackupHeatingCapacity" type="Capacity">
 						<xs:annotation>
 							<xs:documentation>[Btuh]</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="BackupHeatingSwitchoverTemperature"
-						type="Temperature">
+					<xs:element minOccurs="0" name="BackupHeatingSwitchoverTemperature" type="Temperature">
 						<xs:annotation>
 							<xs:documentation>[deg F] Temperature at which the backup heating is activated.</xs:documentation>
 						</xs:annotation>
@@ -3615,10 +3245,8 @@
 							<xs:documentation>[sq.ft.]</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType"
-						minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="AnnualHeatingEfficiency" minOccurs="0"
-						type="HeatingEfficiencyType" maxOccurs="unbounded"> </xs:element>
+					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="AnnualHeatingEfficiency" minOccurs="0" type="HeatingEfficiencyType" maxOccurs="unbounded"> </xs:element>
 					<xs:element minOccurs="0" ref="extension"/>
 				</xs:sequence>
 			</xs:extension>
@@ -3641,8 +3269,7 @@
 							<xs:documentation>[sq.ft.]</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType"
-						minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType" minOccurs="0" maxOccurs="unbounded"/>
 					<xs:element minOccurs="0" name="SensibleHeatFraction" type="Fraction"/>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
@@ -3682,8 +3309,7 @@
 				</xs:annotation>
 			</xs:element>
 			<xs:element minOccurs="0" name="PipeDiameter" type="PipeDiameterType"/>
-			<xs:element name="HydronicDistributionType" type="HydronicDistributionType"
-				minOccurs="0"/>
+			<xs:element name="HydronicDistributionType" type="HydronicDistributionType" minOccurs="0"/>
 			<xs:element minOccurs="0" name="SupplyTemperature" type="Temperature">
 				<xs:annotation>
 					<xs:documentation>[degF]</xs:documentation>
@@ -3702,8 +3328,7 @@
 								<xs:documentation>System Pump and Zone Valve Corrections made</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="ThermostaticRadiatorValves"
-							type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="ThermostaticRadiatorValves" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="VariableSpeedPump" type="HPXMLBoolean"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -3717,25 +3342,21 @@
 		<xs:sequence>
 			<xs:element name="AirDistributionType" type="AirDistributionType" minOccurs="0"/>
 			<xs:element name="AirHandlerMotorType" type="AirHandlerMotorType" minOccurs="0"/>
-			<xs:element minOccurs="0" name="DuctLeakageMeasurement"
-				type="DuctLeakageMeasurementType" maxOccurs="unbounded"/>
+			<xs:element minOccurs="0" name="DuctLeakageMeasurement" type="DuctLeakageMeasurementType" maxOccurs="unbounded"/>
 			<xs:element minOccurs="0" name="DuctSystemSizingAppropriate" type="HPXMLBoolean"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="Ducts">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element name="DuctType" type="DuctType" minOccurs="0"/>
 						<xs:element name="DuctMaterial" type="DuctMaterial" minOccurs="0"/>
-						<xs:element minOccurs="0" name="DuctInsulationMaterial"
-							type="InsulationMaterial"/>
+						<xs:element minOccurs="0" name="DuctInsulationMaterial" type="InsulationMaterial"/>
 						<xs:element name="DuctInsulationRValue" type="RValue" minOccurs="0"/>
-						<xs:element minOccurs="0" name="DuctInsulationThickness"
-							type="LengthMeasurement">
+						<xs:element minOccurs="0" name="DuctInsulationThickness" type="LengthMeasurement">
 							<xs:annotation>
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DuctInsulationCondition"
-							type="InsulationCondition"/>
+						<xs:element minOccurs="0" name="DuctInsulationCondition" type="InsulationCondition"/>
 						<xs:element name="DuctLocation" type="DuctLocation" minOccurs="0"/>
 						<xs:element minOccurs="0" name="FractionDuctArea" type="Fraction">
 							<xs:annotation>
@@ -3753,15 +3374,12 @@
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="NumberofReturnRegisters"
-				type="IntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="NumberofReturnRegisters" type="IntegerGreaterThanOrEqualToZero"/>
 			<xs:element minOccurs="0" name="TotalExternalStaticPressureMeasurement">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="Supply"
-							type="TotalExternalStaticPressureMeasurement"/>
-						<xs:element minOccurs="0" name="Return"
-							type="TotalExternalStaticPressureMeasurement"/>
+						<xs:element minOccurs="0" name="Supply" type="TotalExternalStaticPressureMeasurement"/>
+						<xs:element minOccurs="0" name="Return" type="TotalExternalStaticPressureMeasurement"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -3811,61 +3429,50 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:element minOccurs="0" name="SiteType" type="SiteType"/>
-									<xs:element minOccurs="0" name="Surroundings"
-										type="Surroundings">
+									<xs:element minOccurs="0" name="Surroundings" type="Surroundings">
 										<xs:annotation>
 											<xs:documentation>If the building is attached to other units in the horizontal plane.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="VerticalSurroundings"
-										type="VerticalSurroundings">
+									<xs:element minOccurs="0" name="VerticalSurroundings" type="VerticalSurroundings">
 										<xs:annotation>
 											<xs:documentation>If the building is attached to other units on the vertical plane.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ShieldingofHome" type="ShieldingofHome"
-										minOccurs="0"/>
-									<xs:element minOccurs="0" name="OrientationOfFrontOfHome"
-										type="OrientationType"/>
-									<xs:element minOccurs="0" name="AzimuthOfFrontOfHome"
-										type="AzimuthType"/>
+									<xs:element name="ShieldingofHome" type="ShieldingofHome" minOccurs="0"/>
+									<xs:element minOccurs="0" name="OrientationOfFrontOfHome" type="OrientationType"/>
+									<xs:element minOccurs="0" name="AzimuthOfFrontOfHome" type="AzimuthType"/>
 									<xs:element minOccurs="0" name="PublicTransportation">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="DistanceFromSubway"
-												type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>[ft]</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="DistanceFromSubway" type="LengthMeasurement">
+													<xs:annotation>
+														<xs:documentation>[ft]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="DistanceFromBus"
-												type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>[ft]</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="DistanceFromBus" type="LengthMeasurement">
+													<xs:annotation>
+														<xs:documentation>[ft]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="DistanceFromTrain"
-												type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>[ft]</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="DistanceFromTrain" type="LengthMeasurement">
+													<xs:annotation>
+														<xs:documentation>[ft]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="WalkingScore"
-										type="IntegerGreaterThanOrEqualToZero"/>
-									<xs:element minOccurs="0" name="WalkingScoreSource"
-										type="HPXMLString"/>
+									<xs:element minOccurs="0" name="WalkingScore" type="IntegerGreaterThanOrEqualToZero"/>
+									<xs:element minOccurs="0" name="WalkingScoreSource" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="FuelTypesAvailable">
 										<xs:annotation>
 											<xs:documentation>Fuels available on site via utility lines/pipes or delivery.</xs:documentation>
 										</xs:annotation>
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element maxOccurs="unbounded" name="Fuel"
-												type="FuelType"/>
+												<xs:element maxOccurs="unbounded" name="Fuel" type="FuelType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -3878,47 +3485,38 @@
 						<xs:element minOccurs="0" name="BuildingOccupancy">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element minOccurs="0" name="HouseholdType"
-										type="HouseholdType"/>
+									<xs:element minOccurs="0" name="HouseholdType" type="HouseholdType"/>
 									<xs:element minOccurs="0" name="YearOccupied" type="Year">
 										<xs:annotation>
 											<xs:documentation>The year the current occupants moved into the building</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="ResidentPopulationType"
-										type="ResidentPopulationType"/>
+									<xs:element minOccurs="0" name="ResidentPopulationType" type="ResidentPopulationType"/>
 									<xs:element minOccurs="0" name="Occupancy" type="Occupancy"/>
-									<xs:element name="NumberofResidents" type="PeopleCount"
-										minOccurs="0"/>
-									<xs:element minOccurs="0" name="NumberofAdults"
-										type="PeopleCount">
+									<xs:element name="NumberofResidents" type="PeopleCount" minOccurs="0"/>
+									<xs:element minOccurs="0" name="NumberofAdults" type="PeopleCount">
 										<xs:annotation>
 											<xs:documentation>18 or older</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofChildren"
-										type="IntegerGreaterThanOrEqualToZero">
+									<xs:element minOccurs="0" name="NumberofChildren" type="IntegerGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>less than 18 years old</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="PubliclySubsidized"
-										type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="PubliclySubsidized" type="HPXMLBoolean"/>
 									<xs:element minOccurs="0" name="LowIncome" type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="OccupantIncomeRange"
-										type="FractionGreaterThanOne">
+									<xs:element minOccurs="0" name="OccupantIncomeRange" type="FractionGreaterThanOne">
 										<xs:annotation>
 											<xs:documentation>Percentage as a fraction (50% = 0.5)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="OccupantIncomeRangeUnits"
-										type="OccupantIncomeRangeUnits">
+									<xs:element minOccurs="0" name="OccupantIncomeRangeUnits" type="OccupantIncomeRangeUnits">
 										<xs:annotation>
 											<xs:documentation>AMI = Area Median Income; FPL = Federal Poverty Level</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HighestLevelofOccupantEducation"
-										type="EducationLevels"/>
+									<xs:element minOccurs="0" name="HighestLevelofOccupantEducation" type="EducationLevels"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -3928,80 +3526,62 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:element name="YearBuilt" type="Year" minOccurs="0"/>
-									<xs:element minOccurs="0" name="YearBuiltKnownOrEstimated"
-										type="KnownOrEstimated"/>
+									<xs:element minOccurs="0" name="YearBuiltKnownOrEstimated" type="KnownOrEstimated"/>
 									<xs:element minOccurs="0" name="YearofLastRemodel" type="Year"/>
-									<xs:element name="ResidentialFacilityType"
-										type="ResidentialFacilityType" minOccurs="0"/>
-									<xs:element minOccurs="0" name="PassiveSolar"
-										type="HPXMLBoolean">
+									<xs:element name="ResidentialFacilityType" type="ResidentialFacilityType" minOccurs="0"/>
+									<xs:element minOccurs="0" name="PassiveSolar" type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Passive solar design—also known as climatic design—involves using a building's windows, walls, and floors to collect, store, and
 												distribute solar energy in the form of heat in the winter and reject solar heat in the summer. (source:
 												http://www.eere.energy.gov/basics/buildings/passive_solar_design.html)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="BuildingHeight"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="BuildingHeight" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] height of building</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofUnits"
-										type="IntegerGreaterThanZero"/>
-									<xs:element minOccurs="0" name="NumberofFloors"
-										type="NumberOfFloorsType">
+									<xs:element minOccurs="0" name="NumberofUnits" type="IntegerGreaterThanZero"/>
+									<xs:element minOccurs="0" name="NumberofFloors" type="NumberOfFloorsType">
 										<xs:annotation>
 											<xs:documentation>Total number of floors including a basement, whether conditioned or unconditioned</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofConditionedFloors"
-										type="NumberOfFloorsType">
+									<xs:element minOccurs="0" name="NumberofConditionedFloors" type="NumberOfFloorsType">
 										<xs:annotation>
 											<xs:documentation>Number of floors that are heated/cooled including a basement</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0"
-										name="NumberofConditionedFloorsAboveGrade"
-										type="NumberOfFloorsType">
+									<xs:element minOccurs="0" name="NumberofConditionedFloorsAboveGrade" type="NumberOfFloorsType">
 										<xs:annotation>
 											<xs:documentation>Number of floors above grade that are heated/cooled</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="AverageCeilingHeight" type="LengthMeasurement"
-										minOccurs="0">
+									<xs:element name="AverageCeilingHeight" type="LengthMeasurement" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[ft] Average distance from the floor to the ceiling</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FloorToFloorHeight"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="FloorToFloorHeight" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] distance between floors</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofRooms"
-										type="IntegerGreaterThanZero"/>
-									<xs:element name="NumberofBedrooms"
-										type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
-									<xs:element name="NumberofBathrooms"
-										type="IntegerGreaterThanZero" minOccurs="0"/>
-									<xs:element minOccurs="0" name="NumberofCompleteBathrooms"
-										type="IntegerGreaterThanZero">
+									<xs:element minOccurs="0" name="NumberofRooms" type="IntegerGreaterThanZero"/>
+									<xs:element name="NumberofBedrooms" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+									<xs:element name="NumberofBathrooms" type="IntegerGreaterThanZero" minOccurs="0"/>
+									<xs:element minOccurs="0" name="NumberofCompleteBathrooms" type="IntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Number of bathrooms with a tub or shower</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="BuildingFootprintArea"
-										type="SurfaceArea">
+									<xs:element minOccurs="0" name="BuildingFootprintArea" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FootprintShape"
-										type="FootprintShape"/>
-									<xs:element minOccurs="0" name="GrossFloorArea"
-										type="SurfaceArea">
+									<xs:element minOccurs="0" name="FootprintShape" type="FootprintShape"/>
+									<xs:element minOccurs="0" name="GrossFloorArea" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Gross floor area (based on ASHRAE definition) is the sum of the floor areas of the spaces within the building, including
 												basements, mezzanine and intermediate‐floored tiers, and penthouses with headroom height of 7.5 ft (2.2 meters) or greater. Measurements must be taken
@@ -4019,39 +3599,33 @@
 												area.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ConditionedFloorArea" type="SurfaceArea"
-										minOccurs="0">
+									<xs:element name="ConditionedFloorArea" type="SurfaceArea" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] All finished space that is within the (insulated) conditioned space boundary (that is, within the insulated envelope), regardless
 												of HVAC configuration.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FinishedFloorArea"
-										type="SurfaceArea">
+									<xs:element minOccurs="0" name="FinishedFloorArea" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Floor area of home that is finished and assumed to be occupied.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="NumberofStoriesAboveGrade"
-										type="IntegerGreaterThanZero" minOccurs="0"/>
-									<xs:element minOccurs="0" name="CooledFloorArea"
-										type="SurfaceArea">
+									<xs:element name="NumberofStoriesAboveGrade" type="IntegerGreaterThanZero" minOccurs="0"/>
+									<xs:element minOccurs="0" name="CooledFloorArea" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] The total area of all enclosed spaces measured to the internal face of the external walls. Included are areas of sloping surfaces
 												such as staircases, galleries, raked auditoria, and tiered terraces where the area taken is from the area on the plan. Excluded are areas that are not
 												enclosed such as open floors, covered ways and balconies.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HeatedFloorArea"
-										type="SurfaceArea">
+									<xs:element minOccurs="0" name="HeatedFloorArea" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] The total area of all enclosed spaces measured to the internal face of the external walls. Included are areas of sloping surfaces
 												such as staircases, galleries, raked auditoria, and tiered terraces where the area taken is from the area on the plan. Excluded are areas that are not
 												enclosed such as open floors, covered ways and balconies.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="UnconditionedFloorArea"
-										type="SurfaceArea">
+									<xs:element minOccurs="0" name="UnconditionedFloorArea" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] An enclosed space within a building that does not meet the requirements of a conditioned space. Spaces that have no control over
 												thermal conditions but intentionally or unintentionally receive thermal energy from adjacent spaces are considered unconditioned spaces (such as an
@@ -4067,8 +3641,7 @@
 												building.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ConditionedBuildingVolume" type="Volume"
-										minOccurs="0">
+									<xs:element name="ConditionedBuildingVolume" type="Volume" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[cu.ft.] Volume inside the building envelope of the conditioned spaces. This metric can be calculated as the volume of the building if
 												every space is conditioned or on a floor-by-floor basis. For spaces with vertical walls and horizontal ceilings and floors, this is calculated as the
@@ -4078,8 +3651,7 @@
 												return air plenums.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="FoundationType" minOccurs="0"
-										type="FoundationType">
+									<xs:element name="FoundationType" minOccurs="0" type="FoundationType">
 										<xs:annotation>
 											<xs:documentation>Primary foundation type of building</xs:documentation>
 										</xs:annotation>
@@ -4089,18 +3661,13 @@
 											<xs:documentation>Primary attic type of building</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="AverageAtticRValue" type="RValue"
-										minOccurs="0"/>
+									<xs:element name="AverageAtticRValue" type="RValue" minOccurs="0"/>
 									<xs:element name="AverageWallRValue" type="RValue" minOccurs="0"/>
-									<xs:element name="AverageFloorRValue" type="RValue"
-										minOccurs="0"/>
+									<xs:element name="AverageFloorRValue" type="RValue" minOccurs="0"/>
 									<xs:element name="AverageDuctRValue" type="RValue" minOccurs="0"/>
-									<xs:element minOccurs="0" name="GaragePresent"
-										type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="GarageLocation"
-										type="GarageLocation"/>
-									<xs:element minOccurs="0" name="SpaceAboveGarage"
-										type="SpaceAboveGarage"/>
+									<xs:element minOccurs="0" name="GaragePresent" type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="GarageLocation" type="GarageLocation"/>
+									<xs:element minOccurs="0" name="SpaceAboveGarage" type="SpaceAboveGarage"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -4109,8 +3676,7 @@
 						<xs:element name="AnnualEnergyUse" minOccurs="0">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"
-										maxOccurs="unbounded"/>
+									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType" maxOccurs="unbounded"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
@@ -4124,15 +3690,13 @@
 				<xs:complexType>
 					<xs:sequence minOccurs="0">
 						<xs:element name="ClimateZoneDOE" type="ClimateZoneDOE" minOccurs="0"/>
-						<xs:element name="ClimateZoneIECC" minOccurs="0" type="IECCClimateZoneType"
-							maxOccurs="unbounded"/>
+						<xs:element name="ClimateZoneIECC" minOccurs="0" type="IECCClimateZoneType" maxOccurs="unbounded"/>
 						<xs:element name="RadonZone" type="RadonZone" minOccurs="0"/>
 						<xs:element name="TermiteZone" type="TermiteZone" minOccurs="0"/>
 						<xs:element name="HurricaneZone" type="HPXMLBoolean" minOccurs="0"/>
 						<xs:element name="FloodZone" type="HPXMLBoolean" minOccurs="0"/>
 						<xs:element name="EarthquakeZone" type="EarthquakeZone" minOccurs="0"/>
-						<xs:element maxOccurs="unbounded" minOccurs="0" name="WeatherStation"
-							type="WeatherStation">
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="WeatherStation" type="WeatherStation">
 							<xs:annotation>
 								<xs:documentation>Weather location used in model simulation and/or utility bill regression analysis</xs:documentation>
 							</xs:annotation>
@@ -4186,15 +3750,13 @@
 												which is the purpose of this field.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Source"
-										type="GreenBuildingVerificationSource">
+									<xs:element minOccurs="0" name="Source" type="GreenBuildingVerificationSource">
 										<xs:annotation>
 											<xs:documentation>The source of the green data. May address photovoltaic characteristics, or a verified score, certification, label, etc. This may be a pick
 												list of options showing the source. i.e. Program Sponsor, Program Verifier, Public Record, Assessor, etc.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Status"
-										type="GreenBuildingVerificationStatus">
+									<xs:element minOccurs="0" name="Status" type="GreenBuildingVerificationStatus">
 										<xs:annotation>
 											<xs:documentation>Many verification programs include a multi-step process that may begin with plans and specs, involve testing and/or submission of building
 												specifications along the way and include a final verification step. When ratings are involved it is not uncommon for the final rating to be either
@@ -4285,14 +3847,12 @@
 			<xs:element name="Incentives" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="Incentive"
-							type="IncentiveDetailsType"/>
+						<xs:element maxOccurs="unbounded" name="Incentive" type="IncentiveDetailsType"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType"
-				maxOccurs="2"/>
+			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType" maxOccurs="2"/>
 			<xs:element maxOccurs="2" minOccurs="0" name="WaterSavingsInfo" type="WaterSavingsType"/>
 			<xs:element minOccurs="0" name="Measures">
 				<xs:complexType>
@@ -4308,10 +3868,8 @@
 	</xs:complexType>
 	<xs:complexType name="TotalCostType">
 		<xs:sequence>
-			<xs:element name="TotalCostHealthSafetyMeasures" type="TotalCostHealthSafetyMeasures"
-				minOccurs="1"/>
-			<xs:element name="TotalCostQualEnergyMeasures" type="TotalCostQualEnergyMeasures"
-				minOccurs="1"/>
+			<xs:element name="TotalCostHealthSafetyMeasures" type="TotalCostHealthSafetyMeasures" minOccurs="1"/>
+			<xs:element name="TotalCostQualEnergyMeasures" type="TotalCostQualEnergyMeasures" minOccurs="1"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
@@ -4348,8 +3906,7 @@
 			<xs:element minOccurs="0" name="Incentives">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="Incentive"
-							type="IncentiveDetailsType"/>
+						<xs:element maxOccurs="unbounded" name="Incentive" type="IncentiveDetailsType"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -4368,8 +3925,7 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element name="Quantity" type="Quantity"/>
-									<xs:element name="AnnualAmount" type="AnnualAmount"
-										minOccurs="0"/>
+									<xs:element name="AnnualAmount" type="AnnualAmount" minOccurs="0"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -4379,8 +3935,7 @@
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType"
-				maxOccurs="2"/>
+			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType" maxOccurs="2"/>
 			<xs:element maxOccurs="2" minOccurs="0" name="WaterSavingsInfo" type="WaterSavingsType"/>
 			<xs:element minOccurs="0" name="CustomerNotes" type="Notes"/>
 			<xs:element minOccurs="0" name="WorkscopeNotes" type="Notes"/>
@@ -4407,8 +3962,7 @@
 				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="ReplacedComponent"
-							type="RemoteReference"/>
+						<xs:element maxOccurs="unbounded" name="ReplacedComponent" type="RemoteReference"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -4416,8 +3970,7 @@
 			<xs:element minOccurs="0" name="InstalledComponents">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="1" name="InstalledComponent" type="RemoteReference"
-							maxOccurs="unbounded"/>
+						<xs:element minOccurs="1" name="InstalledComponent" type="RemoteReference" maxOccurs="unbounded"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -4434,8 +3987,7 @@
 				</xs:annotation>
 			</xs:element>
 			<xs:element minOccurs="0" name="EnergySavingsReported" type="GrossOrNet"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="FuelSavings"
-				type="FuelSavingsType"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="FuelSavings" type="FuelSavingsType"/>
 			<xs:element name="DemandSavings" minOccurs="0" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[kW] Demand savings from energy efficiency programs</xs:documentation>
@@ -4470,8 +4022,7 @@
 	<xs:complexType name="DuctLeakageMeasurementType">
 		<xs:sequence>
 			<xs:element minOccurs="0" name="DuctType" type="DuctType"/>
-			<xs:element name="LeakinessObservedVisualInspection"
-				type="LeakinessObservedVisualInspection" minOccurs="0"/>
+			<xs:element name="LeakinessObservedVisualInspection" type="LeakinessObservedVisualInspection" minOccurs="0"/>
 			<xs:element name="DuctLeakageTestMethod" type="DuctLeakageTestMethod" minOccurs="0"/>
 			<xs:element minOccurs="0" name="DuctLeakage">
 				<xs:complexType>
@@ -4482,8 +4033,7 @@
 							</xs:annotation>
 						</xs:element>
 						<xs:element name="Value" type="MeasuredDuctLeakage" minOccurs="0"/>
-						<xs:element minOccurs="0" name="TotalOrToOutside"
-							type="DuctLeakageTotalOrToOutside"/>
+						<xs:element minOccurs="0" name="TotalOrToOutside" type="DuctLeakageTotalOrToOutside"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -4551,8 +4101,7 @@
 		<xs:sequence>
 			<xs:element minOccurs="0" name="WeatherRegressionBeginDate" type="HPXMLDate"/>
 			<xs:element minOccurs="0" name="WeatherRegressionEndDate" type="HPXMLDate"/>
-			<xs:element minOccurs="0" name="CalibrationQualification"
-				type="BPI2400CalibrationQualification">
+			<xs:element minOccurs="0" name="CalibrationQualification" type="BPI2400CalibrationQualification">
 				<xs:annotation>
 					<xs:documentation>This identifies which data quality requirements (if any) were met by the bills for the relevant energy source and therefore which calibration metrics (if any) are
 						used to determine whether the calibrated model is accepted.</xs:documentation>
@@ -4578,65 +4127,55 @@
 					<xs:documentation>Weather Normalized Annual Baseload Usage</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingBiasError"
-				type="HPXMLDouble">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingBiasError" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Eqn. 3.2.3.A.i of BPI-2400. Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingAbsoluteError"
-				type="HPXMLDouble">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingAbsoluteError" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Eqn. 3.2.3.A.ii of BPI-2400. In either kWh for electricity or MMBTU for all other fuels.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingBiasError"
-				type="HPXMLDouble">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingBiasError" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingAbsoluteError"
-				type="HPXMLDouble">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingAbsoluteError" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>In either kWh for electricity or MMBTU for all other fuels.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadBiasError"
-				type="HPXMLDouble">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadBiasError" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadAbsoluteError"
-				type="HPXMLDouble">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadAbsoluteError" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>In either kWh for electricity or MMBTU for all other fuels.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SimplifiedModelCalibrationHeatingBiasError"
-				nillable="true" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationHeatingBiasError" nillable="true" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% =
 						0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SimplifiedModelCalibrationCoolingBiasError"
-				type="HPXMLDouble">
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationCoolingBiasError" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% =
 						0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SimplifiedModelCalibrationBaseloadBiasError"
-				nillable="true" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationBaseloadBiasError" nillable="true" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% =
 						0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SimplifiedModelCalibrationTotalBiasError"
-				type="HPXMLDouble">
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationTotalBiasError" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% =
 						0.1)</xs:documentation>
@@ -4657,8 +4196,7 @@
 							</xs:annotation>
 						</xs:element>
 						<xs:element name="UnitofMeasure" type="energyUnitType"/>
-						<xs:element minOccurs="0" name="MeteringConfiguration"
-							type="MeteringConfiguration">
+						<xs:element minOccurs="0" name="MeteringConfiguration" type="MeteringConfiguration">
 							<xs:annotation>
 								<xs:documentation>direct metering = tenants directly metered; master meter without sub-metering = tenants not sub metered; master meter with sub-metering = tenant
 									sub-metered by building owner</xs:documentation>
@@ -4671,8 +4209,7 @@
 										<xs:complexType>
 											<xs:sequence>
 												<xs:element name="EmissionType" type="EmissionType"/>
-												<xs:element name="EmissionUnits"
-												type="EmissionUnits"/>
+												<xs:element name="EmissionUnits" type="EmissionUnits"/>
 												<xs:element name="Emissions" type="HPXMLDouble"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
@@ -4682,10 +4219,8 @@
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
-						<xs:element minOccurs="0" name="FuelInterruptibility"
-							type="FuelInterruptibility"/>
-						<xs:element minOccurs="0" name="SharedEnergySystem"
-							type="SharedEnergySystem"/>
+						<xs:element minOccurs="0" name="FuelInterruptibility" type="FuelInterruptibility"/>
+						<xs:element minOccurs="0" name="SharedEnergySystem" type="SharedEnergySystem"/>
 						<xs:element minOccurs="0" name="IntervalType" type="IntervalType"/>
 						<xs:element minOccurs="0" name="ReadingTimeZone" type="HPXMLString"/>
 						<xs:element minOccurs="0" name="MarginalEnergyCostRate" type="HPXMLDouble">
@@ -4746,8 +4281,7 @@
 			<xs:element name="UnitofMeasure" type="energyUnitType"/>
 			<xs:element minOccurs="0" name="AnnualConsumption" type="HPXMLDouble"/>
 			<xs:element minOccurs="0" name="AnnualFuelCost" type="HPXMLDouble"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="ConsumptionByEndUse"
-				type="EndUseInfoType"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ConsumptionByEndUse" type="EndUseInfoType"/>
 			<xs:element minOccurs="0" name="BaseLoad" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Baseload power is the energy consumed for the day-to-day operation of a home that is not used as a response to outside weather (i.e. excludes heating and cooling)
@@ -4802,12 +4336,9 @@
 			<xs:element name="BusinessName" type="HPXMLString"/>
 			<xs:element name="BusinessType" type="BusinessType" minOccurs="0"/>
 			<xs:element name="BusinessSpecialization" type="BusinessSpecialization" minOccurs="0"/>
-			<xs:element name="Certification" type="BusinessCertification" minOccurs="0"
-				maxOccurs="unbounded"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="BusinessContact"
-				type="BusinessContactInfoType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="TelephoneInfo"
-				type="TelephoneInfoType"/>
+			<xs:element name="Certification" type="BusinessCertification" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="BusinessContact" type="BusinessContactInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="TelephoneInfo" type="TelephoneInfoType"/>
 			<xs:element minOccurs="0" maxOccurs="unbounded" name="EmailInfo" type="EmailInfoType"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
@@ -4849,8 +4380,7 @@
 			<xs:element name="SHGC" type="SHGC" minOccurs="0"/>
 			<xs:element minOccurs="0" name="VisibleTransmittance" type="Fraction"/>
 			<xs:element name="NFRCCertified" type="HPXMLBoolean" minOccurs="0"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification"
-				type="WindowThirdPartyCertification"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="WindowThirdPartyCertification"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="WindowFilm">
 				<xs:complexType>
 					<xs:sequence>
@@ -4946,14 +4476,12 @@
 								<xs:documentation>[in] Depth of overhang</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DistanceToTopOfWindow"
-							type="LengthMeasurement">
+						<xs:element minOccurs="0" name="DistanceToTopOfWindow" type="LengthMeasurement">
 							<xs:annotation>
 								<xs:documentation>[in] Vertical distance from overhang to top of window</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DistanceToBottomOfWindow"
-							type="LengthMeasurement">
+						<xs:element minOccurs="0" name="DistanceToBottomOfWindow" type="LengthMeasurement">
 							<xs:annotation>
 								<xs:documentation>[in] Vertical distance from overhang to bottom of window</xs:documentation>
 							</xs:annotation>
@@ -5090,8 +4618,7 @@
 				</xs:annotation>
 			</xs:element>
 			<xs:element minOccurs="0" name="WindConditions" type="WindConditions"/>
-			<xs:element name="TypeOfInfiltrationMeasurement" type="TypeofInfiltrationMeasurement"
-				minOccurs="0"/>
+			<xs:element name="TypeOfInfiltrationMeasurement" type="TypeofInfiltrationMeasurement" minOccurs="0"/>
 			<xs:element name="TypeOfBlowerDoorTest" type="TypeofBlowerDoorTest" minOccurs="0"/>
 			<xs:element name="HousePressure" type="HousePressure" minOccurs="0">
 				<xs:annotation>
@@ -5133,10 +4660,8 @@
 	<xs:complexType name="MoistureControlInfoType">
 		<xs:sequence>
 			<xs:group ref="SystemInfo"/>
-			<xs:element name="ExteriorLocationsWaterIntrusionorDamage"
-				type="ExteriorLocationsWaterIntrusionorDamage" minOccurs="0" maxOccurs="unbounded"/>
-			<xs:element name="InteriorLocationsofWaterLeaksorDamage"
-				type="InteriorLocationsofWaterLeaksorDamage" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ExteriorLocationsWaterIntrusionorDamage" type="ExteriorLocationsWaterIntrusionorDamage" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="InteriorLocationsofWaterLeaksorDamage" type="InteriorLocationsofWaterLeaksorDamage" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -5237,8 +4762,7 @@
 			<xs:element name="WoodStud">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="ExpandedPolystyreneSheathing"
-							type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="ExpandedPolystyreneSheathing" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Sheathing insulation should be specified in the Insulation element as well.</xs:documentation>
 							</xs:annotation>
@@ -5403,8 +4927,7 @@
 					<xs:documentation>Percent of rooms controlled by electronic zone valves with thermostats</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="HVACSystemsServed" type="LocalReference" minOccurs="0"
-				maxOccurs="unbounded"/>
+			<xs:element name="HVACSystemsServed" type="LocalReference" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -5436,11 +4959,9 @@
 					<xs:documentation>The year and month the duct system was sealed.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="DuctOutsideEnvelopeInsulatedaspartofRetrofit" type="HPXMLBoolean"
-				minOccurs="0"/>
+			<xs:element name="DuctOutsideEnvelopeInsulatedaspartofRetrofit" type="HPXMLBoolean" minOccurs="0"/>
 			<xs:element name="DuctSystemReplaced" type="HPXMLBoolean" minOccurs="0"/>
-			<xs:element name="SystemPumpandZoneValveCorrectionsMade" type="HPXMLBoolean"
-				minOccurs="0"/>
+			<xs:element name="SystemPumpandZoneValveCorrectionsMade" type="HPXMLBoolean" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -5453,10 +4974,8 @@
 					<xs:documentation>Year and month of the last tune and repair for this HVAC equipment.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="NumberofCoilsReplaced"
-				type="IntegerGreaterThanOrEqualToZero"/>
-			<xs:element minOccurs="0" name="NumberofAirHandlersReplaced"
-				type="IntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="NumberofCoilsReplaced" type="IntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="NumberofAirHandlersReplaced" type="IntegerGreaterThanOrEqualToZero"/>
 			<xs:element minOccurs="0" name="AirFilter">
 				<xs:complexType>
 					<xs:sequence>
@@ -5509,10 +5028,8 @@
 	<xs:complexType name="WaterHeaterImprovementInfo">
 		<xs:sequence>
 			<xs:element name="JacketInstalledIndicator" type="HPXMLBoolean" minOccurs="0"/>
-			<xs:element name="DispositionofExistingSystem" type="DispositionofExistingSystem"
-				minOccurs="0"/>
-			<xs:element name="RepairsDescription" type="HPXMLString" minOccurs="0"
-				maxOccurs="unbounded"/>
+			<xs:element name="DispositionofExistingSystem" type="DispositionofExistingSystem" minOccurs="0"/>
+			<xs:element name="RepairsDescription" type="HPXMLString" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="PipeInsulated" type="PipeInsulated" minOccurs="0"/>
 			<xs:element name="LengthofPipeInsulated" type="LengthMeasurement" minOccurs="0">
 				<xs:annotation>
@@ -5567,8 +5084,7 @@
 									Building/BuildingDetails/ClimateAndRiskZones/WeatherStation</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element maxOccurs="unbounded" name="ModeledUsage"
-							type="ModeledUsageType"/>
+						<xs:element maxOccurs="unbounded" name="ModeledUsage" type="ModeledUsageType"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -5659,8 +5175,7 @@
 			<xs:element minOccurs="0" name="ConsumptionDetails">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="ConsumptionInfo"
-							type="ConsumptionInfoType"/>
+						<xs:element maxOccurs="unbounded" name="ConsumptionInfo" type="ConsumptionInfoType"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -5708,8 +5223,7 @@
 					<xs:documentation>[Pa] positive for supply side measurements, negative for return side.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="MeasurementLocation"
-				type="AirHandlerStaticPressureMeasurementLocation"/>
+			<xs:element minOccurs="0" name="MeasurementLocation" type="AirHandlerStaticPressureMeasurementLocation"/>
 			<xs:element minOccurs="0" name="LocationDescription" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="StaticPressureSource" type="StaticPressureSource"/>
 			<xs:element minOccurs="0" ref="extension"/>
@@ -5811,10 +5325,8 @@
 			<xs:sequence>
 				<xs:group ref="SystemInfo"/>
 				<xs:element name="IsConnected" type="HPXMLBoolean"/>
-				<xs:element maxOccurs="unbounded" minOccurs="0" name="CommunicatesWith"
-					type="LocalReference"/>
-				<xs:element minOccurs="0" name="CommunicationProtocol"
-					type="ConnectedDeviceCommunicationProtocol" maxOccurs="unbounded"/>
+				<xs:element maxOccurs="unbounded" minOccurs="0" name="CommunicatesWith" type="LocalReference"/>
+				<xs:element minOccurs="0" name="CommunicationProtocol" type="ConnectedDeviceCommunicationProtocol" maxOccurs="unbounded"/>
 				<xs:element minOccurs="0" name="DemandResponseCapability" type="HPXMLBoolean"/>
 				<xs:element minOccurs="0" name="OccupancySensor" type="HPXMLBoolean"/>
 				<xs:element minOccurs="0" ref="extension"/>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.0">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10"
+	targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.0">
 	<xs:simpleType name="DataSource">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="user"/>
@@ -3753,7 +3754,8 @@
 	</xs:complexType>
 	<xs:simpleType name="GreenBuildingVerificationType_simple">
 		<xs:restriction base="xs:string">
-			<xs:enumeration value="BPI-2101-compliant Certificate of Residential Energy Efficiency Features and Performance"/>
+			<xs:enumeration
+				value="BPI-2101-compliant Certificate of Residential Energy Efficiency Features and Performance"/>
 			<xs:enumeration value="Certified Passive House"/>
 			<xs:enumeration value="ENERGY STAR Certified Homes"/>
 			<xs:enumeration value="EnerPHit"/>
@@ -4526,6 +4528,25 @@
 	<xs:complexType name="SolarThermalSystemEnergyFactor">
 		<xs:simpleContent>
 			<xs:extension base="SolarThermalSystemEnergyFactor_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="PerformanceClass_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Residential (R)"/>
+			<xs:enumeration value="Light Commercial (LC)"/>
+			<xs:enumeration value="Commercial (C)"/>
+			<xs:enumeration value="Heavy Commercial (HC)"/>
+			<xs:enumeration value="Architectural (AW)"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="PerformanceClass">
+		<xs:annotation>
+			<xs:documentation>The North American Fenestration Standard/Specification for windows, doors and, skylights provides a method for rating the structural performance, water resistance and air leakage of fenestration products.</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="PerformanceClass_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -4532,11 +4532,11 @@
 	</xs:complexType>
 	<xs:simpleType name="PerformanceClass_simple">
 		<xs:restriction base="xs:string">
-			<xs:enumeration value="Residential (R)"/>
-			<xs:enumeration value="Light Commercial (LC)"/>
-			<xs:enumeration value="Commercial (C)"/>
-			<xs:enumeration value="Heavy Commercial (HC)"/>
-			<xs:enumeration value="Architectural (AW)"/>
+			<xs:enumeration value="residential"/>
+			<xs:enumeration value="architectural"/>
+			<xs:enumeration value="light commercial"/>
+			<xs:enumeration value="commercial"/>
+			<xs:enumeration value="heavy commercial"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="PerformanceClass">

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10"
-	targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.0">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.0">
 	<xs:simpleType name="DataSource">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="user"/>
@@ -3754,8 +3753,7 @@
 	</xs:complexType>
 	<xs:simpleType name="GreenBuildingVerificationType_simple">
 		<xs:restriction base="xs:string">
-			<xs:enumeration
-				value="BPI-2101-compliant Certificate of Residential Energy Efficiency Features and Performance"/>
+			<xs:enumeration value="BPI-2101-compliant Certificate of Residential Energy Efficiency Features and Performance"/>
 			<xs:enumeration value="Certified Passive House"/>
 			<xs:enumeration value="ENERGY STAR Certified Homes"/>
 			<xs:enumeration value="EnerPHit"/>


### PR DESCRIPTION
Adds `PerformanceClass` element for windows, skylights, and doors per AAMA Standard. Choices are:
- residential
- architectural
- light commercial
- commercial
- heavy commercial