### PR TITLE
`Skylight/AttachedToFloor` element

### DIFF
--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -1280,6 +1280,7 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="AttachedToRoof" type="LocalReference"/>
+									<xs:element minOccurs="0" name="AttachedToFloor" type="LocalReference"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>


### PR DESCRIPTION
There is an existing `Skylight/AttachedToRoof` element. This adds a `Skylight/AttachedToFloor` element to describe, e.g., skylights that include shafts or sun tunnels, which penetrate not just the roof but also the ceiling below the attic.

Closes #286.