### PR TITLE
`DetailedConstruction` element for surfaces

### DIFF
--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -186,6 +186,29 @@
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
+	<xs:complexType name="DetailedConstruction">
+		<xs:sequence>
+			<xs:group ref="SystemInfo"/>
+			<xs:element maxOccurs="unbounded" name="ConstructionLayer">
+				<xs:annotation>
+					<xs:documentation>Layers should be ordered from exterior to interior. Do not include air films.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element minOccurs="0" name="Material" type="xs:string"/>
+						<xs:element minOccurs="0" name="Thickness" type="HPXMLDouble"/>
+						<xs:element minOccurs="0" name="Conductivity" type="HPXMLDouble"/>
+						<xs:element minOccurs="0" name="Density" type="HPXMLDouble"/>
+						<xs:element minOccurs="0" name="SpecificHeat" type="HPXMLDouble"/>
+						<xs:element minOccurs="0" name="RValue" type="HPXMLDouble"/>
+						<xs:element ref="extension" minOccurs="0"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="extension" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="dataSource" type="DataSource"/>
+	</xs:complexType>
 	<xs:complexType name="InsulationMaterial">
 		<xs:choice>
 			<xs:element name="Batt" type="InsulationBattType"/>
@@ -1062,6 +1085,7 @@
 									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
 									<xs:element minOccurs="0" name="InteriorFinish" type="InteriorFinishInfo"/>
 									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"/>
+									<xs:element minOccurs="0" name="DetailedConstruction" type="DetailedConstruction"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>


### PR DESCRIPTION
Strawman proposal:

![HPXMLBaseElements_DetailedConstruction](https://user-images.githubusercontent.com/5861765/218597367-8f315825-0705-492c-bac9-bda01f0bdbc1.png)

Initial notes/questions:
- Documentation calls out that layers should be ordered from exterior to interior.
- Documentation calls out that air films should not be included.
- Should each construction layer have its own SystemIdentifier?
- Should we include a standardized list of common materials? (We would still need to allow a user-specified value.)
- Should we allow for parallel paths for, e.g., surfaces with frame/cavity construction? Note: For some wall types, parallel path calculations are not appropriate. For metal frame walls, ASHRAE provides correction factors.
  - Some software tools describe the insulation grade using a path. Should insulation grading be included or excluded? There is a separate [InsulationGrade](https://hpxml.nrel.gov/datadictionary/3.1.0/Building/BuildingDetails/Enclosure/Walls/Wall/Insulation/InsulationGrade) element.
- What is relationship between these inputs and existing inputs (insulation layers, framing factor, siding, assembly R-value, etc.)?