### PR TITLE
Standalone `Inverter`

### DIFF
--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -1990,14 +1990,12 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="NumberOfPanels" type="IntegerGreaterThanZero"/>
-									<xs:element minOccurs="0" name="InverterEfficiency" type="Fraction"/>
 									<xs:element minOccurs="0" name="SystemLossesFraction" type="Fraction">
 										<xs:annotation>
 											<xs:documentation>System losses can be due to soiling, shading, snow, mismatch, wiring, electrical connections, light-induced degradation, nameplate rating
 												inaccuracies, age, and availability.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="YearInverterManufactured" type="Year"/>
 									<xs:element minOccurs="0" name="YearModulesManufactured" type="Year"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
 									<xs:element minOccurs="0" name="AnnualOutput" type="RatedAnnualkWh">
@@ -2012,9 +2010,21 @@
 												http://www.nrel.gov/analysis/tech_lcoe.html.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
+									<xs:element minOccurs="0" name="AttachedToInverter" type="LocalReference"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
+							</xs:complexType>
+						</xs:element>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="Inverter">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:group ref="SystemInfo"/>
+									<xs:element minOccurs="0" name="InverterEfficiency" type="Fraction"/>
+									<xs:element minOccurs="0" name="YearInverterManufactured" type="Year"/>
+									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
+									<xs:element ref="extension" minOccurs="0"/>
+								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -2020,6 +2020,7 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
+									<xs:element minOccurs="0" name="InverterType" type="InverterType"/>
 									<xs:element minOccurs="0" name="InverterEfficiency" type="Fraction"/>
 									<xs:element minOccurs="0" name="YearInverterManufactured" type="Year"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -4824,4 +4824,20 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+	<xs:simpleType name="InverterType_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="central inverter"/>
+			<xs:enumeration value="string inverter"/>
+			<xs:enumeration value="multi-string inverter"/>
+			<xs:enumeration value="micro inverter"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="InverterType">
+		<xs:simpleContent>
+			<xs:extension base="InverterType_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 </xs:schema>


### PR DESCRIPTION
Closes #294. Moves inverter field into a new `Inverter` element, on the same level as the `PVSystem` element. One or more `PVSystem`s can optionally reference an inverter via a new `AttachedToInverter` element.

Also adds a new `InverterType` element (based on https://powmr.com/blog/types-of-pv-inverters/) with choices of:
- central inverter
- string inverter
- multi-string inverter
- micro inverter
- other

![image](https://user-images.githubusercontent.com/5861765/194920034-9ce70513-7fbf-4975-a119-9cd1e8151f0f.png)
