### PR TITLE
Buried ducts

### DIFF
--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -3845,7 +3845,7 @@
 						<xs:element minOccurs="0" name="DuctInsulationCondition" type="InsulationCondition"/>
 						<xs:element minOccurs="0" name="DuctBuriedInsulationLevel" type="DuctBuriedInsulationLevel">
 							<xs:annotation>
-								<xs:documentation>Describes ducts buried in, e.g., attic loose-fill insulation. Partially buried ducts have insulation that does not cover the top of the ducts. Fully buried ducts have insulation just covers the top of the ducts. Deeply buried ducts means the insulation continues above the top of the ducts. See https://basc.pnnl.gov/resource-guides/ducts-buried-attic-insulation for more information.</xs:documentation>
+								<xs:documentation>Describes ducts buried in, e.g., attic loose-fill insulation. Partially buried ducts have insulation that does not cover the top of the ducts. Fully buried ducts have insulation that just covers the top of the ducts. Deeply buried ducts have insulation that continues above the top of the ducts. See https://basc.pnnl.gov/resource-guides/ducts-buried-attic-insulation for more information.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element name="DuctLocation" type="DuctLocation" minOccurs="0"/>

--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -3854,7 +3854,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" name="DuctEffectiveRValue" type="RValue">
 							<xs:annotation>
-								<xs:documentation>The overall efective R-value. Includes the exterior air film as well as other effects such as adjustments for insulation wrapped around round ducts, or ducts buried in attic insulation.</xs:documentation>
+								<xs:documentation>The overall effective R-value. Includes the exterior air film as well as other effects such as adjustments for insulation wrapped around round ducts, or ducts buried in attic insulation.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element name="DuctLocation" type="DuctLocation" minOccurs="0"/>

--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -3757,6 +3757,7 @@
 						<xs:group ref="SystemInfo"/>
 						<xs:element name="DuctType" type="DuctType" minOccurs="0"/>
 						<xs:element name="DuctMaterial" type="DuctMaterial" minOccurs="0"/>
+						<xs:element minOccurs="0" name="DuctInsulationLocation" type="DuctInsulationLocation"/>
 						<xs:element minOccurs="0" name="DuctInsulationMaterial" type="InsulationMaterial"/>
 						<xs:element name="DuctInsulationRValue" type="RValue" minOccurs="0"/>
 						<xs:element minOccurs="0" name="DuctInsulationThickness" type="LengthMeasurement">
@@ -7855,6 +7856,23 @@
 	<xs:complexType name="DuctMaterial">
 		<xs:simpleContent>
 			<xs:extension base="DuctMaterial_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="DuctInsulationLocation_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="around duct or ductboard"/>
+			<xs:enumeration value="buried in attic"/>
+			<xs:enumeration value="above duct"/>
+			<xs:enumeration value="below duct"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="DuctInsulationLocation">
+		<xs:simpleContent>
+			<xs:extension base="DuctInsulationLocation_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>

--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -3841,11 +3841,6 @@
 								<xs:documentation>This should exclude the exterior air film -- e.g., use zero for uninsulated ducts. For ducts buried in insulation, this should only represent any surrounding insulation duct wrap and not the entire attic insulation R-value.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DuctEffectiveRValue">
-							<xs:annotation>
-								<xs:documentation>The overall efective R-value. Includes the exterior air film as well as other effects such as adjustments for insulation wrapped around round ducts, or ducts buried in attic insulation.</xs:documentation>
-							</xs:annotation>
-						</xs:element>
 						<xs:element minOccurs="0" name="DuctInsulationThickness" type="LengthMeasurement">
 							<xs:annotation>
 								<xs:documentation>[in]</xs:documentation>
@@ -3855,6 +3850,11 @@
 						<xs:element minOccurs="0" name="DuctBuriedInsulationLevel" type="DuctBuriedInsulationLevel">
 							<xs:annotation>
 								<xs:documentation>Describes ducts buried in, e.g., attic loose-fill insulation. Partially buried ducts have insulation that does not cover the top of the ducts. Fully buried ducts have insulation that just covers the top of the ducts. Deeply buried ducts have insulation that continues above the top of the ducts. See https://basc.pnnl.gov/resource-guides/ducts-buried-attic-insulation for more information.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="DuctEffectiveRValue" type="RValue">
+							<xs:annotation>
+								<xs:documentation>The overall efective R-value. Includes the exterior air film as well as other effects such as adjustments for insulation wrapped around round ducts, or ducts buried in attic insulation.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element name="DuctLocation" type="DuctLocation" minOccurs="0"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -3840,7 +3840,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" name="DuctEffectiveRValue" type="RValue">
 							<xs:annotation>
-								<xs:documentation>The overall efective R-value. Includes the exterior air film as well as other effects such as adjustments for insulation wrapped around round ducts, or ducts buried in attic insulation.</xs:documentation>
+								<xs:documentation>The overall effective R-value. Includes the exterior air film as well as other effects such as adjustments for insulation wrapped around round ducts, or ducts buried in attic insulation.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element name="DuctLocation" type="DuctLocation" minOccurs="0"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -3821,7 +3821,6 @@
 						<xs:group ref="SystemInfo"/>
 						<xs:element name="DuctType" type="DuctType" minOccurs="0"/>
 						<xs:element name="DuctMaterial" type="DuctMaterial" minOccurs="0"/>
-						<xs:element minOccurs="0" name="DuctInsulationLocation" type="DuctInsulationLocation"/>
 						<xs:element minOccurs="0" name="DuctInsulationMaterial" type="InsulationMaterial"/>
 						<xs:element name="DuctInsulationRValue" type="RValue" minOccurs="0"/>
 						<xs:element minOccurs="0" name="DuctInsulationThickness" type="LengthMeasurement">
@@ -3830,6 +3829,11 @@
 							</xs:annotation>
 						</xs:element>
 						<xs:element minOccurs="0" name="DuctInsulationCondition" type="InsulationCondition"/>
+						<xs:element minOccurs="0" name="DuctBuriedInsulationLevel" type="DuctBuriedInsulationLevel">
+							<xs:annotation>
+								<xs:documentation>Describes ducts buried in, e.g., attic loose-fill insulation. Partially buried ducts have insulation that does not cover the top of the ducts. Fully buried ducts have insulation just covers the top of the ducts. Deeply buried ducts means the insulation continues above the top of the ducts. See https://basc.pnnl.gov/resource-guides/ducts-buried-attic-insulation for more information.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
 						<xs:element name="DuctLocation" type="DuctLocation" minOccurs="0"/>
 						<xs:element minOccurs="0" name="FractionDuctArea" type="Fraction">
 							<xs:annotation>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -3827,11 +3827,6 @@
 								<xs:documentation>This should exclude the exterior air film -- e.g., use zero for uninsulated ducts. For ducts buried in insulation, this should only represent any surrounding insulation duct wrap and not the entire attic insulation R-value.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DuctEffectiveRValue">
-							<xs:annotation>
-								<xs:documentation>The overall efective R-value. Includes the exterior air film as well as other effects such as adjustments for insulation wrapped around round ducts, or ducts buried in attic insulation.</xs:documentation>
-							</xs:annotation>
-						</xs:element>
 						<xs:element minOccurs="0" name="DuctInsulationThickness" type="LengthMeasurement">
 							<xs:annotation>
 								<xs:documentation>[in]</xs:documentation>
@@ -3841,6 +3836,11 @@
 						<xs:element minOccurs="0" name="DuctBuriedInsulationLevel" type="DuctBuriedInsulationLevel">
 							<xs:annotation>
 								<xs:documentation>Describes ducts buried in, e.g., attic loose-fill insulation. Partially buried ducts have insulation that does not cover the top of the ducts. Fully buried ducts have insulation that just covers the top of the ducts. Deeply buried ducts have insulation that continues above the top of the ducts. See https://basc.pnnl.gov/resource-guides/ducts-buried-attic-insulation for more information.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="DuctEffectiveRValue" type="RValue">
+							<xs:annotation>
+								<xs:documentation>The overall efective R-value. Includes the exterior air film as well as other effects such as adjustments for insulation wrapped around round ducts, or ducts buried in attic insulation.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element name="DuctLocation" type="DuctLocation" minOccurs="0"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -3743,6 +3743,7 @@
 						<xs:group ref="SystemInfo"/>
 						<xs:element name="DuctType" type="DuctType" minOccurs="0"/>
 						<xs:element name="DuctMaterial" type="DuctMaterial" minOccurs="0"/>
+						<xs:element minOccurs="0" name="DuctInsulationLocation" type="DuctInsulationLocation"/>
 						<xs:element minOccurs="0" name="DuctInsulationMaterial" type="InsulationMaterial"/>
 						<xs:element name="DuctInsulationRValue" type="RValue" minOccurs="0"/>
 						<xs:element minOccurs="0" name="DuctInsulationThickness" type="LengthMeasurement">

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -3831,7 +3831,7 @@
 						<xs:element minOccurs="0" name="DuctInsulationCondition" type="InsulationCondition"/>
 						<xs:element minOccurs="0" name="DuctBuriedInsulationLevel" type="DuctBuriedInsulationLevel">
 							<xs:annotation>
-								<xs:documentation>Describes ducts buried in, e.g., attic loose-fill insulation. Partially buried ducts have insulation that does not cover the top of the ducts. Fully buried ducts have insulation just covers the top of the ducts. Deeply buried ducts means the insulation continues above the top of the ducts. See https://basc.pnnl.gov/resource-guides/ducts-buried-attic-insulation for more information.</xs:documentation>
+								<xs:documentation>Describes ducts buried in, e.g., attic loose-fill insulation. Partially buried ducts have insulation that does not cover the top of the ducts. Fully buried ducts have insulation that just covers the top of the ducts. Deeply buried ducts have insulation that continues above the top of the ducts. See https://basc.pnnl.gov/resource-guides/ducts-buried-attic-insulation for more information.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element name="DuctLocation" type="DuctLocation" minOccurs="0"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -3822,7 +3822,16 @@
 						<xs:element name="DuctType" type="DuctType" minOccurs="0"/>
 						<xs:element name="DuctMaterial" type="DuctMaterial" minOccurs="0"/>
 						<xs:element minOccurs="0" name="DuctInsulationMaterial" type="InsulationMaterial"/>
-						<xs:element name="DuctInsulationRValue" type="RValue" minOccurs="0"/>
+						<xs:element name="DuctInsulationRValue" type="RValue" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>This should exclude the exterior air film -- e.g., use zero for uninsulated ducts. For ducts buried in insulation, this should only represent any surrounding insulation duct wrap and not the entire attic insulation R-value.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="DuctEffectiveRValue">
+							<xs:annotation>
+								<xs:documentation>The overall efective R-value. Includes the exterior air film as well as other effects such as adjustments for insulation wrapped around round ducts, or ducts buried in attic insulation.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
 						<xs:element minOccurs="0" name="DuctInsulationThickness" type="LengthMeasurement">
 							<xs:annotation>
 								<xs:documentation>[in]</xs:documentation>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1953,19 +1953,17 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="DuctInsulationLocation_simple">
+	<xs:simpleType name="DuctBuriedInsulationLevel_simple">
 		<xs:restriction base="xs:string">
-			<xs:enumeration value="around duct or ductboard"/>
-			<xs:enumeration value="buried in attic"/>
-			<xs:enumeration value="above duct"/>
-			<xs:enumeration value="below duct"/>
-			<xs:enumeration value="other"/>
-			<xs:enumeration value="none"/>
+			<xs:enumeration value="not buried"/>
+			<xs:enumeration value="partially buried"/>
+			<xs:enumeration value="fully buried"/>
+			<xs:enumeration value="deeply buried"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:complexType name="DuctInsulationLocation">
+	<xs:complexType name="DuctBuriedInsulationLevel">
 		<xs:simpleContent>
-			<xs:extension base="DuctInsulationLocation_simple">
+			<xs:extension base="DuctBuriedInsulationLevel_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1931,6 +1931,7 @@
 			<xs:enumeration value="above duct"/>
 			<xs:enumeration value="below duct"/>
 			<xs:enumeration value="other"/>
+			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="DuctInsulationLocation">

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1924,6 +1924,22 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+	<xs:simpleType name="DuctInsulationLocation_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="around duct or ductboard"/>
+			<xs:enumeration value="buried in attic"/>
+			<xs:enumeration value="above duct"/>
+			<xs:enumeration value="below duct"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="DuctInsulationLocation">
+		<xs:simpleContent>
+			<xs:extension base="DuctInsulationLocation_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="DuctLocation_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="attic"/>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5861765/231841121-9b3a3ccd-d1f8-4056-978e-5e0a7e471d49.png)

New `DuctBuriedInsulationLevel` element with choices of:
- not buried
- partially buried
- fully buried
- deeply buried

Description of element: "Describes ducts buried in, e.g., attic loose-fill insulation. Partially buried ducts have insulation that does not cover the top of the ducts. Fully buried ducts have insulation that just covers the top of the ducts. Deeply buried ducts have insulation that continues above the top of the ducts. See https://basc.pnnl.gov/resource-guides/ducts-buried-attic-insulation for more information."

Also:
- Updates `DuctInsulationRValue` description: "This should exclude the exterior air film -- e.g., use zero for uninsulated ducts. For ducts buried in insulation, this should only represent any surrounding insulation duct wrap and not the entire attic insulation R-value."
- Adds a `DuctEffectiveRValue` element with description: "The overall effective R-value. Includes the exterior air film as well as other effects such as adjustments for insulation wrapped around round ducts, or ducts buried in attic insulation."

Closes #374.