### PR TITLE
HeatingSeason and CoolingSeason

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -4926,6 +4926,8 @@
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="HVACSystemsServed" type="LocalReference" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element maxOccurs="1" minOccurs="0" name="HeatingSeason" type="Season"/>
+			<xs:element minOccurs="0" name="CoolingSeason" type="Season"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -4927,7 +4927,7 @@
 			</xs:element>
 			<xs:element name="HVACSystemsServed" type="LocalReference" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element maxOccurs="1" minOccurs="0" name="HeatingSeason" type="Season"/>
-			<xs:element minOccurs="0" name="CoolingSeason" type="Season"/>
+			<xs:element maxOccurs="1" minOccurs="0" name="CoolingSeason" type="Season"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -5416,4 +5416,13 @@
 			<xs:attribute name="dataSource" type="DataSource"/>
 		</xs:complexType>
 	</xs:element>
+	<xs:complexType name="Season">
+		<xs:sequence>
+			<xs:element maxOccurs="1" minOccurs="0" name="BeginMonth" type="Month"/>
+			<xs:element maxOccurs="1" minOccurs="0" name="BeginDayOfMonth" type="DayOfMonth"/>
+			<xs:element maxOccurs="1" minOccurs="0" name="EndMonth" type="Month"/>
+			<xs:element maxOccurs="1" minOccurs="0" name="EndDayOfMonth" type="DayOfMonth"/>
+		</xs:sequence>
+		<xs:attribute name="dataSource" type="DataSource"/>
+	</xs:complexType>
 </xs:schema>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -4532,10 +4532,10 @@
 	</xs:complexType>
 	<xs:complexType name="Season">
 		<xs:sequence>
-			<xs:element name="BeginMonth" type="Month"/>
+			<xs:element maxOccurs="1" minOccurs="0" name="BeginMonth" type="Month"/>
 			<xs:element maxOccurs="1" minOccurs="0" name="BeginDayOfMonth" type="DayOfMonth"/>
-			<xs:element name="EndMonth" type="Month"/>
-			<xs:element minOccurs="0" name="EndDayOfMonth" type="DayOfMonth"/>
+			<xs:element maxOccurs="1" minOccurs="0" name="EndMonth" type="Month"/>
+			<xs:element maxOccurs="1" minOccurs="0" name="EndDayOfMonth" type="DayOfMonth"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -4530,4 +4530,25 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+	<xs:complexType name="Season">
+		<xs:sequence>
+			<xs:element name="BeginMonth" type="Month_simple"/>
+			<xs:element maxOccurs="1" minOccurs="0" name="BeginDayOfMonth" type="DayOfMonth_simple"/>
+			<xs:element name="EndMonth" type="Month_simple"/>
+			<xs:element minOccurs="0" name="EndDayOfMonth" type="DayOfMonth_simple"/>
+		</xs:sequence>
+		<xs:attribute name="dataSource" type="DataSource"/>
+	</xs:complexType>
+	<xs:simpleType name="Month_simple">
+		<xs:restriction base="xs:integer">
+			<xs:minInclusive value="1"/>
+			<xs:maxInclusive value="12"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DayOfMonth_simple">
+		<xs:restriction base="xs:integer">
+			<xs:minInclusive value="1"/>
+			<xs:maxInclusive value="31"/>
+		</xs:restriction>
+	</xs:simpleType>
 </xs:schema>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -4532,10 +4532,10 @@
 	</xs:complexType>
 	<xs:complexType name="Season">
 		<xs:sequence>
-			<xs:element name="BeginMonth" type="Month_simple"/>
-			<xs:element maxOccurs="1" minOccurs="0" name="BeginDayOfMonth" type="DayOfMonth_simple"/>
-			<xs:element name="EndMonth" type="Month_simple"/>
-			<xs:element minOccurs="0" name="EndDayOfMonth" type="DayOfMonth_simple"/>
+			<xs:element name="BeginMonth" type="Month"/>
+			<xs:element maxOccurs="1" minOccurs="0" name="BeginDayOfMonth" type="DayOfMonth"/>
+			<xs:element name="EndMonth" type="Month"/>
+			<xs:element minOccurs="0" name="EndDayOfMonth" type="DayOfMonth"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
@@ -4545,10 +4545,24 @@
 			<xs:maxInclusive value="12"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="Month">
+		<xs:simpleContent>
+			<xs:extension base="Month_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="DayOfMonth_simple">
 		<xs:restriction base="xs:integer">
 			<xs:minInclusive value="1"/>
 			<xs:maxInclusive value="31"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="DayOfMonth">
+		<xs:simpleContent>
+			<xs:extension base="DayOfMonth_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 </xs:schema>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -4534,15 +4534,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:complexType name="Season">
-		<xs:sequence>
-			<xs:element maxOccurs="1" minOccurs="0" name="BeginMonth" type="Month"/>
-			<xs:element maxOccurs="1" minOccurs="0" name="BeginDayOfMonth" type="DayOfMonth"/>
-			<xs:element maxOccurs="1" minOccurs="0" name="EndMonth" type="Month"/>
-			<xs:element maxOccurs="1" minOccurs="0" name="EndDayOfMonth" type="DayOfMonth"/>
-		</xs:sequence>
-		<xs:attribute name="dataSource" type="DataSource"/>
-	</xs:complexType>
 	<xs:simpleType name="Month_simple">
 		<xs:restriction base="xs:integer">
 			<xs:minInclusive value="1"/>


### PR DESCRIPTION
Many cities, such as NYC, mandate lengths of heating seasons in rental properties. For NYC, it is from October 1 to May 31st (regardless of weather conditions).

On `BuildingDetails/Systems/HVAC/HVACControl`:

![image](https://user-images.githubusercontent.com/5861765/120863921-a74b9e00-c548-11eb-819a-8d9c6b187bb8.png)

`Month_simple` is restricted to integers 1 - 12, and `DayOfMonth_simple` is restricted to integers 1 - 31.