### PR TITLE
Adds `FrameFloor/FloorOrCeiling` element

### DIFF
--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -1152,6 +1152,11 @@
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
 									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo" minOccurs="0"/>
 									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="FloorOrCeiling" type="FloorOrCeiling">
+										<xs:annotation>
+											<xs:documentation>From the perspective of the living/conditioned space.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
 									<xs:element minOccurs="0" name="FloorJoists" type="StudProperties"/>
 									<xs:element minOccurs="0" name="FloorTrusses" type="StudProperties"/>
 									<xs:element minOccurs="0" name="FloorCovering" type="FloorCovering"/>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -4824,4 +4824,17 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+	<xs:simpleType name="FloorOrCeiling_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="floor"/>
+			<xs:enumeration value="ceiling"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="FloorOrCeiling">
+		<xs:simpleContent>
+			<xs:extension base="FloorOrCeiling_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 </xs:schema>


### PR DESCRIPTION
Closes #253. Adds `Floor/FloorOrCeiling`: string (choices: "floor", "ceiling"). From the perspective of the living/conditioned space. Often it can be inferred from other information in the HPXML, but not always. This is particularly useful because a lot of standards (like IECC, ANSI 301, etc.) refer to ceilings and floors.

(I'm not calling it `FloorType` because that is being used [here](https://github.com/hpxmlwg/hpxml/pull/332) to support wood frame floors vs mass floors vs ...).

This is a far simpler implementation than [adding an `Enclosure/Ceilings` element](https://github.com/hpxmlwg/hpxml/pull/264), which would require a lot of software updates. 

Should we also deprecate (or mark as deprecated) the "other housing unit above" and "other housing unit below" AdjacentTo enumerations? This is a more flexible implementation and can be used for adjacent locations other than just "other housing unit".