### PR TITLE
Adds SEER2, EER2, and HSPF2

### DIFF
--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1806,8 +1806,10 @@
 	<xs:simpleType name="CoolingEfficiencyUnits_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="SEER"/>
+			<xs:enumeration value="SEER2"/>
 			<xs:enumeration value="CEER"/>
 			<xs:enumeration value="EER"/>
+			<xs:enumeration value="EER2"/>
 			<xs:enumeration value="COP"/>
 			<xs:enumeration value="kW/ton"/>
 		</xs:restriction>
@@ -1822,6 +1824,7 @@
 	<xs:simpleType name="HeatingEfficiencyUnits_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="HSPF"/>
+			<xs:enumeration value="HSPF2"/>
 			<xs:enumeration value="COP"/>
 			<xs:enumeration value="AFUE"/>
 			<xs:enumeration value="Percent"/>


### PR DESCRIPTION
Adds "SEER2" and "EER2" to `CoolingEfficiencyUnits` and "HSPF2" to `HeatingEfficiencyUnits`. Effective Jan 1, 2023. Closes #325.