### PR TITLE
Adds storm window material field

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -4445,6 +4445,7 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
+						<xs:element minOccurs="0" name="GlazingMaterial" type="GlazingMaterial"/>
 						<xs:element minOccurs="0" name="GlassType" type="GlassType"/>
 						<xs:element minOccurs="0" name="FrameType" type="WindowFrameType"/>
 						<xs:element minOccurs="0" name="Operable" type="HPXMLBoolean"/>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -2866,6 +2866,20 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+	<xs:simpleType name="GlazingMaterial_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="glass"/>
+			<xs:enumeration value="plastic"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="GlazingMaterial">
+		<xs:simpleContent>
+			<xs:extension base="GlazingMaterial_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="ClothesWasherType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="top loader"/>


### PR DESCRIPTION
Adds a `StormWindow/GlazingMaterial` element to characterize, e.g., plastic (instead of glass) storms. Options are:
- glass
- plastic
- other