### PR TITLE
Requires AssemblyEffectiveRValue to be > 0

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -189,7 +189,7 @@
 			<xs:group ref="SystemInfo"/>
 			<xs:element minOccurs="0" name="InsulationGrade" type="InsulationGrade"/>
 			<xs:element minOccurs="0" name="InsulationCondition" type="InsulationCondition"/>
-			<xs:element minOccurs="0" name="AssemblyEffectiveRValue" type="RValue">
+			<xs:element minOccurs="0" name="AssemblyEffectiveRValue" type="AssemblyRValue">
 				<xs:annotation>
 					<xs:documentation>This should indicate the effective R-value of the complete assembly including any air films or other treatments.</xs:documentation>
 				</xs:annotation>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1256,6 +1256,18 @@
 		</xs:simpleContent>
 	</xs:complexType>
 	<!--Insulation Below-->
+	<xs:simpleType name="AssemblyRValue_simple">
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="AssemblyRValue">
+		<xs:simpleContent>
+			<xs:extension base="AssemblyRValue_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="DoorThirdPartyCertifications_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Energy Star"/>


### PR DESCRIPTION
Changes `AssemblyEffectiveRValue` from minInclusive=0 to minExclusive=0. The R-values associated with insulation materials are unchanged (i.e., they can still be zero).

An assembly effective R-value, which is documented as including air films, can never be zero. This change is proposed to prevent software tools from potentially _incorrectly_ using a value of zero. This change helps to ensure that all software tools consistently include air films in their value.