### PR TITLE
Subfloor Type

### DIFF
--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -1155,6 +1155,7 @@
 									<xs:element minOccurs="0" name="FloorType" type="FloorType"/>
 									<xs:element minOccurs="0" name="FloorJoists" type="StudProperties"/>
 									<xs:element minOccurs="0" name="FloorTrusses" type="StudProperties"/>
+									<xs:element minOccurs="0" name="SubfloorType" type="SubfloorType"/>
 									<xs:element minOccurs="0" name="FloorCovering" type="FloorCovering"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -4781,4 +4781,22 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+	<xs:simpleType name="SubfloorType_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="none"/>
+			<xs:enumeration value="plywood"/>
+			<xs:enumeration value="osb"/>
+			<xs:enumeration value="wood"/>
+			<xs:enumeration value="concrete"/>
+			<xs:enumeration value="gypcrete"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="SubfloorType">
+		<xs:simpleContent>
+			<xs:extension base="SubfloorType_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 </xs:schema>


### PR DESCRIPTION
Closes #353. Adds a `Floor/SubfloorType` element with choices of:
- none
- plywood
- osb
- wood
- concrete
- gypcrete
- other