### PR TITLE
Fix idref attribute

### DIFF
--- a/examples/audit.xml
+++ b/examples/audit.xml
@@ -294,7 +294,7 @@
           <CombustionApplianceZone>
             <SystemIdentifier id="cazzone1"/>
             <CombustionApplianceTest>
-              <CAZAppliance id="dhw1"/>
+              <CAZAppliance idref="dhw1"/>
             </CombustionApplianceTest>
           </CombustionApplianceZone>
         </CombustionAppliances>
@@ -558,7 +558,7 @@
             <DepressurizationFindingPoorCase>pass</DepressurizationFindingPoorCase>
             <AmountAmbientCOinCAZduringTesting>2</AmountAmbientCOinCAZduringTesting>
             <CombustionApplianceTest>
-              <CAZAppliance id="dhw1p"/>
+              <CAZAppliance idref="dhw1p"/>
               <FlueDraftTest>
                 <PoorScenario>456</PoorScenario>
                 <CurrentCondition>123</CurrentCondition>
@@ -582,7 +582,7 @@
               </FuelLeaks>
             </CombustionApplianceTest>
             <CombustionApplianceTest>
-              <CAZAppliance id="htgsys1p"/>
+              <CAZAppliance idref="htgsys1p"/>
               <FlueDraftTest>
                 <PoorScenario>456</PoorScenario>
                 <CurrentCondition>123</CurrentCondition>
@@ -612,8 +612,8 @@
   </Building>
   <Project>
     <ProjectID id="project-1"/>
-    <PreBuildingID id="bldg1"/>
-    <PostBuildingID id="bldg1p"/>
+    <PreBuildingID idref="bldg1"/>
+    <PostBuildingID idref="bldg1p"/>
     <ProjectDetails>
       <ProjectStatus>
         <EventType>proposed workscope</EventType>
@@ -644,10 +644,10 @@
           </MeasureSystemIdentifiers>
           <Cost>1200</Cost>
           <ReplacedComponents>
-            <ReplacedComponent id="attic1ins"/>
+            <ReplacedComponent idref="attic1ins"/>
           </ReplacedComponents>
           <InstalledComponents>
-            <InstalledComponent id="attic1insp"/>
+            <InstalledComponent idref="attic1insp"/>
           </InstalledComponents>
         </Measure>
         <Measure>
@@ -656,10 +656,10 @@
           </MeasureSystemIdentifiers>
           <Cost>3000</Cost>
           <ReplacedComponents>
-            <ReplacedComponent id="htgsys1"/>
+            <ReplacedComponent idref="htgsys1"/>
           </ReplacedComponents>
           <InstalledComponents>
-            <InstalledComponent id="htgsys1p"/>
+            <InstalledComponent idref="htgsys1p"/>
           </InstalledComponents>
         </Measure>
       </Measures>

--- a/examples/bpi2101.xml
+++ b/examples/bpi2101.xml
@@ -617,8 +617,8 @@
   </Building>
   <Project>
     <ProjectID id="project-1"/>
-    <PreBuildingID id="bldg-audit"/>
-    <PostBuildingID id="bldg-proposed"/>
+    <PreBuildingID idref="bldg-audit"/>
+    <PostBuildingID idref="bldg-proposed"/>
     <ProjectDetails>
       <ProjectStatus>
         <EventType>proposed workscope</EventType>
@@ -639,10 +639,10 @@
           <MeasureDescription>Blow in cellulose insulation in attic to R-50.</MeasureDescription>
           <Cost>1000</Cost>
           <ReplacedComponents>
-            <ReplacedComponent id="attic1flrins"/>
+            <ReplacedComponent idref="attic1flrins"/>
           </ReplacedComponents>
           <InstalledComponents>
-            <InstalledComponent id="attic1flrinsproposed"/>
+            <InstalledComponent idref="attic1flrinsproposed"/>
           </InstalledComponents>
         </Measure>
         <Measure>
@@ -652,24 +652,24 @@
           <MeasureDescription>Replace Refrigerator with EnergyStar version</MeasureDescription>
           <Cost>1200</Cost>
           <ReplacedComponents>
-            <ReplacedComponent id="refrigerator1"/>
+            <ReplacedComponent idref="refrigerator1"/>
           </ReplacedComponents>
           <InstalledComponents>
-            <InstalledComponent id="refrigerator1proposed"/>
+            <InstalledComponent idref="refrigerator1proposed"/>
           </InstalledComponents>
         </Measure>
       </Measures>
     </ProjectDetails>
     <extension>
       <BuildingID id="bldg-proposed"/>
-      <ProjectSystemIdentifiers id="bldg-audit"/>
-      <ProjectSystemIdentifiers id="bldg-proposed"/>
+      <ProjectSystemIdentifiers idref="bldg-audit"/>
+      <ProjectSystemIdentifiers idref="bldg-proposed"/>
     </extension>
   </Project>
   <Project>
     <ProjectID id="project-2"/>
-    <PreBuildingID id="bldg-audit"/>
-    <PostBuildingID id="bldg-completion"/>
+    <PreBuildingID idref="bldg-audit"/>
+    <PostBuildingID idref="bldg-completion"/>
     <ProjectDetails>
       <ProjectStatus>
         <EventType>job completion testing/final inspection</EventType>
@@ -690,10 +690,10 @@
           <MeasureDescription>Blow in cellulose insulation in attic to R-49.</MeasureDescription>
           <Cost>1032.12</Cost>
           <ReplacedComponents>
-            <ReplacedComponent id="attic1flrins"/>
+            <ReplacedComponent idref="attic1flrins"/>
           </ReplacedComponents>
           <InstalledComponents>
-            <InstalledComponent id="attic1flrinscompletion"/>
+            <InstalledComponent idref="attic1flrinscompletion"/>
           </InstalledComponents>
         </Measure>
         <Measure>
@@ -703,18 +703,18 @@
           <MeasureDescription>Replace Refrigerator with EnergyStar version</MeasureDescription>
           <Cost>1234.56</Cost>
           <ReplacedComponents>
-            <ReplacedComponent id="refrigerator1"/>
+            <ReplacedComponent idref="refrigerator1"/>
           </ReplacedComponents>
           <InstalledComponents>
-            <InstalledComponent id="refrigerator1completion"/>
+            <InstalledComponent idref="refrigerator1completion"/>
           </InstalledComponents>
         </Measure>
       </Measures>
     </ProjectDetails>
     <extension>
       <BuildingID id="bldg-completion"/>
-      <ProjectSystemIdentifiers id="bldg-audit"/>
-      <ProjectSystemIdentifiers id="bldg-completion"/>
+      <ProjectSystemIdentifiers idref="bldg-audit"/>
+      <ProjectSystemIdentifiers idref="bldg-completion"/>
     </extension>
   </Project>
   <Utility>
@@ -728,11 +728,11 @@
     </UtilitiesorFuelProviders>
   </Utility>
   <Consumption>
-    <BuildingID id="bldg-audit"/>
-    <CustomerID id="person1"/>
+    <BuildingID idref="bldg-audit"/>
+    <CustomerID idref="person1"/>
     <ConsumptionDetails>
       <ConsumptionInfo>
-        <UtilityID id="xcel"/>
+        <UtilityID idref="xcel"/>
         <ConsumptionType>
           <Energy>
             <FuelType>electricity</FuelType>
@@ -749,11 +749,11 @@
     </ConsumptionDetails>
   </Consumption>
   <Consumption>
-    <BuildingID id="bldg-completion"/>
-    <CustomerID id="person1"/>
+    <BuildingID idref="bldg-completion"/>
+    <CustomerID idref="person1"/>
     <ConsumptionDetails>
       <ConsumptionInfo>
-        <UtilityID id="xcel"/>
+        <UtilityID idref="xcel"/>
         <ConsumptionType>
           <Energy>
             <FuelType>electricity</FuelType>

--- a/examples/bpi2101.xml
+++ b/examples/bpi2101.xml
@@ -661,7 +661,7 @@
       </Measures>
     </ProjectDetails>
     <extension>
-      <BuildingID id="bldg-proposed"/>
+      <BuildingID idref="bldg-proposed"/>
       <ProjectSystemIdentifiers idref="bldg-audit"/>
       <ProjectSystemIdentifiers idref="bldg-proposed"/>
     </extension>
@@ -712,7 +712,7 @@
       </Measures>
     </ProjectDetails>
     <extension>
-      <BuildingID id="bldg-completion"/>
+      <BuildingID idref="bldg-completion"/>
       <ProjectSystemIdentifiers idref="bldg-audit"/>
       <ProjectSystemIdentifiers idref="bldg-completion"/>
     </extension>

--- a/examples/invalid.xml
+++ b/examples/invalid.xml
@@ -294,7 +294,7 @@
           <CombustionApplianceZone>
             <SystemIdentifier id="cazzone1"/>
             <CombustionApplianceTest>
-              <CAZAppliance id="dhw1"/>
+              <CAZAppliance idref="dhw1"/>
             </CombustionApplianceTest>
           </CombustionApplianceZone>
         </CombustionAppliances>
@@ -558,7 +558,7 @@
             <DepressurizationFindingPoorCase>pass</DepressurizationFindingPoorCase>
             <AmountAmbientCOinCAZduringTesting>2</AmountAmbientCOinCAZduringTesting>
             <CombustionApplianceTest>
-              <CAZAppliance id="dhw1p"/>
+              <CAZAppliance idref="dhw1p"/>
               <FlueDraftTest>
                 <PoorScenario>456</PoorScenario>
                 <CurrentCondition>123</CurrentCondition>
@@ -582,7 +582,7 @@
               </FuelLeaks>
             </CombustionApplianceTest>
             <CombustionApplianceTest>
-              <CAZAppliance id="htgsys1p"/>
+              <CAZAppliance idref="htgsys1p"/>
               <FlueDraftTest>
                 <PoorScenario>456</PoorScenario>
                 <CurrentCondition>123</CurrentCondition>
@@ -612,8 +612,8 @@
   </Building>
   <Project>
     <ProjectID id="project-1"/>
-    <PreBuildingID id="bldg1"/>
-    <PostBuildingID id="bldg1p"/>
+    <PreBuildingID idref="bldg1"/>
+    <PostBuildingID idref="bldg1p"/>
     <ProjectDetails>
       <ProjectStatus>
         <EventType>proposed workscope</EventType>
@@ -644,10 +644,10 @@
           </MeasureSystemIdentifiers>
           <Cost>1200</Cost>
           <ReplacedComponents>
-            <ReplacedComponent id="attic1ins"/>
+            <ReplacedComponent idref="attic1ins"/>
           </ReplacedComponents>
           <InstalledComponents>
-            <InstalledComponent id="attic1insp"/>
+            <InstalledComponent idref="attic1insp"/>
           </InstalledComponents>
         </Measure>
         <Measure>
@@ -656,10 +656,10 @@
           </MeasureSystemIdentifiers>
           <Cost>3000</Cost>
           <ReplacedComponents>
-            <ReplacedComponent id="htgsys1"/>
+            <ReplacedComponent idref="htgsys1"/>
           </ReplacedComponents>
           <InstalledComponents>
-            <InstalledComponent id="htgsys1p"/>
+            <InstalledComponent idref="htgsys1p"/>
           </InstalledComponents>
         </Measure>
       </Measures>

--- a/examples/upgrade.xml
+++ b/examples/upgrade.xml
@@ -302,7 +302,7 @@
           <CombustionApplianceZone>
             <SystemIdentifier id="cazzone1"/>
             <CombustionApplianceTest>
-              <CAZAppliance id="dhw1c"/>
+              <CAZAppliance idref="dhw1c"/>
             </CombustionApplianceTest>
           </CombustionApplianceZone>
         </CombustionAppliances>
@@ -585,7 +585,7 @@
             <DepressurizationFindingPoorCase>fail</DepressurizationFindingPoorCase>
             <AmountAmbientCOinCAZduringTesting>0.0</AmountAmbientCOinCAZduringTesting>
             <CombustionApplianceTest>
-              <CAZAppliance id="dhw1c"/>
+              <CAZAppliance idref="dhw1c"/>
               <FlueDraftTest>
                 <PoorScenario>0.0</PoorScenario>
                 <CurrentCondition>0.0</CurrentCondition>
@@ -615,8 +615,8 @@
   </Building>
   <Project>
     <ProjectID id="project-1"/>
-    <PreBuildingID id="bldg1"/>
-    <PostBuildingID id="bldg1c"/>
+    <PreBuildingID idref="bldg1"/>
+    <PostBuildingID idref="bldg1c"/>
     <ProjectDetails>
       <ProjectStatus>
         <EventType>job completion testing/final inspection</EventType>
@@ -638,7 +638,7 @@
             <SystemIdentifiersInfo id="dishwasherreplacement"/>
           </MeasureSystemIdentifiers>
           <InstalledComponents>
-            <InstalledComponent id="dishwasher1c"/>
+            <InstalledComponent idref="dishwasher1c"/>
           </InstalledComponents>
         </Measure>
         <Measure>
@@ -646,7 +646,7 @@
             <SystemIdentifiersInfo id="freezerreplacement"/>
           </MeasureSystemIdentifiers>
           <InstalledComponents>
-            <InstalledComponent id="freezer1c"/>
+            <InstalledComponent idref="freezer1c"/>
           </InstalledComponents>
         </Measure>
         <Measure>
@@ -654,10 +654,10 @@
             <SystemIdentifiersInfo id="htgsysreplacement"/>
           </MeasureSystemIdentifiers>
           <ReplacedComponents>
-            <ReplacedComponent id="htgsys1"/>
+            <ReplacedComponent idref="htgsys1"/>
           </ReplacedComponents>
           <InstalledComponents>
-            <InstalledComponent id="htgsys1c"/>
+            <InstalledComponent idref="htgsys1c"/>
           </InstalledComponents>
         </Measure>
         <Measure>
@@ -665,10 +665,10 @@
             <SystemIdentifiersInfo id="windowreplacement"/>
           </MeasureSystemIdentifiers>
           <ReplacedComponents>
-            <ReplacedComponent id="window1"/>
+            <ReplacedComponent idref="window1"/>
           </ReplacedComponents>
           <InstalledComponents>
-            <InstalledComponent id="window1c"/>
+            <InstalledComponent idref="window1c"/>
           </InstalledComponents>
         </Measure>
         <Measure>
@@ -676,10 +676,10 @@
             <SystemIdentifiersInfo id="doorreplacement"/>
           </MeasureSystemIdentifiers>
           <ReplacedComponents>
-            <ReplacedComponent id="door2"/>
+            <ReplacedComponent idref="door2"/>
           </ReplacedComponents>
           <InstalledComponents>
-            <InstalledComponent id="door2c"/>
+            <InstalledComponent idref="door2c"/>
           </InstalledComponents>
         </Measure>
         <Measure>
@@ -687,10 +687,10 @@
             <SystemIdentifiersInfo id="atticfloorreplacement"/>
           </MeasureSystemIdentifiers>
           <ReplacedComponents>
-            <ReplacedComponent id="insul1"/>
+            <ReplacedComponent idref="insul1"/>
           </ReplacedComponents>
           <InstalledComponents>
-            <InstalledComponent id="insul1c"/>
+            <InstalledComponent idref="insul1c"/>
           </InstalledComponents>
         </Measure>
         <Measure>
@@ -698,18 +698,18 @@
             <SystemIdentifiersInfo id="dehumidifierrreplacement"/>
           </MeasureSystemIdentifiers>
           <ReplacedComponents>
-            <ReplacedComponent id="dehumidifier1"/>
+            <ReplacedComponent idref="dehumidifier1"/>
           </ReplacedComponents>
           <InstalledComponents>
-            <InstalledComponent id="dehumidifier1c"/>
+            <InstalledComponent idref="dehumidifier1c"/>
           </InstalledComponents>
         </Measure>
       </Measures>
     </ProjectDetails>
     <extension>
-      <BuildingID id="bldg1c"/>
-      <ProjectSystemIdentifiers id="bldg1"/>
-      <ProjectSystemIdentifiers id="bldg1c"/>
+      <BuildingID idref="bldg1c"/>
+      <ProjectSystemIdentifiers idref="bldg1"/>
+      <ProjectSystemIdentifiers idref="bldg1c"/>
     </extension>
   </Project>
   <Utility>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -96,7 +96,7 @@
 			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType" minOccurs="0"/>
 			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue" minOccurs="0"/>
 		</xs:sequence>
-		<xs:attribute name="id" type="xs:IDREF">
+		<xs:attribute name="idref" type="xs:IDREF">
 			<xs:annotation>
 				<xs:documentation>Id reference in the current document. Optional. If the element isn't available in the current document, don't use this.</xs:documentation>
 			</xs:annotation>


### PR DESCRIPTION
Changes the `RemoteReference` base element so that the "id" attribute (of type xs:idref) is now an "idref" attribute.

Closes #284.