### PR TITLE
Adds "none" as a siding type

### DIFF
--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -3394,6 +3394,7 @@
 			<xs:enumeration value="composite shingle siding"/>
 			<xs:enumeration value="masonite siding"/>
 			<xs:enumeration value="other"/>
+			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="Siding">


### PR DESCRIPTION
Adds "none" as a choice for the `Siding` element. (This is different from omitting the `Siding` element, which might indicate that the siding type is unknown rather than not present.)