### PR TITLE
Add HeatPump lockout temperature elements

### DIFF
--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -3400,9 +3400,9 @@
 							<xs:documentation>[deg F] Temperature at which the backup heating is activated.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="BackupHeatingLockout" type="HPXMLBoolean">
+					<xs:element minOccurs="0" name="BackupHeatingLockoutTemperature" type="Temperature">
 						<xs:annotation>
-							<xs:documentation>Does the heat pump have the ability to lock out the backup heating above a certain outdoor temperature to prevent, e.g., backup heating operation during recovery from a thermostat setback? Newer heat pump installations have "smart thermostats" connected to outdoor temperature sensors that allow this.</xs:documentation>
+							<xs:documentation>[deg F] Temperature at which the backup heating is disabled, often to prevent backup heating usage during recovery from a thermostat heating setback.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="FractionHeatLoadServed" type="Fraction" minOccurs="0"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -3402,7 +3402,7 @@
 					</xs:element>
 					<xs:element minOccurs="0" name="BackupHeatingLockout" type="HPXMLBoolean">
 						<xs:annotation>
-							<xs:documentation>Does the heat pump have the ability to lock out the backup heating above a certain outdoor temperature to prevent, e.g., backup heating operation during recovery from a thermostat setback? Newer heat pump installations have "smart thermostats" connected to outoor temperature sensors that allow this.</xs:documentation>
+							<xs:documentation>Does the heat pump have the ability to lock out the backup heating above a certain outdoor temperature to prevent, e.g., backup heating operation during recovery from a thermostat setback? Newer heat pump installations have "smart thermostats" connected to outdoor temperature sensors that allow this.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="FractionHeatLoadServed" type="Fraction" minOccurs="0"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -3400,6 +3400,11 @@
 							<xs:documentation>[deg F] Temperature at which the backup heating is activated.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
+					<xs:element minOccurs="0" name="BackupHeatingLockoutTemperature" type="Temperature">
+						<xs:annotation>
+							<xs:documentation>[deg F] Temperature at which the backup heating is disabled, often to prevent backup heating usage during recovery from a thermostat heating setback.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
 					<xs:element name="FractionHeatLoadServed" type="Fraction" minOccurs="0"/>
 					<xs:element name="FractionCoolLoadServed" type="Fraction" minOccurs="0"/>
 					<xs:element minOccurs="0" name="FloorAreaServed" type="SurfaceArea">

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -3370,6 +3370,11 @@
 						</xs:annotation>
 					</xs:element>
 					<xs:element minOccurs="0" name="CompressorType" type="CompressorType"/>
+					<xs:element minOccurs="0" name="CompressorLockoutTemperature" type="Temperature">
+						<xs:annotation>
+							<xs:documentation>[deg F] Temperature below which the compressor is disabled, often to prevent damage or occupant comfort issues. The default is the manufacturer's minimum operating temperature, but the value may be set higher. For a duel-fuel heat pump, use the BackupHeatingSwitchoverTemperature element.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
 					<xs:element minOccurs="0" name="CoolingSensibleHeatFraction" type="Fraction"/>
 					<xs:element name="GeothermalLoop" type="GeothermalLoop" minOccurs="0"/>
 					<xs:element minOccurs="0" name="BackupType" type="HeatPumpBackupType">
@@ -3397,12 +3402,12 @@
 					</xs:element>
 					<xs:element minOccurs="0" name="BackupHeatingSwitchoverTemperature" type="Temperature">
 						<xs:annotation>
-							<xs:documentation>[deg F] Temperature at which the backup heating is activated.</xs:documentation>
+							<xs:documentation>[deg F] Temperature at which the backup heating is activated and the compressor is disabled in, e.g., a dual-fuel heat pump.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element minOccurs="0" name="BackupHeatingLockoutTemperature" type="Temperature">
 						<xs:annotation>
-							<xs:documentation>[deg F] Temperature above which the backup heating is disabled, often to prevent backup heating usage during recovery from a thermostat heating setback.</xs:documentation>
+							<xs:documentation>[deg F] Temperature above which the backup heating is disabled, often to prevent backup heating usage during recovery from a thermostat heating setback. For a duel-fuel heat pump, use the BackupHeatingSwitchoverTemperature element.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="FractionHeatLoadServed" type="Fraction" minOccurs="0"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -3400,9 +3400,9 @@
 							<xs:documentation>[deg F] Temperature at which the backup heating is activated.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="BackupHeatingLockoutTemperature" type="Temperature">
+					<xs:element minOccurs="0" name="BackupHeatingLockout" type="HPXMLBoolean">
 						<xs:annotation>
-							<xs:documentation>[deg F] Temperature at which the backup heating is disabled, often to prevent backup heating usage during recovery from a thermostat heating setback.</xs:documentation>
+							<xs:documentation>Does the heat pump have the ability to lock out the backup heating above a certain outdoor temperature to prevent, e.g., backup heating operation during recovery from a thermostat setback? Newer heat pump installations have "smart thermostats" connected to outoor temperature sensors that allow this.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="FractionHeatLoadServed" type="Fraction" minOccurs="0"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -3402,7 +3402,7 @@
 					</xs:element>
 					<xs:element minOccurs="0" name="BackupHeatingLockoutTemperature" type="Temperature">
 						<xs:annotation>
-							<xs:documentation>[deg F] Temperature at which the backup heating is disabled, often to prevent backup heating usage during recovery from a thermostat heating setback.</xs:documentation>
+							<xs:documentation>[deg F] Temperature above which the backup heating is disabled, often to prevent backup heating usage during recovery from a thermostat heating setback.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="FractionHeatLoadServed" type="Fraction" minOccurs="0"/>


### PR DESCRIPTION
New elements for a HeatPump:
- `CompressorLockoutTemperature`: "[deg F] Temperature below which the compressor is disabled, often to prevent damage or occupant comfort issues. The default is the manufacturer's minimum operating temperature, but the value may be set higher. For a duel-fuel heat pump, use the BackupHeatingSwitchoverTemperature element."
- `BackupHeatingLockoutTemperature`: "[deg F] Temperature above which the backup heating is disabled, often to prevent backup heating usage during recovery from a thermostat heating setback. For a duel-fuel heat pump, use the BackupHeatingSwitchoverTemperature element."

Also adds documentation to the `BackupHeatingSwitchoverTemperature element`: "[deg F] Temperature at which the backup heating is activated _and the compressor is disabled in, e.g., a dual-fuel heat pump._"

(References for BackupHeatingLockoutTemperature: [1](https://www.energy.wsu.edu/documents/AHT_Electric%20Heat%20Lock%20Out%20on%20Heat%20Pumps%20(2).pdf), [2](https://www.howtolookatahouse.com/Blog/Entries/2020/11/what-is-an-electric-heat-lock-out-on-a-heat-pump.html))