### PR TITLE
Add `LightingGroup/Load` element

### DIFF
--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -2334,6 +2334,15 @@
 								<xs:documentation>[sq.ft.]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
+						<xs:element minOccurs="0" name="Load">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="Units" type="PlugLoadUnits"/>
+									<xs:element name="Value" type="HPXMLDouble"/>
+								</xs:sequence>
+								<xs:attribute name="dataSource" type="DataSource"/>
+							</xs:complexType>
+						</xs:element>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -2308,6 +2308,15 @@
 								<xs:documentation>[sq.ft.]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
+						<xs:element minOccurs="0" name="Load">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="Units" type="PlugLoadUnits"/>
+									<xs:element name="Value" type="HPXMLDouble"/>
+								</xs:sequence>
+								<xs:attribute name="dataSource" type="DataSource"/>
+							</xs:complexType>
+						</xs:element>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>


### PR DESCRIPTION
Adds a `LightingGroup/Load` element, similar to the `PlugLoad/Load` element. Allows specifying the lighting usage in kWh/yr or W. (There is an existing `LightingGroup/AverageWattage` element, but it's W **per unit** and thus requires the number of units, which may not be known/collected, to obtain the total wattage.)

E.g.:

```xml
<LightingGroup>
    <SystemIdentifier id='LightingGroup'/>
    <Location>interior</Location>
    <Load>
        <Units>kWh/year</Units>
        <Value>620</Value>
    </Load>
</LightingGroup>
```