### PR TITLE
Allow additional floor types

### DIFF
--- a/examples/audit.xml
+++ b/examples/audit.xml
@@ -98,7 +98,7 @@
               </Attic>
             </AtticType>
             <AttachedToRoof idref="roof1"/>
-            <AttachedToFrameFloor idref="attic-floor-0"/>
+            <AttachedToFloor idref="attic-floor-0"/>
           </Attic>
         </Attics>
         <Foundations>
@@ -110,7 +110,7 @@
                 <Conditioned>true</Conditioned>
               </Basement>
             </FoundationType>
-            <AttachedToFrameFloor idref="fnd1flr1"/>
+            <AttachedToFloor idref="fnd1flr1"/>
           </Foundation>
         </Foundations>
         <Roofs>
@@ -136,8 +136,8 @@
             </Insulation>
           </Wall>
         </Walls>
-        <FrameFloors>
-          <FrameFloor>
+        <Floors>
+          <Floor>
             <SystemIdentifier id="attic-floor-0"/>
             <Insulation>
               <SystemIdentifier id="attic1ins"/>
@@ -145,8 +145,8 @@
                 <NominalRValue>19</NominalRValue>
               </Layer>
             </Insulation>
-          </FrameFloor>
-          <FrameFloor>
+          </Floor>
+          <Floor>
             <SystemIdentifier id="fnd1flr1"/>
             <Insulation>
               <SystemIdentifier id="fnd1flr1ins"/>
@@ -154,8 +154,8 @@
                 <NominalRValue>0</NominalRValue>
               </Layer>
             </Insulation>
-          </FrameFloor>
-        </FrameFloors>
+          </Floor>
+        </Floors>
         <Doors>
           <Door>
             <SystemIdentifier id="frontdoor1"/>
@@ -354,7 +354,7 @@
               </Attic>
             </AtticType>
             <AttachedToRoof idref="roof1p"/>
-            <AttachedToFrameFloor idref="attic-floor-1"/>
+            <AttachedToFloor idref="attic-floor-1"/>
           </Attic>
         </Attics>
         <Foundations>
@@ -366,7 +366,7 @@
                 <Conditioned>true</Conditioned>
               </Basement>
             </FoundationType>
-            <AttachedToFrameFloor idref="fnd1flr1p"/>
+            <AttachedToFloor idref="fnd1flr1p"/>
           </Foundation>
         </Foundations>
         <Roofs>
@@ -392,8 +392,8 @@
             </Insulation>
           </Wall>
         </Walls>
-        <FrameFloors>
-          <FrameFloor>
+        <Floors>
+          <Floor>
             <SystemIdentifier id="attic-floor-1"/>
             <Insulation>
               <SystemIdentifier id="attic1insp"/>
@@ -401,8 +401,8 @@
                 <NominalRValue>49</NominalRValue>
               </Layer>
             </Insulation>
-          </FrameFloor>
-          <FrameFloor>
+          </Floor>
+          <Floor>
             <SystemIdentifier id="fnd1flr1p" sameas="fnd1flr1"/>
             <Insulation>
               <SystemIdentifier id="fnd1flr1insp" sameas="fnd1flr1ins"/>
@@ -410,8 +410,8 @@
                 <NominalRValue>0</NominalRValue>
               </Layer>
             </Insulation>
-          </FrameFloor>
-        </FrameFloors>
+          </Floor>
+        </Floors>
         <Doors>
           <Door>
             <SystemIdentifier id="frontdoor1p" sameas="frontdoor1"/>

--- a/examples/bpi2101.xml
+++ b/examples/bpi2101.xml
@@ -54,7 +54,7 @@
               </Attic>
             </AtticType>
             <AttachedToRoof idref="roof1"/>
-            <AttachedToFrameFloor idref="attic-floor-0"/>
+            <AttachedToFloor idref="attic-floor-0"/>
           </Attic>
         </Attics>
         <Roofs>
@@ -87,8 +87,8 @@
             </Insulation>
           </Wall>
         </Walls>
-        <FrameFloors>
-          <FrameFloor>
+        <Floors>
+          <Floor>
             <SystemIdentifier id="attic-floor-0"/>
             <Insulation>
               <SystemIdentifier id="attic1flrins"/>
@@ -99,8 +99,8 @@
                 <NominalRValue>19</NominalRValue>
               </Layer>
             </Insulation>
-          </FrameFloor>
-        </FrameFloors>
+          </Floor>
+        </Floors>
         <Windows>
           <Window>
             <SystemIdentifier id="windows"/>
@@ -243,7 +243,7 @@
               </Attic>
             </AtticType>
             <AttachedToRoof idref="roof1proposed"/>
-            <AttachedToFrameFloor idref="attic-floor-1"/>
+            <AttachedToFloor idref="attic-floor-1"/>
           </Attic>
         </Attics>
         <Roofs>
@@ -276,8 +276,8 @@
             </Insulation>
           </Wall>
         </Walls>
-        <FrameFloors>
-          <FrameFloor>
+        <Floors>
+          <Floor>
             <SystemIdentifier id="attic-floor-1"/>
             <Insulation>
               <SystemIdentifier id="attic1flrinsproposed"/>
@@ -288,8 +288,8 @@
                 <NominalRValue>50</NominalRValue>
               </Layer>
             </Insulation>
-          </FrameFloor>
-        </FrameFloors>
+          </Floor>
+        </Floors>
         <Windows>
           <Window>
             <SystemIdentifier id="windowsproposed" sameas="windows"/>
@@ -441,7 +441,7 @@
               </Attic>
             </AtticType>
             <AttachedToRoof idref="roof1completion"/>
-            <AttachedToFrameFloor idref="attic-floor-2"/>
+            <AttachedToFloor idref="attic-floor-2"/>
           </Attic>
         </Attics>
         <Roofs>
@@ -474,8 +474,8 @@
             </Insulation>
           </Wall>
         </Walls>
-        <FrameFloors>
-          <FrameFloor>
+        <Floors>
+          <Floor>
             <SystemIdentifier id="attic-floor-2"/>
             <Insulation>
               <SystemIdentifier id="attic1flrinscompletion"/>
@@ -486,8 +486,8 @@
                 <NominalRValue>49</NominalRValue>
               </Layer>
             </Insulation>
-          </FrameFloor>
-        </FrameFloors>
+          </Floor>
+        </Floors>
         <Windows>
           <Window>
             <SystemIdentifier id="windowscompletion" sameas="windows"/>

--- a/examples/upgrade.xml
+++ b/examples/upgrade.xml
@@ -94,7 +94,7 @@
               </Attic>
             </AtticType>
             <AttachedToRoof idref="roof1"/>
-            <AttachedToFrameFloor idref="attic-floor-0"/>
+            <AttachedToFloor idref="attic-floor-0"/>
           </Attic>
         </Attics>
         <Foundations>
@@ -105,7 +105,7 @@
                 <Conditioned>false</Conditioned>
               </Basement>
             </FoundationType>
-            <AttachedToFrameFloor idref="fnd1flr1"/>
+            <AttachedToFloor idref="fnd1flr1"/>
           </Foundation>
         </Foundations>
         <Roofs>
@@ -131,8 +131,8 @@
             </Insulation>
           </Wall>
         </Walls>
-        <FrameFloors>
-          <FrameFloor>
+        <Floors>
+          <Floor>
             <SystemIdentifier id="attic-floor-0"/>
             <Insulation>
               <SystemIdentifier id="insul1"/>
@@ -140,8 +140,8 @@
                 <NominalRValue>13.0</NominalRValue>
               </Layer>
             </Insulation>
-          </FrameFloor>
-          <FrameFloor>
+          </Floor>
+          <Floor>
             <SystemIdentifier id="fnd1flr1"/>
             <Insulation>
               <SystemIdentifier id="fnd1flr1ins1"/>
@@ -154,8 +154,8 @@
                 <Thickness>2.0</Thickness>
               </Layer>
             </Insulation>
-          </FrameFloor>
-        </FrameFloors>
+          </Floor>
+        </Floors>
         <Windows>
           <Window>
             <SystemIdentifier id="window1"/>
@@ -334,7 +334,7 @@
               </Attic>
             </AtticType>
             <AttachedToRoof idref="roof1c"/>
-            <AttachedToFrameFloor idref="attic-floor-1"/>
+            <AttachedToFloor idref="attic-floor-1"/>
           </Attic>
         </Attics>
         <Foundations>
@@ -345,7 +345,7 @@
                 <Conditioned>false</Conditioned>
               </Basement>
             </FoundationType>
-            <AttachedToFrameFloor idref="fnd1cflr1c"/>
+            <AttachedToFloor idref="fnd1cflr1c"/>
           </Foundation>
         </Foundations>
         <Roofs>
@@ -381,8 +381,8 @@
             </Insulation>
           </Wall>
         </Walls>
-        <FrameFloors>
-          <FrameFloor>
+        <Floors>
+          <Floor>
             <SystemIdentifier id="attic-floor-1"/>
             <Insulation>
               <SystemIdentifier id="insul1c" sameas="insul1"/>
@@ -395,8 +395,8 @@
                 <Thickness>1.0</Thickness>
               </Layer>
             </Insulation>
-          </FrameFloor>
-          <FrameFloor>
+          </Floor>
+          <Floor>
             <SystemIdentifier id="fnd1cflr1c" sameas="fnd1flr1"/>
             <Insulation>
               <SystemIdentifier id="fnd1cflr1cins1c" sameas="fnd1flr1ins1"/>
@@ -409,8 +409,8 @@
                 <Thickness>2.0</Thickness>
               </Layer>
             </Insulation>
-          </FrameFloor>
-        </FrameFloors>
+          </Floor>
+        </Floors>
         <Windows>
           <Window>
             <SystemIdentifier id="window1c"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-	xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.1">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.1">
 	<xs:include schemaLocation="HPXMLDataTypes.xsd"/>
 	<xs:element name="XMLTransactionHeaderInformation">
 		<xs:annotation>
@@ -727,7 +726,7 @@
 									</xs:element>
 									<xs:element minOccurs="0" name="AttachedToRoof" type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFrameFloor" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFloor" type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
@@ -767,7 +766,7 @@
 									<xs:element minOccurs="0" name="AttachedToRimJoist" type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element minOccurs="0" name="AttachedToFoundationWall" type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFrameFloor" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFloor" type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element minOccurs="0" name="AttachedToSlab" type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
@@ -815,7 +814,7 @@
 									<xs:element minOccurs="0" name="AttachedToRoof" type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element minOccurs="0" name="AttachedToFoundationWall" type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFrameFloor" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFloor" type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element minOccurs="0" name="AttachedToSlab" type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
@@ -1052,12 +1051,12 @@
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="FrameFloors">
+			<xs:element minOccurs="0" name="Floors">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="FrameFloor" maxOccurs="unbounded" minOccurs="1">
+						<xs:element name="Floor" maxOccurs="unbounded" minOccurs="1">
 							<xs:annotation>
-								<xs:documentation>Use the FrameFloor element for all floors/ceilings. For example, living space ceilings/attic floors, floors above foundations, floors under bonus
+								<xs:documentation>Use the Floor element for all floors/ceilings. For example, living space ceilings/attic floors, floors above foundations, floors under bonus
 									rooms, cantilevered floors, etc.</xs:documentation>
 							</xs:annotation>
 							<xs:complexType>
@@ -5086,6 +5085,54 @@
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Adobe">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+					<xs:attribute name="dataSource" type="DataSource"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Other">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+					<xs:attribute name="dataSource" type="DataSource"/>
+				</xs:complexType>
+			</xs:element>
+		</xs:choice>
+		<xs:attribute name="dataSource" type="DataSource"/>
+	</xs:complexType>
+	<xs:complexType name="FloorType">
+		<xs:choice>
+			<xs:element name="WoodFrame">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+					<xs:attribute name="dataSource" type="DataSource"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="StructurallyInsulatedPanel">
+				<xs:annotation>
+					<xs:documentation>Structurally Insulated Panel</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+					<xs:attribute name="dataSource" type="DataSource"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="SteelFrame">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" ref="extension"/>
+					</xs:sequence>
+					<xs:attribute name="dataSource" type="DataSource"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="SolidConcrete">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -1065,6 +1065,7 @@
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
 									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo" minOccurs="0"/>
 									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="FloorType" type="FloorType"/>
 									<xs:element minOccurs="0" name="FloorJoists" type="StudProperties"/>
 									<xs:element minOccurs="0" name="FloorTrusses" type="StudProperties"/>
 									<xs:element minOccurs="0" name="FloorCovering" type="FloorCovering"/>
@@ -5004,9 +5005,6 @@
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="ConcreteMasonryUnit">
-				<xs:annotation>
-					<xs:documentation>Concrete Masonry Unit</xs:documentation>
-				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
@@ -5014,10 +5012,7 @@
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="StructurallyInsulatedPanel">
-				<xs:annotation>
-					<xs:documentation>Structurally Insulated Panel</xs:documentation>
-				</xs:annotation>
+			<xs:element name="StructuralInsulatedPanel">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
@@ -5026,9 +5021,6 @@
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="InsulatedConcreteForms">
-				<xs:annotation>
-					<xs:documentation>Insulated Concrete Forms</xs:documentation>
-				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>
@@ -5113,10 +5105,7 @@
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="StructurallyInsulatedPanel">
-				<xs:annotation>
-					<xs:documentation>Structurally Insulated Panel</xs:documentation>
-				</xs:annotation>
+			<xs:element name="StructuralInsulatedPanel">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element minOccurs="0" ref="extension"/>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-	xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.1">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.1">
 	<xs:simpleType name="DataSource">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="user"/>
@@ -3341,7 +3340,7 @@
 	</xs:complexType>
 	<xs:simpleType name="FoundationThermalBoundary_simple">
 		<xs:restriction base="xs:string">
-			<xs:enumeration value="frame floor"/>
+			<xs:enumeration value="floor"/>
 			<xs:enumeration value="foundation wall"/>
 		</xs:restriction>
 	</xs:simpleType>


### PR DESCRIPTION
Fixes #321 

Renames `FrameFloors/FrameFloor` to `Floors/Floor`.
Renames `WallType/StructurallyInsulatedPanel` to `WallType/StructuralInsulatedPanel`
Adds `FloorType` with choices of:
- `WoodFrame`
- `StructuralInsulatedPanel`
- `SteelFrame`
- `SolidConcrete`
- `Other`