### PR TITLE
Add battery kWh elements

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -1882,9 +1882,19 @@
 												voltage. Capacity is computed by multiplying the discharge current (Amps) by the discharge time (hours).</xs:documentation>
 										</xs:annotation>
 									</xs:element>
+									<xs:element minOccurs="0" name="NominalCapacitykWh" type="BatteryCapacity">
+										<xs:annotation>
+											<xs:documentation>[kWh] The total Kilowatt hours available when the battery is discharged starting from 100% state of charge until it reaches the cut-off voltage. Capacity is computed by multiplying the discharge power (kW) by the discharge time (hours).</xs:documentation>
+										</xs:annotation>
+									</xs:element>
 									<xs:element minOccurs="0" name="UsableCapacity" type="BatteryCapacity">
 										<xs:annotation>
 											<xs:documentation>[Ah] The stored energy that can actually be used. In most cases usable capacity is less than the nominal capacity.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="UsableCapacitykWh" type="BatteryCapacity">
+										<xs:annotation>
+											<xs:documentation>[kWh] The stored energy that can actually be used. In most cases usable capacity is less than the nominal capacity.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="RatedPowerOutput" type="Power">


### PR DESCRIPTION
Adds `NominalCapacitykWh` and `UsableCapacitykWh` elements so we can store capacities in terms of kWh instead of Ah.

Related to https://github.com/hpxmlwg/hpxml/issues/292.