### PR TITLE
Infiltration Height

### DIFF
--- a/schemas/BaseElements.xsd
+++ b/schemas/BaseElements.xsd
@@ -4735,6 +4735,11 @@
 						plus the volume of crawlspaces, attics, and/or basements that are connected to the building's conditioned space via open doors or hatches.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
+			<xs:element minOccurs="0" name="InfiltrationHeight" type="HPXMLDouble">
+				<xs:annotation>
+					<xs:documentation>[ft] Vertical distance between lowest and highest above-grade points within the pressure boundary, per ASHRAE 62.2.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>


### PR DESCRIPTION
Adds an `AirInfiltrationMeasurement/InfiltrationHeight` element, alongside the existing `InfiltrationVolume` element. It is defined as: "[ft] Vertical distance between lowest and highest above-grade points within the pressure boundary, per ASHRAE 62.2."