### PR TITLE
Adds a `SystemIdentifier` element for Ducts

### DIFF
--- a/examples/audit.xml
+++ b/examples/audit.xml
@@ -222,6 +222,7 @@
                   </DuctLeakage>
                 </DuctLeakageMeasurement>
                 <Ducts>
+                  <SystemIdentifier id="duct1"/>
                   <DuctMaterial>sheet metal</DuctMaterial>
                   <DuctInsulationRValue>4</DuctInsulationRValue>
                   <DuctLocation>living space</DuctLocation>
@@ -478,6 +479,7 @@
                   </DuctLeakage>
                 </DuctLeakageMeasurement>
                 <Ducts>
+                  <SystemIdentifier id="duct1p" sameas="duct1"/>
                   <DuctMaterial>sheet metal</DuctMaterial>
                   <DuctInsulationRValue>4</DuctInsulationRValue>
                   <DuctLocation>living space</DuctLocation>

--- a/examples/bpi2101.xml
+++ b/examples/bpi2101.xml
@@ -166,6 +166,7 @@
                   </DuctLeakage>
                 </DuctLeakageMeasurement>
                 <Ducts>
+                  <SystemIdentifier id="hvacduct1"/>
                   <DuctInsulationRValue>0</DuctInsulationRValue>
                 </Ducts>
               </AirDistribution>
@@ -355,6 +356,7 @@
                   </DuctLeakage>
                 </DuctLeakageMeasurement>
                 <Ducts>
+                  <SystemIdentifier id="hvacduct1proposed" sameas="hvacduct1"/>
                   <DuctInsulationRValue>0</DuctInsulationRValue>
                 </Ducts>
               </AirDistribution>
@@ -553,6 +555,7 @@
                   </DuctLeakage>
                 </DuctLeakageMeasurement>
                 <Ducts>
+                  <SystemIdentifier id="hvacduct1completion" sameas="hvacduct1"/>
                   <DuctInsulationRValue>0</DuctInsulationRValue>
                 </Ducts>
               </AirDistribution>

--- a/examples/upgrade.xml
+++ b/examples/upgrade.xml
@@ -222,6 +222,7 @@
                   </DuctLeakage>
                 </DuctLeakageMeasurement>
                 <Ducts>
+                  <SystemIdentifier id="duct1"/>
                   <DuctMaterial>duct board</DuctMaterial>
                   <DuctInsulationRValue>2</DuctInsulationRValue>
                   <DuctLocation>living space</DuctLocation>
@@ -480,6 +481,7 @@
                   </DuctLeakage>
                 </DuctLeakageMeasurement>
                 <Ducts>
+                  <SystemIdentifier id="duct1c" sameas="duct1"/>
                   <DuctMaterial>duct board</DuctMaterial>
                   <DuctInsulationRValue>2</DuctInsulationRValue>
                   <DuctLocation>living space</DuctLocation>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -3648,6 +3648,7 @@
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="Ducts">
 				<xs:complexType>
 					<xs:sequence>
+						<xs:group ref="SystemInfo"/>
 						<xs:element name="DuctType" type="DuctType" minOccurs="0"/>
 						<xs:element name="DuctMaterial" type="DuctMaterial" minOccurs="0"/>
 						<xs:element minOccurs="0" name="DuctInsulationMaterial" type="InsulationMaterial"/>


### PR DESCRIPTION
Facilitates referring to specific ducts for, e.g., upgrade measures.