### PR TITLE
Move `MaxAmbientCOinLivingSpaceDuringAudit` element

### DIFF
--- a/examples/audit.xml
+++ b/examples/audit.xml
@@ -549,6 +549,7 @@
         </MoistureControl>
         <CombustionAppliances>
           <!-- Seems odd to have all these on the proposed workscope. -->
+          <MaxAmbientCOinLivingSpaceDuringAudit>2</MaxAmbientCOinLivingSpaceDuringAudit>
           <CombustionApplianceZone>
             <SystemIdentifier id="cazzone1p" sameas="cazzone1"/>
             <CAZDepressurizationLimit>1</CAZDepressurizationLimit>
@@ -573,7 +574,6 @@
                 <PoorScenario>456.7</PoorScenario>
                 <CurrentCondition>123.4</CurrentCondition>
                 <TestResult>passed</TestResult>
-                <MaxAmbientCOinLivingSpaceDuringAudit>2</MaxAmbientCOinLivingSpaceDuringAudit>
               </CarbonMonoxideTest>
               <FuelLeaks>
                 <FuelType>natural gas</FuelType>
@@ -597,7 +597,6 @@
                 <PoorScenario>456.7</PoorScenario>
                 <CurrentCondition>123.4</CurrentCondition>
                 <TestResult>passed</TestResult>
-                <MaxAmbientCOinLivingSpaceDuringAudit>2</MaxAmbientCOinLivingSpaceDuringAudit>
               </CarbonMonoxideTest>
               <FuelLeaks>
                 <FuelType>natural gas</FuelType>

--- a/examples/invalid.xml
+++ b/examples/invalid.xml
@@ -549,6 +549,7 @@
         </MoistureControl>
         <CombustionAppliances>
           <!-- Seems odd to have all these on the proposed workscope. -->
+          <MaxAmbientCOinLivingSpaceDuringAudit>2</MaxAmbientCOinLivingSpaceDuringAudit>
           <CombustionApplianceZone>
             <SystemIdentifier id="cazzone1p" sameas="cazzone1"/>
             <CAZDepressurizationLimit>1</CAZDepressurizationLimit>
@@ -573,7 +574,6 @@
                 <PoorScenario>456.7</PoorScenario>
                 <CurrentCondition>123.4</CurrentCondition>
                 <TestResult>passed</TestResult>
-                <MaxAmbientCOinLivingSpaceDuringAudit>2</MaxAmbientCOinLivingSpaceDuringAudit>
               </CarbonMonoxideTest>
               <FuelLeaks>
                 <FuelType>natural gas</FuelType>
@@ -597,7 +597,6 @@
                 <PoorScenario>456.7</PoorScenario>
                 <CurrentCondition>123.4</CurrentCondition>
                 <TestResult>passed</TestResult>
-                <MaxAmbientCOinLivingSpaceDuringAudit>2</MaxAmbientCOinLivingSpaceDuringAudit>
               </CarbonMonoxideTest>
               <FuelLeaks>
                 <FuelType>natural gas</FuelType>

--- a/examples/upgrade.xml
+++ b/examples/upgrade.xml
@@ -576,6 +576,7 @@
           </MoistureControlImprovement>
         </MoistureControl>
         <CombustionAppliances>
+          <MaxAmbientCOinLivingSpaceDuringAudit>0.0</MaxAmbientCOinLivingSpaceDuringAudit>
           <CombustionApplianceZone>
             <SystemIdentifier id="cazzone1c" sameas="cazzone1"/>
             <CAZDepressurizationLimit>0.0</CAZDepressurizationLimit>
@@ -600,7 +601,6 @@
                 <PoorScenario>0.0</PoorScenario>
                 <CurrentCondition>0.0</CurrentCondition>
                 <TestResult>failed</TestResult>
-                <MaxAmbientCOinLivingSpaceDuringAudit>0.0</MaxAmbientCOinLivingSpaceDuringAudit>
               </CarbonMonoxideTest>
               <FuelLeaks>
                 <FuelType>anthracite coal</FuelType>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -2761,6 +2761,11 @@
 			<xs:element minOccurs="0" name="CombustionAppliances">
 				<xs:complexType>
 					<xs:sequence>
+						<xs:element name="MaxAmbientCOinLivingSpaceDuringAudit" minOccurs="0" type="HPXMLDouble">
+							<xs:annotation>
+								<xs:documentation>Monitored throughout assessment, not just appliance testing</xs:documentation>
+							</xs:annotation>
+						</xs:element>
 						<xs:element minOccurs="0" name="CombustionApplianceZone" maxOccurs="unbounded">
 							<xs:complexType>
 								<xs:sequence>
@@ -2848,11 +2853,6 @@
 														<xs:complexContent>
 															<xs:extension base="CAZApplianceReading">
 																<xs:sequence>
-																	<xs:element name="MaxAmbientCOinLivingSpaceDuringAudit" minOccurs="0" type="HPXMLDouble">
-																		<xs:annotation>
-																			<xs:documentation>Monitored throughout assessment, not just appliance testing</xs:documentation>
-																		</xs:annotation>
-																	</xs:element>
 																	<xs:element minOccurs="0" name="AmbientCOActionDuringCAZTesting" type="HPXMLString">
 																		<xs:annotation>
 																			<xs:documentation>BPI Gold Sheet is one example that shows action levels based upon decision logic</xs:documentation>


### PR DESCRIPTION
Previously:
`HealthAndSafety/CombustionAppliances/CombustionApplianceZone/CombustionApplianceTest/CarbonMonoxideTest/MaxAmbientCOinLivingSpaceDuringAudit`

Now:
`HealthAndSafety/CombustionAppliances/MaxAmbientCOinLivingSpaceDuringAudit`

Closes #87.