### PR TITLE
Additional HPWH inputs

### DIFF
--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -1639,7 +1639,12 @@
 									<xs:element minOccurs="0" name="FractionDHWLoadServed" type="Fraction"/>
 									<xs:element name="HeatingCapacity" type="Capacity" minOccurs="0">
 										<xs:annotation>
-											<xs:documentation>[Btuh]</xs:documentation>
+											<xs:documentation>[Btuh] For a heat pump water heater, the capacity of the heat pump.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="BackupHeatingCapacity" type="Capacity" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>[Btuh] The capacity of the electric resistance heating in a heat pump water heater.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element name="EnergyFactor" type="EnergyFactor" minOccurs="0">

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -1665,6 +1665,7 @@
 											<xs:documentation>The dimensionless coefficient of performance, used to measure the efficiency of a commercial heat pump water heater.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
+									<xs:element minOccurs="0" name="HPWHOperatingMode" type="HPWHOperatingMode"/>
 									<xs:element minOccurs="0" name="FirstHourRating" type="Volume">
 										<xs:annotation>
 											<xs:documentation>[gal per hour] An estimate of the maximum volume of hot water in gallons that a storage water heater can supply within an hour that begins

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -2968,12 +2968,14 @@
 		</xs:simpleContent>
 	</xs:complexType>
 	<xs:simpleType name="WaterHeaterType_simple">
+		<xs:annotation>
+			<xs:documentation>The generic "heat pump water heater" enumeration is assumed to refer to an integrated (not split) heat pump water heater.</xs:documentation>
+		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="storage water heater"/>
 			<xs:enumeration value="dedicated boiler with storage tank"/>
 			<xs:enumeration value="instantaneous water heater"/>
 			<xs:enumeration value="heat pump water heater"/>
-			<xs:enumeration value="integrated heat pump water heater"/>
 			<xs:enumeration value="split heat pump water heater"/>
 			<xs:enumeration value="space-heating boiler with storage tank"/>
 			<xs:enumeration value="space-heating boiler with tankless coil"/>
@@ -4804,7 +4806,7 @@
 			<xs:pattern value="hybrid/auto"/>
 			<xs:pattern value="heat pump only"/>
 			<xs:pattern value="electric heater only"/>
-			<xs:pattern value="high demand"/>
+			<xs:pattern value="high demand/recovery"/>
 			<xs:pattern value="other"/>
 		</xs:restriction>
 	</xs:simpleType>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -4801,7 +4801,7 @@
 		<xs:restriction base="xs:string">
 			<xs:pattern value="hybrid/auto"/>
 			<xs:pattern value="heat pump only"/>
-			<xs:pattern value="electric only"/>
+			<xs:pattern value="electric heater only"/>
 			<xs:pattern value="high demand"/>
 			<xs:pattern value="other"/>
 		</xs:restriction>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -2973,6 +2973,8 @@
 			<xs:enumeration value="dedicated boiler with storage tank"/>
 			<xs:enumeration value="instantaneous water heater"/>
 			<xs:enumeration value="heat pump water heater"/>
+			<xs:enumeration value="integrated heat pump water heater"/>
+			<xs:enumeration value="split heat pump water heater"/>
 			<xs:enumeration value="space-heating boiler with storage tank"/>
 			<xs:enumeration value="space-heating boiler with tankless coil"/>
 		</xs:restriction>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -4797,4 +4797,20 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+	<xs:simpleType name="HPWHOperatingModeType_simple">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="hybrid/auto"/>
+			<xs:pattern value="heat pump only"/>
+			<xs:pattern value="electric only"/>
+			<xs:pattern value="high demand"/>
+			<xs:pattern value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="HPWHOperatingMode">
+		<xs:simpleContent>
+			<xs:extension base="HPWHOperatingModeType_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 </xs:schema>


### PR DESCRIPTION
### 1. Type

Adds "split heat pump water heater" choice to `WaterHeaterType`. Adds documentation to `WaterHeaterType`: The generic "heat pump water heater" enumeration is assumed to refer to an integrated (not split) heat pump water heater.

### 2. Operating Mode

New `HPWHOperatingMode` element with choices of:
  - hybrid/auto
  - heat pump only
  - electric heater only
  - high demand/recovery
  - other

Closes #313.

### 3. Capacities

Allows/documents how to separately describe the heat pump capacity and the electric resistance capacity for a heat pump water heater.

- Existing `HeatingCapacity` element: [Btuh] For a heat pump water heater, the capacity of the heat pump.
- New `BackupHeatingCapacity` element: [Btuh] The capacity of the electric resistance heating in a heat pump water heater.
