### PR TITLE
Removes outdated reference to HPXML wiki

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -4753,9 +4753,6 @@
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="WallType">
-		<xs:annotation>
-			<xs:documentation>Wall type enumerations are further explained at https://hpxml.nrel.gov/wiki/WallTypes</xs:documentation>
-		</xs:annotation>
 		<xs:choice>
 			<xs:element name="WoodStud">
 				<xs:complexType>


### PR DESCRIPTION
I don't know what happened to said wiki, but it clearly doesn't exist anymore. There was only a single reference to it, though.