### PR TITLE
Support commercial water heaters

### DIFF
--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -1543,7 +1543,7 @@
 												430, Subpart B, Appendix E.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HeatingCOP" type="Efficiency">
+									<xs:element minOccurs="0" name="HeatPumpCOP" type="Efficiency">
 										<xs:annotation>
 											<xs:documentation>The dimensionless coefficient of performance, used to measure the efficiency of a commercial heat pump water heater.</xs:documentation>
 										</xs:annotation>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -3502,7 +3502,7 @@
 		<xs:sequence>
 			<xs:element name="Units" type="StandbyLossUnits">
 				<xs:annotation>
-					<xs:documentation>For %/hr enter values as a percent, i.e. 1.20%/hr = 1.20 and 0.68%/hr = 0.68.</xs:documentation>
+					<xs:documentation>For %/hr enter values as a fraction, i.e. 1.20%/hr = 0.0120 and 0.68%/hr = 0.0068.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Value" type="Efficiency"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -1543,6 +1543,11 @@
 												430, Subpart B, Appendix E.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
+									<xs:element minOccurs="0" name="HeatingCOP" type="Efficiency">
+										<xs:annotation>
+											<xs:documentation>The dimensionless coefficient of performance, used to measure the efficiency of a commercial heat pump water heater.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
 									<xs:element minOccurs="0" name="FirstHourRating" type="Volume">
 										<xs:annotation>
 											<xs:documentation>[gal per hour] An estimate of the maximum volume of hot water in gallons that a storage water heater can supply within an hour that begins

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -3505,7 +3505,7 @@
 					<xs:documentation>For %/hr enter values as a fraction, i.e. 1.20%/hr = 0.0120 and 0.68%/hr = 0.0068.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Value" type="Efficiency"/>
+			<xs:element name="Value" type="HPXMLDouble"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-	xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.1">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.1">
 	<xs:include schemaLocation="HPXMLDataTypes.xsd"/>
 	<xs:element name="XMLTransactionHeaderInformation">
 		<xs:annotation>
@@ -1609,9 +1608,9 @@
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="StandbyLoss" type="HPXMLDouble">
+									<xs:element minOccurs="0" name="StandbyLoss" type="StandbyLossType">
 										<xs:annotation>
-											<xs:documentation>[degF/hr] The standby heat loss rate for, e.g., indirect water heaters in degrees per hour. Published in the AHRI Consumer’s Directory of Certified Efficiency Ratings.</xs:documentation>
+											<xs:documentation>The standby heat loss rate for, e.g., indirect or commercial water heaters. Published in the AHRI Consumer’s Directory of Certified Efficiency Ratings.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element name="MeetsACCA5QIHVACSpecification" type="HPXMLBoolean" minOccurs="0"/>
@@ -3488,6 +3487,17 @@
 			<xs:element name="Units" type="HeatingEfficiencyUnits">
 				<xs:annotation>
 					<xs:documentation>For AFUE and Percent enter values as a fractional number between 0 and 1, i.e. 80% = 0.8</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Value" type="Efficiency"/>
+		</xs:sequence>
+		<xs:attribute name="dataSource" type="DataSource"/>
+	</xs:complexType>
+	<xs:complexType name="StandbyLossType">
+		<xs:sequence>
+			<xs:element name="Units" type="StandbyLossUnits">
+				<xs:annotation>
+					<xs:documentation>For %/hr enter values as a percent, i.e. 1.20%/hr = 1.20 and 0.68%/hr = 0.68.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Value" type="Efficiency"/>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-	xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.1">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.1">
 	<xs:simpleType name="DataSource">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="user"/>
@@ -1836,6 +1835,20 @@
 	<xs:complexType name="HeatingEfficiencyUnits">
 		<xs:simpleContent>
 			<xs:extension base="HeatingEfficiencyUnits_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="StandbyLossUnits_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="F/hr"/>
+			<xs:enumeration value="%/hr"/>
+			<xs:enumeration value="Btu/hr"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="StandbyLossUnits">
+		<xs:simpleContent>
+			<xs:extension base="StandbyLossUnits_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>


### PR DESCRIPTION
Closes #333. 

**Conventional storage and instantaneous commercial water heaters**

- Replaces `StandbyLoss` with `StandbyLoss[Units]/Value` to support different units (F/hr, %/hr, or Btu/hr). This is a breaking change.
- Already has a `ThermalEfficiency` element.

**Heat pump commercial water heaters**

- Adds a `HeatPumpCOP` element.