### PR TITLE
Fix broken link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ HPXML
 
 Home Performance XML (HPXML) is a data transfer standard for the home performance industry. This repository is where the development of the schemas happens. 
 
-* `Official HPXML Website <http://hpxmlonline.com>`_ - includes press releases, and general information about the project.
+* `Official HPXML Website <https://hpxmlonline.com>`_ - includes press releases, and general information about the project.
 * `HPXML Guide <http://hpxml-guide.readthedocs.org/en/latest/>`_ - Draft documentation including program administrator and software implementer guides. Includes examples and explanation of how to use HPXML.
 * `HPXML Toolbox <https://hpxml.nrel.gov>`_ - Validator and Data Dictionary (schema explorer).
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ HPXML
 
 Home Performance XML (HPXML) is a data transfer standard for the home performance industry. This repository is where the development of the schemas happens. 
 
-* `Official HPXML Website <http://www.hpxmlonline.com>`_ - includes press releases, and general information about the project.
+* `Official HPXML Website <https://www.hpxmlonline.com>`_ - includes press releases, and general information about the project.
 * `HPXML Guide <http://hpxml-guide.readthedocs.org/en/latest/>`_ - Draft documentation including program administrator and software implementer guides. Includes examples and explanation of how to use HPXML.
 * `HPXML Toolbox <https://hpxml.nrel.gov>`_ - Validator and Data Dictionary (schema explorer).
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ HPXML
 
 Home Performance XML (HPXML) is a data transfer standard for the home performance industry. This repository is where the development of the schemas happens. 
 
-* `Official HPXML Website <https://hpxmlonline.com>`_ - includes press releases, and general information about the project.
+* `Official HPXML Website <http://www.hpxmlonline.com>`_ - includes press releases, and general information about the project.
 * `HPXML Guide <http://hpxml-guide.readthedocs.org/en/latest/>`_ - Draft documentation including program administrator and software implementer guides. Includes examples and explanation of how to use HPXML.
 * `HPXML Toolbox <https://hpxml.nrel.gov>`_ - Validator and Data Dictionary (schema explorer).
 

--- a/guide/source/index.rst
+++ b/guide/source/index.rst
@@ -21,7 +21,7 @@ If you are thinking about implementing HPXML, or just want to learn more about t
 
    * The :doc:`Software Developer Guide </software_developer/index>` provides developers with information on versioning, document structure, XML element references, and use case validation. The section also provides links to sample HPXML files.
 
-HPXML is periodically updated to reflect changes in the needs of the market and the stakeholders that are using the standard. Whenever a new version of HXPML is released, the Implementation Guide will be updated to reflect changes to the data standard and how it is being used in the market. If you have questions about HPXML or believe you can contribute to the overall success of its deployment, please email us at hpxml@homeperformance.org. For more information on HPXML, visit http://www.hpxmlonline.com.   
+HPXML is periodically updated to reflect changes in the needs of the market and the stakeholders that are using the standard. Whenever a new version of HXPML is released, the Implementation Guide will be updated to reflect changes to the data standard and how it is being used in the market. If you have questions about HPXML or believe you can contribute to the overall success of its deployment, please email us at hpxml@homeperformance.org. For more information on HPXML, visit https://www.hpxmlonline.com.   
 
 .. toctree::
    :maxdepth: 2

--- a/guide/source/overview.rst
+++ b/guide/source/overview.rst
@@ -64,7 +64,7 @@ The HPXML schema follows the `Semantic Versioning 2.0 specification <http://semv
 
 The minor version number is incremented when the schemas are changed in a manner that is backwards compatible with previous versions that share the same major version. In other words, a document created in a previous version of the schema will also validate against the new schema. Examples of changes that require a minor version change include adding elements, adding enumerations, and changing the annotation in the schema for an element. 
 
-Technical documentation can be found at http://www.hpxmlonline.com/.
+Technical documentation can be found at https://www.hpxmlonline.com/.
 
 HPXML Compliance
 ****************

--- a/guide/source/program_administrator/program_management_systems.rst
+++ b/guide/source/program_administrator/program_management_systems.rst
@@ -32,7 +32,7 @@ Leverage HPXML Experience
 
 In procuring a software provider, it is recommended that you consider their HPXML experience, including prior implementations of HPXML and participation in the working group. Many software vendors have already built in HPXML compliance or have been an active part of the HPXML development process. This experience should help speed up implementation and may reduce costs.
 
-There are several program administrators that participate in the HPXML working group. If you have questions, or would like to learn about their experiences, email your request to hpxml@homeperformance.org or visit http://www.hpxmlonline.com.
+There are several program administrators that participate in the HPXML working group. If you have questions, or would like to learn about their experiences, email your request to hpxml@homeperformance.org or visit https://www.hpxmlonline.com.
 
 Plan for Testing and HPXML Coordination Support
 ***********************************************

--- a/guide/source/software_developer/introduction.rst
+++ b/guide/source/software_developer/introduction.rst
@@ -3,7 +3,7 @@ Introduction
 
 This section of the Implementation Guide is designed to outline the technical details of implementing HPXML. HPXML is
 an expansive standard data format based on extensible markup language (XML) and maintained by the Building
-Performance Institute's HPXML working group. For more information on HPXML, visit http://www.hpxmlonline.com. 
+Performance Institute's HPXML working group. For more information on HPXML, visit https://www.hpxmlonline.com. 
 
 The HPXML format is defined by a set of XML Schema (XSD) documents that outline
 all the acceptable data elements, their structure, and relation to one another.

--- a/guide/source/standard_datasets.rst
+++ b/guide/source/standard_datasets.rst
@@ -25,7 +25,7 @@ The audit dataset is designed for use by Home Performance with ENERGY STAR® or 
 
 The audit dataset was established through a consensus process of three geographically diverse existing whole-house programs, and is intended to meet the needs of most programs.
 
-Programs that wish to adopt the audit dataset may download the `Data Selection Tool <http://www.hpxmlonline.com/tools-resources/data-selection-tool/>`_ for guidance on the required data fields. Software developers may visit Github for an example of an HPXML audit file.
+Programs that wish to adopt the audit dataset may download the `Data Selection Tool <https://www.hpxmlonline.com/tools-resources/data-selection-tool/>`_ for guidance on the required data fields. Software developers may visit Github for an example of an HPXML audit file.
 
 .. _upgrade-use-case-defn:
 

--- a/guide/source/tools_and_resources.rst
+++ b/guide/source/tools_and_resources.rst
@@ -6,7 +6,7 @@ A number of tool and resources exist to help software developers, programs, and 
 HPXML Website
 *************
 
-The Home Performance Coalition hosts a website that has information, tools, and resources on HPXML and its business cases. The website is: http://www.hpxmlonline.com.
+The Home Performance Coalition hosts a website that has information, tools, and resources on HPXML and its business cases. The website is: https://www.hpxmlonline.com.
 
 HPXML Implementation Guide 
 **************************


### PR DESCRIPTION
First, thanks for supporting these fantastic tools!

When perusing documentation I noticed a broken link in the README. 
`http://hpxmlonline.com` is broken because the server is set to reject non-HTTPS requests instead of redirecting them. 
So, a user clicking this link in the readme will, for most browsers, wait 30 seconds and then receive a time out error.

The best way to fix this is to add logic to your webserver to redirect non-secure requests to HTTPS, but changing the links is also useful. 

Note that I have not changed any of the non-secure links in the XML namespace (e.g. `<HPXML xmlns="https://hpxmlonline.com/2019/10"  schemaVersion="3.1">` because these uses are just namespaces, not actual resolveable URLs, and are sensitive to the protocol (e.g. `http` vs `https`)

https://stackoverflow.com/questions/30707609/xml-namespace-uri-with-https