### PR TITLE
Infiltration for multifamily buildings

### DIFF
--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -5039,6 +5039,11 @@
 			<xs:element minOccurs="0" name="WindConditions" type="WindConditions"/>
 			<xs:element name="TypeOfInfiltrationMeasurement" type="TypeofInfiltrationMeasurement" minOccurs="0"/>
 			<xs:element name="TypeOfBlowerDoorTest" type="TypeofBlowerDoorTest" minOccurs="0"/>
+			<xs:element minOccurs="0" name="TypeOfInfiltrationLeakage" type="TypeofInfiltrationLeakage">
+				<xs:annotation>
+					<xs:documentation>This element is intended to describe the type of infiltration measured, e.g., for an individual single-family attached or multifamily dwelling unit. Either whole building or single unit infiltration can be measured. For single unit infiltration, leakage can occur through exterior surfaces (adjacent to outside) only, interior surfaces (adjacent to other units or common spaces) only, or both. For example, guarded tests measure unit exterior leakage, unguarded or compartmentalization tests measure unit total leakage, and combining both tests can measure unit interior leakage.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element name="HousePressure" type="HousePressure" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[Pa] with respect to outside</xs:documentation>
@@ -5051,16 +5056,11 @@
 			</xs:element>
 			<xs:element name="FanRingUsed" type="FanRingUsed" minOccurs="0"/>
 			<xs:element minOccurs="0" name="LeakinessDescription" type="BuildingLeakiness"/>
-			<xs:element minOccurs="0" name="BuildingAirLeakage" maxOccurs="unbounded">
+			<xs:element minOccurs="0" name="BuildingAirLeakage" maxOccurs="1">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element name="UnitofMeasure" type="BuildingAirLeakageUnit" minOccurs="0"/>
 						<xs:element name="AirLeakage" type="BuildingAirLeakage" minOccurs="0"/>
-						<xs:element minOccurs="0" name="AirLeakageType" type="BuildingAirLeakageType">
-							<xs:annotation>
-								<xs:documentation>This element is intended to describe the type of air leakage measured for an individual single-family attached or multifamily dwelling unit. Either building-level or unit-level air leakage can be measured. For unit-level air leakage, leakage can be through exterior surfaces (adjacent to outside) only, interior surfaces (adjacent to other units or common spaces) only, or both. For example, guarded tests measure unit exterior leakage, unguarded (or compartmentalization) tests measure unit total leakage, and combining both tests can measure unit interior leakage.</xs:documentation>
-							</xs:annotation>
-						</xs:element>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -6290,7 +6290,7 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="BuildingAirLeakageType_simple">
+	<xs:simpleType name="TypeofInfiltrationLeakage_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="building total"/>
 			<xs:enumeration value="unit total"/>
@@ -6298,9 +6298,9 @@
 			<xs:enumeration value="unit interior only"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:complexType name="BuildingAirLeakageType">
+	<xs:complexType name="TypeofInfiltrationLeakage">
 		<xs:simpleContent>
-			<xs:extension base="BuildingAirLeakageType_simple">
+			<xs:extension base="TypeofInfiltrationLeakage_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>

--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -5039,6 +5039,11 @@
 			<xs:element minOccurs="0" name="WindConditions" type="WindConditions"/>
 			<xs:element name="TypeOfInfiltrationMeasurement" type="TypeofInfiltrationMeasurement" minOccurs="0"/>
 			<xs:element name="TypeOfBlowerDoorTest" type="TypeofBlowerDoorTest" minOccurs="0"/>
+			<xs:element minOccurs="0" name="TypeOfMultifamilyInfiltrationTest" type="TypeOfMultifamilyInfiltrationTest">
+				<xs:annotation>
+					<xs:documentation>Whole building tests measure the infiltration through the total exterior envelope of the multifamily building. Compartmentalization tests measure the infiltration for a single dwelling unit through both exterior (adjacent to outside) and interior/shared (adjacent to other spaces/units) surfaces. Guarded tests measure the infiltration for a single dwelling unit through only exterior (adjacent to outside) surfaces.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element name="HousePressure" type="HousePressure" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[Pa] with respect to outside</xs:documentation>
@@ -6330,6 +6335,21 @@
 	<xs:complexType name="HousePressure">
 		<xs:simpleContent>
 			<xs:extension base="HousePressure_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="TypeOfMultifamilyInfiltrationTest_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="whole building test"/>
+			<xs:enumeration value="compartmentalization test"/>
+			<xs:enumeration value="guarded test"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="TypeOfMultifamilyInfiltrationTest">
+		<xs:simpleContent>
+			<xs:extension base="TypeOfMultifamilyInfiltrationTest_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>

--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -5039,9 +5039,9 @@
 			<xs:element minOccurs="0" name="WindConditions" type="WindConditions"/>
 			<xs:element name="TypeOfInfiltrationMeasurement" type="TypeofInfiltrationMeasurement" minOccurs="0"/>
 			<xs:element name="TypeOfBlowerDoorTest" type="TypeofBlowerDoorTest" minOccurs="0"/>
-			<xs:element minOccurs="0" name="TypeOfMultifamilyInfiltrationTest" type="TypeOfMultifamilyInfiltrationTest">
+			<xs:element minOccurs="0" name="TypeOfInfiltrationTest" type="TypeOfInfiltrationTest">
 				<xs:annotation>
-					<xs:documentation>Whole building tests measure the infiltration through the total exterior envelope of the multifamily building. Compartmentalization tests measure the infiltration for a single dwelling unit through both exterior (adjacent to outside) and interior/shared (adjacent to other spaces/units) surfaces. Guarded tests measure the infiltration for a single dwelling unit through only exterior (adjacent to outside) surfaces.</xs:documentation>
+					<xs:documentation>Applies to single-family attached and multifamily. Whole building tests measure the infiltration through the total exterior envelope of the building. Compartmentalization tests measure the infiltration for a single dwelling unit through both exterior (adjacent to outside) and interior/shared (adjacent to other spaces/units) surfaces. Guarded tests measure the infiltration for a single dwelling unit through only exterior (adjacent to outside) surfaces.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="HousePressure" type="HousePressure" minOccurs="0">
@@ -6339,7 +6339,7 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="TypeOfMultifamilyInfiltrationTest_simple">
+	<xs:simpleType name="TypeOfInfiltrationTest_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="whole building test"/>
 			<xs:enumeration value="compartmentalization test"/>
@@ -6347,9 +6347,9 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:complexType name="TypeOfMultifamilyInfiltrationTest">
+	<xs:complexType name="TypeOfInfiltrationTest">
 		<xs:simpleContent>
-			<xs:extension base="TypeOfMultifamilyInfiltrationTest_simple">
+			<xs:extension base="TypeOfInfiltrationTest_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>

--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -5041,7 +5041,7 @@
 			<xs:element name="TypeOfBlowerDoorTest" type="TypeofBlowerDoorTest" minOccurs="0"/>
 			<xs:element minOccurs="0" name="TypeOfInfiltrationLeakage" type="TypeofInfiltrationLeakage">
 				<xs:annotation>
-					<xs:documentation>This element is intended to describe the type of infiltration measured, e.g., for an individual single-family attached or multifamily dwelling unit. Either whole building or single unit infiltration can be measured. For single unit infiltration, leakage can occur through only exterior surfaces, only interior surfaces, or both. For example, guarded tests measure unit exterior leakage, unguarded or compartmentalization tests measure unit total leakage, and combining both tests can measure unit interior leakage.</xs:documentation>
+					<xs:documentation>This element is intended to describe the type of infiltration measured, e.g., for an individual single-family attached or multifamily dwelling unit. Either whole building or single unit infiltration can be measured. For single unit infiltration, leakage can occur through exterior surfaces, interior surfaces, or both. For example, guarded tests measure unit exterior leakage, unguarded or compartmentalization tests measure unit total leakage, and combining both tests can measure unit interior leakage.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="HousePressure" type="HousePressure" minOccurs="0">

--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -5041,7 +5041,7 @@
 			<xs:element name="TypeOfBlowerDoorTest" type="TypeofBlowerDoorTest" minOccurs="0"/>
 			<xs:element minOccurs="0" name="TypeOfInfiltrationLeakage" type="TypeofInfiltrationLeakage">
 				<xs:annotation>
-					<xs:documentation>This element is intended to describe the type of infiltration measured, e.g., for an individual single-family attached or multifamily dwelling unit. Either whole building or single unit infiltration can be measured. For single unit infiltration, leakage can occur through exterior surfaces (adjacent to outside) only, interior surfaces (adjacent to other units or common spaces) only, or both. For example, guarded tests measure unit exterior leakage, unguarded or compartmentalization tests measure unit total leakage, and combining both tests can measure unit interior leakage.</xs:documentation>
+					<xs:documentation>This element is intended to describe the type of infiltration measured, e.g., for an individual single-family attached or multifamily dwelling unit. Either whole building or single unit infiltration can be measured. For single unit infiltration, leakage can occur through only exterior surfaces, only interior surfaces, or both. For example, guarded tests measure unit exterior leakage, unguarded or compartmentalization tests measure unit total leakage, and combining both tests can measure unit interior leakage.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="HousePressure" type="HousePressure" minOccurs="0">

--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -5056,7 +5056,7 @@
 			</xs:element>
 			<xs:element name="FanRingUsed" type="FanRingUsed" minOccurs="0"/>
 			<xs:element minOccurs="0" name="LeakinessDescription" type="BuildingLeakiness"/>
-			<xs:element minOccurs="0" name="BuildingAirLeakage" maxOccurs="1">
+			<xs:element minOccurs="0" name="BuildingAirLeakage">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element name="UnitofMeasure" type="BuildingAirLeakageUnit" minOccurs="0"/>

--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -5058,7 +5058,7 @@
 						<xs:element name="AirLeakage" type="BuildingAirLeakage" minOccurs="0"/>
 						<xs:element minOccurs="0" name="AirLeakageType" type="BuildingAirLeakageType">
 							<xs:annotation>
-								<xs:documentation>This element is intended to describe the type of air leakage measured for an individual single-family attached or multifamily dwelling unit. Either building-level or unit-level air leakage can be measured. For unit-level air leakage, leakage can be through exterior surfaces (adjacent to outside) only, interior surfaces (adjacent to other units or common spaces), or both. For example, guarded tests measure unit exterior leakage, unguarded (or compartmentalization) tests measure unit total leakage, and combining both tests can measure unit interior leakage.</xs:documentation>
+								<xs:documentation>This element is intended to describe the type of air leakage measured for an individual single-family attached or multifamily dwelling unit. Either building-level or unit-level air leakage can be measured. For unit-level air leakage, leakage can be through exterior surfaces (adjacent to outside) only, interior surfaces (adjacent to other units or common spaces) only, or both. For example, guarded tests measure unit exterior leakage, unguarded (or compartmentalization) tests measure unit total leakage, and combining both tests can measure unit interior leakage.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 					</xs:sequence>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -5025,6 +5025,11 @@
 			<xs:element minOccurs="0" name="WindConditions" type="WindConditions"/>
 			<xs:element name="TypeOfInfiltrationMeasurement" type="TypeofInfiltrationMeasurement" minOccurs="0"/>
 			<xs:element name="TypeOfBlowerDoorTest" type="TypeofBlowerDoorTest" minOccurs="0"/>
+			<xs:element minOccurs="0" name="TypeOfInfiltrationLeakage" type="TypeofInfiltrationLeakage">
+				<xs:annotation>
+					<xs:documentation>This element is intended to describe the type of infiltration measured, e.g., for an individual single-family attached or multifamily dwelling unit. Either whole building or single unit infiltration can be measured. For single unit infiltration, leakage can occur through exterior surfaces (adjacent to outside) only, interior surfaces (adjacent to other units or common spaces) only, or both. For example, guarded tests measure unit exterior leakage, unguarded or compartmentalization tests measure unit total leakage, and combining both tests can measure unit interior leakage.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element name="HousePressure" type="HousePressure" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[Pa] with respect to outside</xs:documentation>
@@ -5037,16 +5042,11 @@
 			</xs:element>
 			<xs:element name="FanRingUsed" type="FanRingUsed" minOccurs="0"/>
 			<xs:element minOccurs="0" name="LeakinessDescription" type="BuildingLeakiness"/>
-			<xs:element minOccurs="0" name="BuildingAirLeakage" maxOccurs="unbounded">
+			<xs:element minOccurs="0" name="BuildingAirLeakage" maxOccurs="1">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element name="UnitofMeasure" type="BuildingAirLeakageUnit" minOccurs="0"/>
 						<xs:element name="AirLeakage" type="BuildingAirLeakage" minOccurs="0"/>
-						<xs:element minOccurs="0" name="AirLeakageType" type="BuildingAirLeakageType">
-							<xs:annotation>
-								<xs:documentation>This element is intended to describe the type of air leakage measured for an individual single-family attached or multifamily dwelling unit. Either building-level or unit-level air leakage can be measured. For unit-level air leakage, leakage can be through exterior surfaces (adjacent to outside) only, interior surfaces (adjacent to other units or common spaces) only, or both. For example, guarded tests measure unit exterior leakage, unguarded (or compartmentalization) tests measure unit total leakage, and combining both tests can measure unit interior leakage.</xs:documentation>
-							</xs:annotation>
-						</xs:element>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -5025,9 +5025,9 @@
 			<xs:element minOccurs="0" name="WindConditions" type="WindConditions"/>
 			<xs:element name="TypeOfInfiltrationMeasurement" type="TypeofInfiltrationMeasurement" minOccurs="0"/>
 			<xs:element name="TypeOfBlowerDoorTest" type="TypeofBlowerDoorTest" minOccurs="0"/>
-			<xs:element minOccurs="0" name="TypeOfMultifamilyInfiltrationTest" type="TypeOfMultifamilyInfiltrationTest">
+			<xs:element minOccurs="0" name="TypeOfInfiltrationTest" type="TypeOfInfiltrationTest">
 				<xs:annotation>
-					<xs:documentation>Whole building tests measure the infiltration through the total exterior envelope of the multifamily building. Compartmentalization tests measure the infiltration for a single dwelling unit through both exterior (adjacent to outside) and interior/shared (adjacent to other spaces/units) surfaces. Guarded tests measure the infiltration for a single dwelling unit through only exterior (adjacent to outside) surfaces.</xs:documentation>
+					<xs:documentation>Applies to single-family attached and multifamily. Whole building tests measure the infiltration through the total exterior envelope of the building. Compartmentalization tests measure the infiltration for a single dwelling unit through both exterior (adjacent to outside) and interior/shared (adjacent to other spaces/units) surfaces. Guarded tests measure the infiltration for a single dwelling unit through only exterior (adjacent to outside) surfaces.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="HousePressure" type="HousePressure" minOccurs="0">

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -5044,7 +5044,7 @@
 						<xs:element name="AirLeakage" type="BuildingAirLeakage" minOccurs="0"/>
 						<xs:element minOccurs="0" name="AirLeakageType" type="BuildingAirLeakageType">
 							<xs:annotation>
-								<xs:documentation>This element is intended to describe the type of air leakage measured for an individual single-family attached or multifamily dwelling unit. Either building-level or unit-level air leakage can be measured. For unit-level air leakage, leakage can be through exterior surfaces (adjacent to outside) only, interior surfaces (adjacent to other units or common spaces), or both. For example, guarded tests measure unit exterior leakage, unguarded (or compartmentalization) tests measure unit total leakage, and combining both tests can measure unit interior leakage.</xs:documentation>
+								<xs:documentation>This element is intended to describe the type of air leakage measured for an individual single-family attached or multifamily dwelling unit. Either building-level or unit-level air leakage can be measured. For unit-level air leakage, leakage can be through exterior surfaces (adjacent to outside) only, interior surfaces (adjacent to other units or common spaces) only, or both. For example, guarded tests measure unit exterior leakage, unguarded (or compartmentalization) tests measure unit total leakage, and combining both tests can measure unit interior leakage.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 					</xs:sequence>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -5027,7 +5027,7 @@
 			<xs:element name="TypeOfBlowerDoorTest" type="TypeofBlowerDoorTest" minOccurs="0"/>
 			<xs:element minOccurs="0" name="TypeOfInfiltrationLeakage" type="TypeofInfiltrationLeakage">
 				<xs:annotation>
-					<xs:documentation>This element is intended to describe the type of infiltration measured, e.g., for an individual single-family attached or multifamily dwelling unit. Either whole building or single unit infiltration can be measured. For single unit infiltration, leakage can occur through only exterior surfaces, only interior surfaces, or both. For example, guarded tests measure unit exterior leakage, unguarded or compartmentalization tests measure unit total leakage, and combining both tests can measure unit interior leakage.</xs:documentation>
+					<xs:documentation>This element is intended to describe the type of infiltration measured, e.g., for an individual single-family attached or multifamily dwelling unit. Either whole building or single unit infiltration can be measured. For single unit infiltration, leakage can occur through exterior surfaces, interior surfaces, or both. For example, guarded tests measure unit exterior leakage, unguarded or compartmentalization tests measure unit total leakage, and combining both tests can measure unit interior leakage.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="HousePressure" type="HousePressure" minOccurs="0">

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -5025,6 +5025,11 @@
 			<xs:element minOccurs="0" name="WindConditions" type="WindConditions"/>
 			<xs:element name="TypeOfInfiltrationMeasurement" type="TypeofInfiltrationMeasurement" minOccurs="0"/>
 			<xs:element name="TypeOfBlowerDoorTest" type="TypeofBlowerDoorTest" minOccurs="0"/>
+			<xs:element minOccurs="0" name="TypeOfMultifamilyInfiltrationTest" type="TypeOfMultifamilyInfiltrationTest">
+				<xs:annotation>
+					<xs:documentation>Whole building tests measure the infiltration through the total exterior envelope of the multifamily building. Compartmentalization tests measure the infiltration for a single dwelling unit through both exterior (adjacent to outside) and interior/shared (adjacent to other spaces/units) surfaces. Guarded tests measure the infiltration for a single dwelling unit through only exterior (adjacent to outside) surfaces.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element name="HousePressure" type="HousePressure" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[Pa] with respect to outside</xs:documentation>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -5027,7 +5027,7 @@
 			<xs:element name="TypeOfBlowerDoorTest" type="TypeofBlowerDoorTest" minOccurs="0"/>
 			<xs:element minOccurs="0" name="TypeOfInfiltrationLeakage" type="TypeofInfiltrationLeakage">
 				<xs:annotation>
-					<xs:documentation>This element is intended to describe the type of infiltration measured, e.g., for an individual single-family attached or multifamily dwelling unit. Either whole building or single unit infiltration can be measured. For single unit infiltration, leakage can occur through exterior surfaces (adjacent to outside) only, interior surfaces (adjacent to other units or common spaces) only, or both. For example, guarded tests measure unit exterior leakage, unguarded or compartmentalization tests measure unit total leakage, and combining both tests can measure unit interior leakage.</xs:documentation>
+					<xs:documentation>This element is intended to describe the type of infiltration measured, e.g., for an individual single-family attached or multifamily dwelling unit. Either whole building or single unit infiltration can be measured. For single unit infiltration, leakage can occur through only exterior surfaces, only interior surfaces, or both. For example, guarded tests measure unit exterior leakage, unguarded or compartmentalization tests measure unit total leakage, and combining both tests can measure unit interior leakage.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="HousePressure" type="HousePressure" minOccurs="0">

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -5042,7 +5042,7 @@
 			</xs:element>
 			<xs:element name="FanRingUsed" type="FanRingUsed" minOccurs="0"/>
 			<xs:element minOccurs="0" name="LeakinessDescription" type="BuildingLeakiness"/>
-			<xs:element minOccurs="0" name="BuildingAirLeakage" maxOccurs="1">
+			<xs:element minOccurs="0" name="BuildingAirLeakage">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element name="UnitofMeasure" type="BuildingAirLeakageUnit" minOccurs="0"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -5025,11 +5025,6 @@
 			<xs:element minOccurs="0" name="WindConditions" type="WindConditions"/>
 			<xs:element name="TypeOfInfiltrationMeasurement" type="TypeofInfiltrationMeasurement" minOccurs="0"/>
 			<xs:element name="TypeOfBlowerDoorTest" type="TypeofBlowerDoorTest" minOccurs="0"/>
-			<xs:element minOccurs="0" name="TypeOfInfiltrationTest" type="TypeOfInfiltrationTest">
-				<xs:annotation>
-					<xs:documentation>Applies to single-family attached and multifamily. Whole building tests measure the infiltration through the total exterior envelope of the building. Compartmentalization tests measure the infiltration for a single dwelling unit through both exterior (adjacent to outside) and interior/shared (adjacent to other spaces/units) surfaces. Guarded tests measure the infiltration for a single dwelling unit through only exterior (adjacent to outside) surfaces.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
 			<xs:element name="HousePressure" type="HousePressure" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[Pa] with respect to outside</xs:documentation>
@@ -5042,11 +5037,16 @@
 			</xs:element>
 			<xs:element name="FanRingUsed" type="FanRingUsed" minOccurs="0"/>
 			<xs:element minOccurs="0" name="LeakinessDescription" type="BuildingLeakiness"/>
-			<xs:element minOccurs="0" name="BuildingAirLeakage">
+			<xs:element minOccurs="0" name="BuildingAirLeakage" maxOccurs="unbounded">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element name="UnitofMeasure" type="BuildingAirLeakageUnit" minOccurs="0"/>
 						<xs:element name="AirLeakage" type="BuildingAirLeakage" minOccurs="0"/>
+						<xs:element minOccurs="0" name="AirLeakageType" type="BuildingAirLeakageType">
+							<xs:annotation>
+								<xs:documentation>This element is intended to describe the type of air leakage measured for an individual single-family attached or multifamily dwelling unit. Either building-level or unit-level air leakage can be measured. For unit-level air leakage, leakage can be through exterior surfaces (adjacent to outside) only, interior surfaces (adjacent to other units or common spaces), or both. For example, guarded tests measure unit exterior leakage, unguarded (or compartmentalization) tests measure unit total leakage, and combining both tests can measure unit interior leakage.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -399,7 +399,7 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="TypeOfMultifamilyInfiltrationTest_simple">
+	<xs:simpleType name="TypeOfInfiltrationTest_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="whole building test"/>
 			<xs:enumeration value="compartmentalization test"/>
@@ -407,9 +407,9 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:complexType name="TypeOfMultifamilyInfiltrationTest">
+	<xs:complexType name="TypeOfInfiltrationTest">
 		<xs:simpleContent>
-			<xs:extension base="TypeOfMultifamilyInfiltrationTest_simple">
+			<xs:extension base="TypeOfInfiltrationTest_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -399,6 +399,21 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+	<xs:simpleType name="TypeOfMultifamilyInfiltrationTest_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="whole building test"/>
+			<xs:enumeration value="compartmentalization test"/>
+			<xs:enumeration value="guarded test"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="TypeOfMultifamilyInfiltrationTest">
+		<xs:simpleContent>
+			<xs:extension base="TypeOfMultifamilyInfiltrationTest_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="TypeofInfiltrationMeasurement_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="blower door"/>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -350,7 +350,7 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="BuildingAirLeakageType_simple">
+	<xs:simpleType name="TypeofInfiltrationLeakage_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="building total"/>
 			<xs:enumeration value="unit total"/>
@@ -358,9 +358,9 @@
 			<xs:enumeration value="unit interior only"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:complexType name="BuildingAirLeakageType">
+	<xs:complexType name="TypeofInfiltrationLeakage">
 		<xs:simpleContent>
-			<xs:extension base="BuildingAirLeakageType_simple">
+			<xs:extension base="TypeofInfiltrationLeakage_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -350,6 +350,21 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+	<xs:simpleType name="BuildingAirLeakageType_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="building total"/>
+			<xs:enumeration value="unit total"/>
+			<xs:enumeration value="unit exterior only"/>
+			<xs:enumeration value="unit interior only"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="BuildingAirLeakageType">
+		<xs:simpleContent>
+			<xs:extension base="BuildingAirLeakageType_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="FanPressure_simple">
 		<xs:restriction base="xs:double"/>
 	</xs:simpleType>
@@ -395,21 +410,6 @@
 	<xs:complexType name="HousePressure">
 		<xs:simpleContent>
 			<xs:extension base="HousePressure_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="TypeOfInfiltrationTest_simple">
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="whole building test"/>
-			<xs:enumeration value="compartmentalization test"/>
-			<xs:enumeration value="guarded test"/>
-			<xs:enumeration value="other"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="TypeOfInfiltrationTest">
-		<xs:simpleContent>
-			<xs:extension base="TypeOfInfiltrationTest_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>


### PR DESCRIPTION
There is currently no way to know what an air infiltration measurement value for a multifamily dwelling unit represents. I propose adding an `AirInfiltrationMeasurement/TypeOfInfiltrationLeakage` element with choices of:
- building total
- unit total
- unit exterior only
- unit interior only

The element is documented as:
> This element is intended to describe the type of infiltration measured, e.g., for an individual single-family attached or multifamily dwelling unit. Either whole building or single unit infiltration can be measured. For single unit infiltration, leakage can occur through exterior surfaces, interior surfaces, or both. For example, guarded tests measure unit exterior leakage, unguarded or compartmentalization tests measure unit total leakage, and combining both tests can measure unit interior leakage.

Relevant information from a RESNET presentation:
![image](https://user-images.githubusercontent.com/5861765/227284217-3d7063c0-c3f4-4cf1-9900-4488521cfd41.png)
