### PR TITLE
HPWH ducting elements

### DIFF
--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -1694,7 +1694,7 @@
 														<xs:documentation>Where the air is supplied from; not the location where the supply ducts are running through.</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="ExhaustAirDestination" type="AdjacentTo">
+												<xs:element minOccurs="0" name="ExhaustAirTermination" type="AdjacentTo">
 													<xs:annotation>
 														<xs:documentation>Where the air is exhausted to; not the location where the exhaust ducts are running through.</xs:documentation>
 													</xs:annotation>

--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -1689,8 +1689,6 @@
 									<xs:element minOccurs="0" name="HPWHDucting">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="1" name="HasSupplyDucting" type="HPXMLBoolean"/>
-												<xs:element minOccurs="1" name="HasExhaustDucting" type="HPXMLBoolean"/>
 												<xs:element minOccurs="0" name="SupplyDuctingLocation" type="AdjacentTo"/>
 												<xs:element minOccurs="0" name="ExhaustDuctingLocation" type="AdjacentTo"/>
 												<xs:element ref="extension" minOccurs="0"/>

--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -1689,8 +1689,16 @@
 									<xs:element minOccurs="0" name="HPWHDucting">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="SupplyDuctingLocation" type="AdjacentTo"/>
-												<xs:element minOccurs="0" name="ExhaustDuctingLocation" type="AdjacentTo"/>
+												<xs:element minOccurs="0" name="SupplyAirSource" type="AdjacentTo">
+													<xs:annotation>
+														<xs:documentation>Where the air is supplied from; not the location where the supply ducts are running through.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="ExhaustAirDestination" type="AdjacentTo">
+													<xs:annotation>
+														<xs:documentation>Where the air is exhausted to; not the location where the exhaust ducts are running through.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
 												<xs:element ref="extension" minOccurs="0"/>
 											</xs:sequence>
 										</xs:complexType>

--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -1686,6 +1686,17 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="HPWHOperatingMode" type="HPWHOperatingMode"/>
+									<xs:element minOccurs="0" name="HPWHDucting">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element minOccurs="1" name="HasSupplyDucting" type="HPXMLBoolean"/>
+												<xs:element minOccurs="1" name="HasExhaustDucting" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="SupplyDuctingLocation" type="AdjacentTo"/>
+												<xs:element minOccurs="0" name="ExhaustDuctingLocation" type="AdjacentTo"/>
+												<xs:element ref="extension" minOccurs="0"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
 									<xs:element minOccurs="0" name="FirstHourRating" type="Volume">
 										<xs:annotation>
 											<xs:documentation>[gal per hour] An estimate of the maximum volume of hot water in gallons that a storage water heater can supply within an hour that begins

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -1675,8 +1675,6 @@
 									<xs:element minOccurs="0" name="HPWHDucting">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="1" name="HasSupplyDucting" type="HPXMLBoolean"/>
-												<xs:element minOccurs="1" name="HasExhaustDucting" type="HPXMLBoolean"/>
 												<xs:element minOccurs="0" name="SupplyDuctingLocation" type="AdjacentTo"/>
 												<xs:element minOccurs="0" name="ExhaustDuctingLocation" type="AdjacentTo"/>
 												<xs:element ref="extension" minOccurs="0"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -1675,8 +1675,16 @@
 									<xs:element minOccurs="0" name="HPWHDucting">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="SupplyDuctingLocation" type="AdjacentTo"/>
-												<xs:element minOccurs="0" name="ExhaustDuctingLocation" type="AdjacentTo"/>
+												<xs:element minOccurs="0" name="SupplyAirSource" type="AdjacentTo">
+													<xs:annotation>
+														<xs:documentation>Where the air is supplied from; not the location where the supply ducts are running through.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="ExhaustAirDestination" type="AdjacentTo">
+													<xs:annotation>
+														<xs:documentation>Where the air is exhausted to; not the location where the exhaust ducts are running through.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
 												<xs:element ref="extension" minOccurs="0"/>
 											</xs:sequence>
 										</xs:complexType>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -1680,7 +1680,7 @@
 														<xs:documentation>Where the air is supplied from; not the location where the supply ducts are running through.</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="ExhaustAirDestination" type="AdjacentTo">
+												<xs:element minOccurs="0" name="ExhaustAirTermination" type="AdjacentTo">
 													<xs:annotation>
 														<xs:documentation>Where the air is exhausted to; not the location where the exhaust ducts are running through.</xs:documentation>
 													</xs:annotation>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -1672,6 +1672,17 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="HPWHOperatingMode" type="HPWHOperatingMode"/>
+									<xs:element minOccurs="0" name="HPWHDucting">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element minOccurs="1" name="HasSupplyDucting" type="HPXMLBoolean"/>
+												<xs:element minOccurs="1" name="HasExhaustDucting" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="SupplyDuctingLocation" type="AdjacentTo"/>
+												<xs:element minOccurs="0" name="ExhaustDuctingLocation" type="AdjacentTo"/>
+												<xs:element ref="extension" minOccurs="0"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
 									<xs:element minOccurs="0" name="FirstHourRating" type="Volume">
 										<xs:annotation>
 											<xs:documentation>[gal per hour] An estimate of the maximum volume of hot water in gallons that a storage water heater can supply within an hour that begins


### PR DESCRIPTION
Closes #363.

![image](https://github.com/hpxmlwg/hpxml/assets/5861765/12482775-209c-47a6-8eb3-5561cb3093e4)

Choices are the same as what's used for surface `AdjacentTo` elements:


    attic
    attic - conditioned
    attic - unconditioned
    attic - unvented
    attic - vented
    basement
    basement - conditioned
    basement - unconditioned
    conditioned space
    crawlspace
    crawlspace - conditioned
    crawlspace - unconditioned
    crawlspace - unvented
    crawlspace - vented
    garage
    garage - conditioned
    garage - unconditioned
    ground
    living space
    other
    other housing unit
    other housing unit above
    other housing unit below
    outside
    unconditioned space
