### PR TITLE
Add Walkout basement element

### DIFF
--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -5233,7 +5233,11 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" name="Finished" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
-						<xs:element minOccurs="0" name="Walkout" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="Walkout" type="HPXMLBoolean">
+							<xs:annotation>
+								<xs:documentation>A partially underground basement that has a door directly to the outside, typically built on a sloping lot.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -5261,7 +5265,6 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
-						<xs:element minOccurs="0" name="Walkout" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>

--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -5189,6 +5189,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" name="Finished" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="Walkout" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -5216,6 +5217,7 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="Walkout" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>

--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -5266,7 +5266,7 @@
 						<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="Walkout" type="HPXMLBoolean">
 							<xs:annotation>
-								<xs:documentation>A partially underground basement that has a door directly to the outside, typically built on a sloping lot.</xs:documentation>
+								<xs:documentation>A partially underground basement that has a door directly on grade to the outside, typically built on a sloping lot.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -5175,6 +5175,7 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" name="Finished" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="Walkout" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -5202,6 +5203,7 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="Walkout" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -5219,7 +5219,11 @@
 					<xs:sequence>
 						<xs:element minOccurs="0" name="Finished" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
-						<xs:element minOccurs="0" name="Walkout" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="Walkout" type="HPXMLBoolean">
+							<xs:annotation>
+								<xs:documentation>A partially underground basement that has a door directly to the outside, typically built on a sloping lot.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -5247,7 +5251,6 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
-						<xs:element minOccurs="0" name="Walkout" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -5252,7 +5252,7 @@
 						<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="Walkout" type="HPXMLBoolean">
 							<xs:annotation>
-								<xs:documentation>A partially underground basement that has a door directly to the outside, typically built on a sloping lot.</xs:documentation>
+								<xs:documentation>A partially underground basement that has a door directly on grade to the outside, typically built on a sloping lot.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element minOccurs="0" ref="extension"/>


### PR DESCRIPTION
Adds a `Walkout` boolean element for the basement foundation type.

![image](https://github.com/hpxmlwg/hpxml/assets/5861765/32b5a562-e53a-4184-ab6a-fd13afa60d35)



