### PR TITLE
Adds UsageBin element for water heaters

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -1410,6 +1410,11 @@
 												with the water heater fully heated.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
+									<xs:element minOccurs="0" name="UsageBin" type="UsageBin">
+										<xs:annotation>
+											<xs:documentation>A water heater's usage bin is derived from its First Hour Rating (FHR) as part of the Uniform Energy Factor (UEF) testing procedures.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
 									<xs:element minOccurs="0" name="GallonsPerMinute" type="Volume">
 										<xs:annotation>
 											<xs:documentation>[gal per minute] The amount of gallons per minute of hot water that can be supplied by an instantaneous water heater while maintaining a

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -4233,6 +4233,21 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+	<xs:simpleType name="UsageBin_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="very small"/>
+			<xs:enumeration value="low"/>
+			<xs:enumeration value="medium"/>
+			<xs:enumeration value="high"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="UsageBin">
+		<xs:simpleContent>
+			<xs:extension base="UsageBin_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="VentilationUnit_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="SLA"/>


### PR DESCRIPTION
Adds `WaterHeatingSystem/UsageBin` element with enumerations ("very small", "low", "medium", or "high"). This input could be provided instead of the numeric First Hour Rating.

Both the usage bin and the FHR are available on a water heater's label (for water heaters that are rated w/ a Uniform Energy Factor).

![image](https://user-images.githubusercontent.com/5861765/121597523-0f452d00-c9fe-11eb-900f-d61253078088.png)
