### PR TITLE
Add `Appliance/Load` and similar elements

### DIFF
--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -396,6 +396,15 @@
 					<xs:element maxOccurs="unbounded" minOccurs="0" name="ControlType" type="ClothesDryerControlType"/>
 					<xs:element minOccurs="0" name="Vented" type="HPXMLBoolean"/>
 					<xs:element minOccurs="0" name="VentedFlowRate" type="FlowRate"/>
+					<xs:element minOccurs="0" name="Load" maxOccurs="2">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="Units" type="ElectricOrFuelLoadUnits"/>
+								<xs:element name="Value" type="HPXMLDouble"/>
+							</xs:sequence>
+							<xs:attribute name="dataSource" type="DataSource"/>
+						</xs:complexType>
+					</xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -468,6 +477,24 @@
 							<xs:documentation>ft^3</xs:documentation>
 						</xs:annotation>
 					</xs:element>
+					<xs:element minOccurs="0" name="Load">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="Units" type="ElectricLoadUnits"/>
+								<xs:element name="Value" type="HPXMLDouble"/>
+							</xs:sequence>
+							<xs:attribute name="dataSource" type="DataSource"/>
+						</xs:complexType>
+					</xs:element>
+					<xs:element minOccurs="0" name="HotWaterLoad">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="Units" type="HotWaterLoadUnits"/>
+								<xs:element name="Value" type="HPXMLDouble"/>
+							</xs:sequence>
+							<xs:attribute name="dataSource" type="DataSource"/>
+						</xs:complexType>
+					</xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -515,6 +542,24 @@
 							<xs:documentation>loads/week per the Energy Guide label; use Usage instead for loads/week of actual usage by the occupants</xs:documentation>
 						</xs:annotation>
 					</xs:element>
+					<xs:element minOccurs="0" name="Load">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="Units" type="ElectricLoadUnits"/>
+								<xs:element name="Value" type="HPXMLDouble"/>
+							</xs:sequence>
+							<xs:attribute name="dataSource" type="DataSource"/>
+						</xs:complexType>
+					</xs:element>
+					<xs:element minOccurs="0" name="HotWaterLoad">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="Units" type="HotWaterLoadUnits"/>
+								<xs:element name="Value" type="HPXMLDouble"/>
+							</xs:sequence>
+							<xs:attribute name="dataSource" type="DataSource"/>
+						</xs:complexType>
+					</xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -531,6 +576,15 @@
 						<xs:annotation>
 							<xs:documentation>[cu.ft.]</xs:documentation>
 						</xs:annotation>
+					</xs:element>
+					<xs:element minOccurs="0" name="Load">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="Units" type="ElectricLoadUnits"/>
+								<xs:element name="Value" type="HPXMLDouble"/>
+							</xs:sequence>
+							<xs:attribute name="dataSource" type="DataSource"/>
+						</xs:complexType>
 					</xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
@@ -563,6 +617,15 @@
 						<xs:annotation>
 							<xs:documentation>[cu.ft.] Freezer Volume</xs:documentation>
 						</xs:annotation>
+					</xs:element>
+					<xs:element minOccurs="0" name="Load">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="Units" type="ElectricLoadUnits"/>
+								<xs:element name="Value" type="HPXMLDouble"/>
+							</xs:sequence>
+							<xs:attribute name="dataSource" type="DataSource"/>
+						</xs:complexType>
 					</xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
@@ -620,6 +683,15 @@
 						</xs:complexType>
 					</xs:element>
 					<xs:element minOccurs="0" name="FractionDehumidificationLoadServed" type="Fraction"/>
+					<xs:element minOccurs="0" name="Load">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="Units" type="ElectricLoadUnits"/>
+								<xs:element name="Value" type="HPXMLDouble"/>
+							</xs:sequence>
+							<xs:attribute name="dataSource" type="DataSource"/>
+						</xs:complexType>
+					</xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -632,6 +704,15 @@
 					<xs:element minOccurs="0" name="Location" type="RefrigeratorLocation"/>
 					<xs:element name="FuelType" type="FuelType" minOccurs="0"/>
 					<xs:element minOccurs="0" name="IsInduction" type="HPXMLBoolean"/>
+					<xs:element minOccurs="0" name="Load" maxOccurs="2">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="Units" type="ElectricOrFuelLoadUnits"/>
+								<xs:element name="Value" type="HPXMLDouble"/>
+							</xs:sequence>
+							<xs:attribute name="dataSource" type="DataSource"/>
+						</xs:complexType>
+					</xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -644,6 +725,15 @@
 					<xs:element minOccurs="0" name="Location" type="RefrigeratorLocation"/>
 					<xs:element name="FuelType" type="FuelType" minOccurs="0"/>
 					<xs:element minOccurs="0" name="IsConvection" type="HPXMLBoolean"/>
+					<xs:element minOccurs="0" name="Load">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="Units" type="ElectricOrFuelLoadUnits"/>
+								<xs:element name="Value" type="HPXMLDouble"/>
+							</xs:sequence>
+							<xs:attribute name="dataSource" type="DataSource"/>
+						</xs:complexType>
+					</xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -1858,6 +1948,15 @@
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
+									<xs:element minOccurs="0" name="HotWaterLoad">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="Units" type="HotWaterLoadUnits"/>
+												<xs:element name="Value" type="HPXMLDouble"/>
+											</xs:sequence>
+											<xs:attribute name="dataSource" type="DataSource"/>
+										</xs:complexType>
+									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1906,6 +2005,15 @@
 										<xs:annotation>
 											<xs:documentation>Independent organization has verified that product or appliance meets or exceeds the standard in question.</xs:documentation>
 										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="HotWaterLoad">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="Units" type="HotWaterLoadUnits"/>
+												<xs:element name="Value" type="HPXMLDouble"/>
+											</xs:sequence>
+											<xs:attribute name="dataSource" type="DataSource"/>
+										</xs:complexType>
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
@@ -2661,7 +2769,7 @@
 						<xs:element minOccurs="0" name="Load">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element name="Units" type="PlugLoadUnits"/>
+									<xs:element name="Units" type="ElectricLoadUnits"/>
 									<xs:element name="Value" type="HPXMLDouble"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -2767,15 +2767,15 @@
 			<xs:extension base="FuelLoadLocation_simple"/>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="PlugLoadUnits_simple">
+	<xs:simpleType name="ElectricLoadUnits_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="kWh/year"/>
 			<xs:enumeration value="W"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:complexType name="PlugLoadUnits">
+	<xs:complexType name="ElectricLoadUnits">
 		<xs:simpleContent>
-			<xs:extension base="PlugLoadUnits_simple">
+			<xs:extension base="ElectricLoadUnits_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -2789,6 +2789,30 @@
 	<xs:complexType name="FuelLoadUnits">
 		<xs:simpleContent>
 			<xs:extension base="FuelLoadUnits_simple"/>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ElectricOrFuelLoadUnits_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="kWh/year"/>
+			<xs:enumeration value="W"/>
+			<xs:enumeration value="therm/year"/>
+			<xs:enumeration value="Btuh"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="ElectricOrFuelLoadUnits">
+		<xs:simpleContent>
+			<xs:extension base="ElectricOrFuelLoadUnits_simple"/>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="HotWaterLoadUnits_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="gal/day"/>
+			<xs:enumeration value="gal/min"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="HotWaterLoadUnits">
+		<xs:simpleContent>
+			<xs:extension base="HotWaterLoadUnits_simple"/>
 		</xs:simpleContent>
 	</xs:complexType>
 	<xs:simpleType name="WindowCondition_simple">


### PR DESCRIPTION
Similar to what's available for plug/fuel loads and [what's proposed for lighting](https://github.com/hpxmlwg/hpxml/pull/366).

New elements:
- **ClothesDryer**: `Load` (0-2, electric or fuel)
- **ClothesWasher**: `Load` (0-1, electric) and `HotWaterLoad`
- **Dishwasher**: `Load` (0-1, electric) and `HotWaterLoad`
- **Freezer**: `Load` (0-1, electric)
- **Refrigerator:** `Load` (0-1, electric)
- **Dehumidifier**: `Load` (0-1, electric)
- **CookingRange:** `Load` (0-1, electric or fuel)
- **Oven:** `Load` (0-1, electric or fuel)
- **HotWaterDistribution:** `HotWaterLoad`
- **WaterFixture:** `HotWaterLoad`

Available enumeration choices are:
- Electric units: "kWh/year" or "W" (same as used for plug loads)
- Fuel units: "therm/year" or "Btuh" (same as used for fuel loads)
- Hot water units: "gal/day" or "gal/min"