### PR TITLE
Add `FoundationWall/Type` enumerations

### DIFF
--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1135,6 +1135,8 @@
 			<xs:enumeration value="concrete block"/>
 			<xs:enumeration value="concrete block foam core"/>
 			<xs:enumeration value="concrete block vermiculite core"/>
+			<xs:enumeration value="concrete block perlite core"/>
+			<xs:enumeration value="concrete block solid core"/>
 			<xs:enumeration value="double brick"/>
 			<xs:enumeration value="wood"/>
 		</xs:restriction>


### PR DESCRIPTION
Adds "concrete block perlite core" and "concrete block solid core" as enumerations for `FoundationWall/Type`, based on Table 2 of https://ncma.org/resource/rvalues-ufactors-of-single-wythe-concrete-masonry-walls/.