### PR TITLE
Number of units

### DIFF
--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -3704,7 +3704,16 @@
 											<xs:documentation>[ft] height of building</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofUnits" type="IntegerGreaterThanZero"/>
+									<xs:element minOccurs="0" name="NumberofUnits" type="IntegerGreaterThanZero">
+										<xs:annotation>
+											<xs:documentation>Number of dwelling units represented by the HPXML Building element. Used as a multiplier.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="NumberofUnitsInBuilding" type="IntegerGreaterThanZero">
+										<xs:annotation>
+											<xs:documentation>Total number of dwelling units in the physical building.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
 									<xs:element minOccurs="0" name="NumberofFloors" type="NumberOfFloorsType">
 										<xs:annotation>
 											<xs:documentation>Total number of floors including a basement, whether conditioned or unconditioned</xs:documentation>


### PR DESCRIPTION
Closes #283.

- Adds `NumberofUnitsInBuilding`: "Total number of dwelling units in the physical building."
- Updates documentation for `NumberofUnits`: "Number of dwelling units represented by the HPXML Building element. Used as a multiplier."