### PR TITLE
Disallow zero for efficiencies

### DIFF
--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -2196,7 +2196,7 @@
 											<xs:documentation>[CFM]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Efficiency" type="HPXMLDouble">
+									<xs:element minOccurs="0" name="Efficiency" type="Efficiency">
 										<xs:annotation>
 											<xs:documentation>[CFM/watt] The efficiency rating of a ceiling fan as determined by the test procedure defined by the Environmental Protection Agency's
 												ENERGY STAR Testing Facility Guidance Manual: Building a Testing Facility and Performing the Solid State Test Method for ENERGY STAR Qualified Ceiling

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1850,7 +1850,7 @@
 	</xs:complexType>
 	<xs:simpleType name="Efficiency_simple">
 		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
+			<xs:minExclusive value="0"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="Efficiency">


### PR DESCRIPTION
Changes the `Efficiency` datatype from `minInclusive=0` to `minExclusive=0`, which will help prevent inappropriate values (whether a bad user input or a software bug). It's hard to imagine how anything could have an efficiency of zero, as that would apply it consumes energy but produces nothing of value.

Also changes `CeilingFan/Efficiency` from an `HPXMLDouble` datatype to the `Efficiency` datatype.

Is this considered a breaking change?