### PR TITLE
Address input vs output heating capacities

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -3051,9 +3051,14 @@
 				<xs:sequence minOccurs="1" maxOccurs="1">
 					<xs:element name="HeatingSystemType" type="HeatingSystemType" minOccurs="0"/>
 					<xs:element name="HeatingSystemFuel" type="FuelType" minOccurs="0"/>
-					<xs:element name="HeatingCapacity" type="Capacity" minOccurs="0">
+					<xs:element name="HeatingInputRating" type="Capacity" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>[Btuh] Input Heating Capacity</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="HeatingCapacity" type="Capacity" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>[Btuh] Output Heating Capacity</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element minOccurs="0" name="AnnualHeatingEfficiency" type="HeatingEfficiencyType" maxOccurs="unbounded"> </xs:element>
@@ -3199,17 +3204,17 @@
 					<xs:element minOccurs="0" name="HeatPumpFuel" type="FuelType"/>
 					<xs:element name="HeatingCapacity" type="Capacity" minOccurs="0">
 						<xs:annotation>
-							<xs:documentation>[Btuh] Typically the nameplate capacity at 47F.</xs:documentation>
+							<xs:documentation>[Btuh] Output heating capacity; typically the nameplate capacity at 47F.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element minOccurs="0" name="HeatingCapacity17F" type="Capacity">
 						<xs:annotation>
-							<xs:documentation>[Btuh] Capacity at 17F from AHRI database.</xs:documentation>
+							<xs:documentation>[Btuh] Output heating capacity at 17F from AHRI database.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element minOccurs="0" name="CoolingCapacity" type="Capacity">
 						<xs:annotation>
-							<xs:documentation>[Btuh]</xs:documentation>
+							<xs:documentation>[Btuh] Output cooling capacity</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element minOccurs="0" name="CoolingSensibleHeatFraction" type="Fraction"/>
@@ -3227,9 +3232,14 @@
 					</xs:element>
 					<xs:element name="BackupSystemFuel" type="FuelType" minOccurs="0"/>
 					<xs:element name="BackupAnnualHeatingEfficiency" minOccurs="0" type="HeatingEfficiencyType" maxOccurs="unbounded"> </xs:element>
+					<xs:element minOccurs="0" name="BackupHeatingInputRating" type="Capacity">
+						<xs:annotation>
+							<xs:documentation>[Btuh] Input heating capacity</xs:documentation>
+						</xs:annotation>
+					</xs:element>
 					<xs:element minOccurs="0" name="BackupHeatingCapacity" type="Capacity">
 						<xs:annotation>
-							<xs:documentation>[Btuh]</xs:documentation>
+							<xs:documentation>[Btuh] Output heating capacity</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element minOccurs="0" name="BackupHeatingSwitchoverTemperature" type="Temperature">
@@ -3259,7 +3269,7 @@
 					<xs:element minOccurs="0" name="CoolingSystemFuel" type="FuelType"/>
 					<xs:element minOccurs="0" name="CoolingCapacity" type="HPXMLDouble">
 						<xs:annotation>
-							<xs:documentation>[Btuh]</xs:documentation>
+							<xs:documentation>[Btuh] Output cooling capacity</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="FractionCoolLoadServed" type="Fraction" minOccurs="0"/>


### PR DESCRIPTION
For furnaces, [AHRI ratings](https://www.ahridirectory.org/NewSearch?programId=64&searchTypeId=3) include "Input Rating" and "Output Heating Capacity".

Most auditors probably collect input heating capacities. Most BEM tools probably collect output heating capacities. Though HPXML did define `HeatingCapacity` as _input_ heating capacity, it's likely that it was being used inconsistently for different use cases, since there was only a single element available.

To align with AHRI, this PR proposes to:
- Add `HeatingSystem/HeatingInputRating` (and `HeatPump/BackupHeatingInputRating`) elements
- Change the definition of `HeatingSystem/HeatingCapacity`  from _input_ heating capacity to _output_ heating capacity
- Clarify that all `CoolingCapacity` and `HeatPump/HeatingCapacity` and `HeatPump/HeatingCapacity17F` elements are _output_ capacities for consistency
