### PR TITLE
Adds InteriorFinish element for enclosure surfaces

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -215,6 +215,19 @@
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
+	<xs:complexType name="InteriorFinishInfo">
+		<xs:sequence>
+			<xs:element minOccurs="0" name="Type" type="InteriorFinish"/>
+			<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+				<xs:annotation>
+					<xs:documentation>[in]</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element minOccurs="0" name="Color" type="WallAndRoofColor"/>
+			<xs:element ref="extension" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="dataSource" type="DataSource"/>
+	</xs:complexType>
 	<xs:element name="CoolingSystemInfo" type="CoolingSystemInfoType"/>
 	<xs:element name="HeatPumpInfo" type="HeatPumpInfoType"/>
 	<xs:element name="HeatingSystemInfo" type="HeatingSystemInfoType"/>
@@ -735,6 +748,7 @@
 									<xs:element minOccurs="0" name="RoofColor" type="WallAndRoofColor"/>
 									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
 									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
+									<xs:element minOccurs="0" name="InteriorFinish" type="InteriorFinishInfo"> </xs:element>
 									<xs:element minOccurs="0" name="Rafters" type="StudProperties"/>
 									<xs:element minOccurs="0" name="DeckType" type="DeckType"/>
 									<xs:element minOccurs="0" name="Pitch" type="Pitch">
@@ -834,19 +848,7 @@
 									<xs:element minOccurs="0" name="Color" type="WallAndRoofColor"/>
 									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
 									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
-									<xs:element minOccurs="0" name="InteriorFinish">
-										<xs:complexType>
-											<xs:sequence>
-												<xs:element minOccurs="0" name="Type" type="InteriorFinish"/>
-												<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
-													<xs:annotation>
-														<xs:documentation>[in]</xs:documentation>
-													</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" name="Color" type="WallAndRoofColor"/>
-											</xs:sequence>
-										</xs:complexType>
-									</xs:element>
+									<xs:element minOccurs="0" name="InteriorFinish" type="InteriorFinishInfo"> </xs:element>
 									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
@@ -913,19 +915,7 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="InteriorStuds" type="StudProperties"/>
-									<xs:element minOccurs="0" name="InteriorFinish">
-										<xs:complexType>
-											<xs:sequence>
-												<xs:element minOccurs="0" name="Type" type="InteriorFinish"/>
-												<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
-													<xs:annotation>
-														<xs:documentation>[in]</xs:documentation>
-													</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" name="Color" type="WallAndRoofColor"/>
-											</xs:sequence>
-										</xs:complexType>
-									</xs:element>
+									<xs:element minOccurs="0" name="InteriorFinish" type="InteriorFinishInfo"> </xs:element>
 									<xs:element minOccurs="0" name="DistanceToTopOfInsulation" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Vertical distance from top of foundation wall to top of insulation.</xs:documentation>
@@ -968,6 +958,7 @@
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
+									<xs:element minOccurs="0" name="InteriorFinish" type="InteriorFinishInfo"> </xs:element>
 									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"> </xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -838,7 +838,11 @@
 										<xs:complexType>
 											<xs:sequence>
 												<xs:element minOccurs="0" name="Type" type="InteriorFinish"/>
-												<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement"/>
+												<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+													<xs:annotation>
+														<xs:documentation>[in]</xs:documentation>
+													</xs:annotation>
+												</xs:element>
 												<xs:element minOccurs="0" name="Color" type="WallAndRoofColor"/>
 											</xs:sequence>
 										</xs:complexType>
@@ -913,7 +917,11 @@
 										<xs:complexType>
 											<xs:sequence>
 												<xs:element minOccurs="0" name="Type" type="InteriorFinish"/>
-												<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement"/>
+												<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+													<xs:annotation>
+														<xs:documentation>[in]</xs:documentation>
+													</xs:annotation>
+												</xs:element>
 												<xs:element minOccurs="0" name="Color" type="WallAndRoofColor"/>
 											</xs:sequence>
 										</xs:complexType>

--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -834,6 +834,15 @@
 									<xs:element minOccurs="0" name="Color" type="WallAndRoofColor"/>
 									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
 									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
+									<xs:element minOccurs="0" name="InteriorFinish">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element minOccurs="0" name="Type" type="InteriorFinish"/>
+												<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement"/>
+												<xs:element minOccurs="0" name="Color" type="WallAndRoofColor"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
 									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
@@ -900,6 +909,15 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="InteriorStuds" type="StudProperties"/>
+									<xs:element minOccurs="0" name="InteriorFinish">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element minOccurs="0" name="Type" type="InteriorFinish"/>
+												<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement"/>
+												<xs:element minOccurs="0" name="Color" type="WallAndRoofColor"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
 									<xs:element minOccurs="0" name="DistanceToTopOfInsulation" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Vertical distance from top of foundation wall to top of insulation.</xs:documentation>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -3403,6 +3403,23 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+	<xs:simpleType name="InteriorFinish_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="gypsum board"/>
+			<xs:enumeration value="gypsum composite board"/>
+			<xs:enumeration value="plaster"/>
+			<xs:enumeration value="wood"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="InteriorFinish">
+		<xs:simpleContent>
+			<xs:extension base="InteriorFinish_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="LengthMeasurement_simple">
 		<xs:restriction base="xs:double">
 			<xs:minInclusive value="0"/>


### PR DESCRIPTION
Allows describing the interior finish for Walls, FoundationWalls, FrameFloors (e.g., ceilings), and Roofs (e.g., cathedral ceilings).

![image](https://user-images.githubusercontent.com/5861765/121095959-84222800-c7ae-11eb-83ff-60a470c8f836.png)

Type choices:
- gypsum board
- gypsum composite board
- plaster
- wood
- other
- none

Color choices are the same as other similar elements in HPXML (i.e., light, medium, medium dark, dark, reflective).