### PR TITLE
Soil properties

### DIFF
--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -10794,7 +10794,7 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="SoilType_Type">
+	<xs:simpleType name="SoilType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="sand"/>
 			<xs:enumeration value="silt"/>
@@ -10807,12 +10807,12 @@
 	</xs:simpleType>
 	<xs:complexType name="SoilType">
 		<xs:simpleContent>
-			<xs:extension base="SoilType_Type">
+			<xs:extension base="SoilType_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="MoistureType_Type">
+	<xs:simpleType name="MoistureType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="wet"/>
 			<xs:enumeration value="dry"/>
@@ -10821,7 +10821,7 @@
 	</xs:simpleType>
 	<xs:complexType name="MoisureType">
 		<xs:simpleContent>
-			<xs:extension base="MoistureType_Type">
+			<xs:extension base="MoistureType_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>

--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -10679,16 +10679,16 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="SoilMoistureType_Type">
+	<xs:simpleType name="MoistureType_Type">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="wet"/>
 			<xs:enumeration value="dry"/>
 			<xs:enumeration value="mixed"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:complexType name="SoilMoisureType">
+	<xs:complexType name="MoisureType">
 		<xs:simpleContent>
-			<xs:extension base="SoilMoistureType_Type">
+			<xs:extension base="MoistureType_Type">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -3843,11 +3843,12 @@
 											<xs:sequence>
 												<xs:element minOccurs="0" name="SoilType" type="SoilType"/>
 												<xs:element minOccurs="0" name="MoistureType" type="MoisureType"/>
-												<xs:element minOccurs="0" name="Conductivity">
+												<xs:element minOccurs="0" name="Conductivity" type="HPXMLDouble">
 													<xs:annotation>
 														<xs:documentation>[Btu/hr-ft-F]</xs:documentation>
 													</xs:annotation>
 												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -3838,6 +3838,19 @@
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
+									<xs:element minOccurs="0" name="Soil">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element minOccurs="0" name="SoilType" type="SoilType"/>
+												<xs:element minOccurs="0" name="MoistureType" type="MoisureType"/>
+												<xs:element minOccurs="0" name="Conductivity">
+													<xs:annotation>
+														<xs:documentation>[Btu/hr-ft-F]</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -4845,7 +4845,7 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="SoilType_Type">
+	<xs:simpleType name="SoilType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="sand"/>
 			<xs:enumeration value="silt"/>
@@ -4858,12 +4858,12 @@
 	</xs:simpleType>
 	<xs:complexType name="SoilType">
 		<xs:simpleContent>
-			<xs:extension base="SoilType_Type">
+			<xs:extension base="SoilType_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="MoistureType_Type">
+	<xs:simpleType name="MoistureType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="wet"/>
 			<xs:enumeration value="dry"/>
@@ -4872,7 +4872,7 @@
 	</xs:simpleType>
 	<xs:complexType name="MoisureType">
 		<xs:simpleContent>
-			<xs:extension base="MoistureType_Type">
+			<xs:extension base="MoistureType_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -4835,16 +4835,16 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="SoilMoistureType_Type">
+	<xs:simpleType name="MoistureType_Type">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="wet"/>
 			<xs:enumeration value="dry"/>
 			<xs:enumeration value="mixed"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:complexType name="SoilMoisureType">
+	<xs:complexType name="MoisureType">
 		<xs:simpleContent>
-			<xs:extension base="SoilMoistureType_Type">
+			<xs:extension base="MoistureType_Type">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -4817,4 +4817,36 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+	<xs:simpleType name="SoilType_Type">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="sand"/>
+			<xs:enumeration value="silt"/>
+			<xs:enumeration value="clay"/>
+			<xs:enumeration value="loam"/>
+			<xs:enumeration value="gravel"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="SoilType">
+		<xs:simpleContent>
+			<xs:extension base="SoilType_Type">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="SoilMoistureType_Type">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="wet"/>
+			<xs:enumeration value="dry"/>
+			<xs:enumeration value="mixed"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="SoilMoisureType">
+		<xs:simpleContent>
+			<xs:extension base="SoilMoistureType_Type">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 </xs:schema>


### PR DESCRIPTION
Adds a `BuildingSummary/Site/Soil` element as follows:

![image](https://user-images.githubusercontent.com/5861765/225163569-e1573000-b0e6-4ced-970b-9f5b755ee64e.png)

SoilType choices:
- sand
- silt
- clay
- loam
- gravel
- other
- unknown

MoistureType choices:
- wet
- dry
- mixed