### PR TITLE
Relax requirement for `Building/Site/Address`

### DIFF
--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -5242,7 +5242,7 @@
 					<xs:sequence>
 						<xs:element name="SiteID" type="SystemIdentifiersInfoType"/>
 						<xs:element maxOccurs="unbounded" minOccurs="0" ref="ExternalResource"/>
-						<xs:element name="Address" type="AddressInformation"/>
+						<xs:element name="Address" type="AddressInformation" minOccurs="0"/>
 						<xs:element minOccurs="0" name="SchoolDistrict" type="HPXMLString"/>
 						<xs:element minOccurs="0" name="eGridRegion" type="eGridRegions"/>
 						<xs:element minOccurs="0" ref="extension"/>


### PR DESCRIPTION
If `Building/Site` is provided, the current schema requires the `Address` child element to exist. This proposal changes the `Address` element to be optional, which is generally the operating philosophy of HPXML. This change accommodates use cases where one wants to set other elements inside `Building/Site` (like the `eGridRegion`) but has no other information about the building's address.