### PR TITLE
Remove "Loop" from `Recirculation/BranchPipingLoopLength` name

### DIFF
--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -1705,7 +1705,7 @@
 																		longitudinally from plans, assuming the hot water piping does not run diagonally. [ft]</xs:documentation>
 																</xs:annotation>
 															</xs:element>
-															<xs:element minOccurs="0" name="BranchPipingLoopLength" type="LengthMeasurement">
+															<xs:element minOccurs="0" name="BranchPipingLength" type="LengthMeasurement">
 																<xs:annotation>
 																	<xs:documentation>Length of the branch hot water piping from the recirculation loop to the farthest hot water fixture from the
 																		recirculation loop, measured longitudinally from plans, assuming the branch hot water piping does not run diagonally, plus 20


### PR DESCRIPTION
Closes #340.