### PR TITLE
Remove redundant datatypes

### DIFF
--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -1425,12 +1425,12 @@
 											<xs:documentation>[sq.ft.] Conditioned floor area that this distribution system serves.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AnnualHeatingDistributionSystemEfficiency" type="HPXMLFractionExcludingZero">
+									<xs:element minOccurs="0" name="AnnualHeatingDistributionSystemEfficiency" type="HPXMLFractionGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for heating, the DSE may be approximated by equation 3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use History. Enter values as a fractional number between 0 and 1, i.e. 80% = 0.8</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AnnualCoolingDistributionSystemEfficiency" type="HPXMLFractionExcludingZero">
+									<xs:element minOccurs="0" name="AnnualCoolingDistributionSystemEfficiency" type="HPXMLFractionGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for cooling, the DSE may be approximated by equation 3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use History. Enter values as a fractional number between 0 and 1, i.e. 80% = 0.8</xs:documentation>
 										</xs:annotation>
@@ -1556,7 +1556,7 @@
 														<xs:documentation>[sones] as tested in field</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="TotalRecoveryEfficiency" type="HPXMLFractionExcludingZero">
+												<xs:element minOccurs="0" name="TotalRecoveryEfficiency" type="HPXMLFractionGreaterThanZero">
 													<xs:annotation>
 														<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by electric
 															consumption, case heat loss or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential
@@ -1564,7 +1564,7 @@
 															(hvi.org).</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="SensibleRecoveryEfficiency" type="HPXMLFractionExcludingZero">
+												<xs:element minOccurs="0" name="SensibleRecoveryEfficiency" type="HPXMLFractionGreaterThanZero">
 													<xs:annotation>
 														<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by electric consumption, case heat loss or heat gain,
 															air leakage, airflow mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test),
@@ -1572,7 +1572,7 @@
 															the Home Ventilating Institute (hvi.org).</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="AdjustedTotalRecoveryEfficiency" type="HPXMLFractionExcludingZero">
+												<xs:element minOccurs="0" name="AdjustedTotalRecoveryEfficiency" type="HPXMLFractionGreaterThanZero">
 													<xs:annotation>
 														<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by case heat loss
 															or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential total energy that could be
@@ -1581,7 +1581,7 @@
 															Ventilating Institute (hvi.org).</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="AdjustedSensibleRecoveryEfficiency" type="HPXMLFractionExcludingZero">
+												<xs:element minOccurs="0" name="AdjustedSensibleRecoveryEfficiency" type="HPXMLFractionGreaterThanZero">
 													<xs:annotation>
 														<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by case heat loss or heat gain, air leakage, airflow
 															mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test), as a percent of the
@@ -1744,7 +1744,7 @@
 												DOE testing procedure.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ThermalEfficiency" type="HPXMLFractionExcludingZero" minOccurs="0"/>
+									<xs:element name="ThermalEfficiency" type="HPXMLFractionGreaterThanZero" minOccurs="0"/>
 									<xs:element minOccurs="0" name="WaterHeaterInsulation">
 										<xs:complexType>
 											<xs:sequence>
@@ -1909,7 +1909,7 @@
 											<xs:sequence>
 												<xs:element minOccurs="0" name="FacilitiesConnected" type="DrainWaterHeatRecoveryFacilitiesConnected"/>
 												<xs:element minOccurs="0" name="EqualFlow" type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="Efficiency" type="HPXMLFractionExcludingZero">
+												<xs:element minOccurs="0" name="Efficiency" type="HPXMLFractionGreaterThanZero">
 													<xs:annotation>
 														<xs:documentation>Efficiency percent expressed as a fraction from 0-1.</xs:documentation>
 													</xs:annotation>
@@ -2030,7 +2030,7 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="ConnectedTo" type="LocalReference"/>
-									<xs:element minOccurs="0" name="SolarFraction" type="HPXMLFractionExcludingZero">
+									<xs:element minOccurs="0" name="SolarFraction" type="HPXMLFractionGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>The Solar Fraction is the portion of the total conventional hot water heating load (delivered energy and tank standby losses). The higher
 												the solar fraction, the greater the solar contribution to water heating, which reduces the energy required by the backup water heater. This value can be
@@ -2124,7 +2124,7 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" name="InverterType" type="InverterType"/>
-									<xs:element minOccurs="0" name="InverterEfficiency" type="HPXMLFractionExcludingZero"/>
+									<xs:element minOccurs="0" name="InverterEfficiency" type="HPXMLFractionGreaterThanZero"/>
 									<xs:element minOccurs="0" name="YearInverterManufactured" type="HPXMLInteger"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="HPXMLInteger"/>
 									<xs:element ref="extension" minOccurs="0"/>
@@ -2186,7 +2186,7 @@
 												with a 0.2C discharge current.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RoundTripEfficiency" type="HPXMLFractionExcludingZero">
+									<xs:element minOccurs="0" name="RoundTripEfficiency" type="HPXMLFractionGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Not all the power that is used to charge the battery is available during discharge. Round trip efficiency is the ratio of the energy put
 												in to the energy retrieved from storage.</xs:documentation>
@@ -6202,7 +6202,7 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="HPXMLFractionExcludingZero_simple">
+	<xs:simpleType name="HPXMLFractionGreaterThanZero_simple">
 		<xs:annotation>
 			<xs:documentation>A fraction that has to be between 0 exclusive and 1 inclusive</xs:documentation>
 		</xs:annotation>
@@ -6211,9 +6211,9 @@
 			<xs:maxInclusive value="1"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:complexType name="HPXMLFractionExcludingZero">
+	<xs:complexType name="HPXMLFractionGreaterThanZero">
 		<xs:simpleContent>
-			<xs:extension base="HPXMLFractionExcludingZero_simple">
+			<xs:extension base="HPXMLFractionGreaterThanZero_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>

--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -21,9 +21,9 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="XMLType" type="XMLType"/>
-				<xs:element name="XMLGeneratedBy" type="XMLGeneratedBy"/>
-				<xs:element name="CreatedDateAndTime" type="CreatedDateAndTime"/>
+				<xs:element name="XMLType" type="HPXMLString"/>
+				<xs:element name="XMLGeneratedBy" type="HPXMLString"/>
+				<xs:element name="CreatedDateAndTime" type="HPXMLDateTime"/>
 				<xs:element name="Transaction" type="TransactionType"/>
 				<xs:element minOccurs="0" ref="extension"/>
 			</xs:sequence>
@@ -39,9 +39,9 @@
 			<xs:element name="Address1" type="HPXMLString" minOccurs="0"/>
 			<xs:element name="Address2" type="HPXMLString" minOccurs="0"/>
 			<xs:element name="CityMunicipality" type="HPXMLString" minOccurs="0"/>
-			<xs:element name="StateCode" type="StateCode" minOccurs="0"/>
+			<xs:element name="StateCode" type="HPXMLString" minOccurs="0"/>
 			<xs:element name="ZipCode" type="ZipCode" minOccurs="0"/>
-			<xs:element name="USPSBarCode" type="USPSBarCode" minOccurs="0"/>
+			<xs:element name="USPSBarCode" type="HPXMLString" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -78,10 +78,10 @@
 				systems, and have it identified in the two systems. Also, there is an id attribute to define a local id to be used internally. </xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType" minOccurs="0"/>
-			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue" minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType" minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue" minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierType" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierValue" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierType" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierValue" type="HPXMLString" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="id" type="xs:ID" use="required">
 			<xs:annotation>
@@ -105,10 +105,10 @@
 				elements in other xml transactions.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType" minOccurs="0"/>
-			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue" minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType" minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue" minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierType" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierValue" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierType" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierValue" type="HPXMLString" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="idref" type="xs:IDREF">
 			<xs:annotation>
@@ -156,11 +156,11 @@
 			<xs:element name="Name">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="PrefixName" type="PrefixName" minOccurs="0"/>
+						<xs:element name="PrefixName" type="HPXMLString" minOccurs="0"/>
 						<xs:element name="FirstName" type="HPXMLString"/>
 						<xs:element name="MiddleName" type="HPXMLString" minOccurs="0"/>
 						<xs:element name="LastName" type="HPXMLString"/>
-						<xs:element name="SuffixName" type="SuffixName" minOccurs="0"/>
+						<xs:element name="SuffixName" type="HPXMLString" minOccurs="0"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -229,7 +229,7 @@
 			<xs:group ref="SystemInfo"/>
 			<xs:element minOccurs="0" name="InsulationGrade" type="InsulationGrade"/>
 			<xs:element minOccurs="0" name="InsulationCondition" type="InsulationCondition"/>
-			<xs:element minOccurs="0" name="AssemblyEffectiveRValue" type="AssemblyRValue">
+			<xs:element minOccurs="0" name="AssemblyEffectiveRValue" type="HPXMLDoubleGreaterThanZero">
 				<xs:annotation>
 					<xs:documentation>This should indicate the effective R-value of the complete assembly including any air films or other treatments. For below-grade surfaces adjacent to ground, it should not include the insulating effect of the ground.</xs:documentation>
 				</xs:annotation>
@@ -282,8 +282,8 @@
 		<xs:sequence>
 			<xs:element name="InstallationType" type="InstallationType" minOccurs="0"/>
 			<xs:element name="InsulationMaterial" type="InsulationMaterial" minOccurs="0"/>
-			<xs:element name="NominalRValue" type="RValue" minOccurs="0"/>
-			<xs:element name="Thickness" type="LengthMeasurement" minOccurs="0">
+			<xs:element name="NominalRValue" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0"/>
+			<xs:element name="Thickness" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[in]</xs:documentation>
 				</xs:annotation>
@@ -304,12 +304,12 @@
 		<xs:complexContent>
 			<xs:extension base="InsulationLayerInfoBase">
 				<xs:sequence>
-					<xs:element name="DistanceToTopOfInsulation" type="LengthMeasurement" minOccurs="0">
+					<xs:element name="DistanceToTopOfInsulation" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>[ft] Vertical distance from top of foundation wall to top of insulation.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="DistanceToBottomOfInsulation" type="LengthMeasurement" minOccurs="0">
+					<xs:element name="DistanceToBottomOfInsulation" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>[ft] Vertical distance from top of foundation wall to bottom of insulation.</xs:documentation>
 						</xs:annotation>
@@ -323,7 +323,7 @@
 		<xs:complexContent>
 			<xs:extension base="InsulationLayerInfoBase">
 				<xs:sequence>
-					<xs:element name="InsulationDepth" type="LengthMeasurement" minOccurs="0">
+					<xs:element name="InsulationDepth" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>[ft] Depth from top of slab to bottom of vertical slab perimeter insulation</xs:documentation>
 						</xs:annotation>
@@ -337,7 +337,7 @@
 		<xs:complexContent>
 			<xs:extension base="InsulationLayerInfoBase">
 				<xs:sequence>
-					<xs:element name="InsulationWidth" type="LengthMeasurement" minOccurs="0">
+					<xs:element name="InsulationWidth" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>[ft] Width from slab edge inward of horizontal under-slab insulation</xs:documentation>
 						</xs:annotation>
@@ -355,7 +355,7 @@
 	<xs:complexType name="InteriorFinishInfo">
 		<xs:sequence>
 			<xs:element minOccurs="0" name="Type" type="InteriorFinish"/>
-			<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+			<xs:element minOccurs="0" name="Thickness" type="HPXMLDoubleGreaterThanOrEqualToZero">
 				<xs:annotation>
 					<xs:documentation>[in]</xs:documentation>
 				</xs:annotation>
@@ -373,12 +373,12 @@
 			<xs:group ref="SystemInfo"/>
 			<xs:element minOccurs="0" ref="ConnectedDevice"/>
 			<xs:element minOccurs="0" ref="AttachedToSpace"/>
-			<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
-			<xs:element name="Manufacturer" type="Manufacturer" minOccurs="0"/>
-			<xs:element name="ModelNumber" type="Model" minOccurs="0"/>
+			<xs:element name="Count" type="HPXMLIntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+			<xs:element name="Manufacturer" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="ModelNumber" type="HPXMLString" minOccurs="0"/>
 			<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
-			<xs:element name="ModelYear" type="Year" minOccurs="0"/>
+			<xs:element name="ModelYear" type="HPXMLInteger" minOccurs="0"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="ApplianceThirdPartyCertifications"/>
 			<xs:element minOccurs="0" name="IsSharedAppliance" type="HPXMLBoolean">
 				<xs:annotation>
@@ -415,7 +415,7 @@
 					</xs:element>
 					<xs:element maxOccurs="unbounded" minOccurs="0" name="ControlType" type="ClothesDryerControlType"/>
 					<xs:element minOccurs="0" name="Vented" type="HPXMLBoolean"/>
-					<xs:element minOccurs="0" name="VentedFlowRate" type="FlowRate"/>
+					<xs:element minOccurs="0" name="VentedFlowRate" type="HPXMLDoubleGreaterThanOrEqualToZero"/>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -458,7 +458,7 @@
 							<xs:documentation>loads/week of actual usage by the occupants; use LabelUsage instead for the loads/week on the EnergyGuide label</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="RatedAnnualkWh" type="RatedAnnualkWh">
+					<xs:element minOccurs="0" name="RatedAnnualkWh" type="HPXMLDoubleGreaterThanZero">
 						<xs:annotation>
 							<xs:documentation>kWh/yr</xs:documentation>
 						</xs:annotation>
@@ -506,10 +506,10 @@
 					<xs:element minOccurs="0" name="Fuel" type="FuelType"/>
 					<xs:element name="HeatDryDefaultOff" type="HPXMLBoolean" minOccurs="0"/>
 					<xs:element name="AuxillaryWaterHeaterDefaultOff" type="HPXMLBoolean" minOccurs="0"/>
-					<xs:element minOccurs="0" name="RatedAnnualkWh" type="RatedAnnualkWh"/>
+					<xs:element minOccurs="0" name="RatedAnnualkWh" type="HPXMLDoubleGreaterThanZero"/>
 					<xs:element minOccurs="0" name="EnergyFactor" type="EnergyFactor"/>
-					<xs:element minOccurs="0" name="RatedWaterGalPerCycle" type="RatedWaterGalPerCycle"/>
-					<xs:element minOccurs="0" name="PlaceSettingCapacity" type="IntegerGreaterThanZero"/>
+					<xs:element minOccurs="0" name="RatedWaterGalPerCycle" type="HPXMLDoubleGreaterThanZero"/>
+					<xs:element minOccurs="0" name="PlaceSettingCapacity" type="HPXMLIntegerGreaterThanZero"/>
 					<xs:element minOccurs="0" name="Usage" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>loads/week of actual usage by the occupants; use LabelUsage instead for the loads/week on the EnergyGuide label</xs:documentation>
@@ -545,9 +545,9 @@
 			<xs:extension base="ApplianceTypeSummaryInfo">
 				<xs:sequence>
 					<xs:element minOccurs="0" name="Location" type="RefrigeratorLocation"/>
-					<xs:element name="RatedAnnualkWh" type="RatedAnnualkWh" minOccurs="0"/>
+					<xs:element name="RatedAnnualkWh" type="HPXMLDoubleGreaterThanZero" minOccurs="0"/>
 					<xs:element name="Configuration" type="FreezerStyle" minOccurs="0"/>
-					<xs:element name="Volume" type="Volume" minOccurs="0">
+					<xs:element name="Volume" type="HPXMLDoubleGreaterThanZero" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>[cu.ft.]</xs:documentation>
 						</xs:annotation>
@@ -563,23 +563,23 @@
 				<xs:sequence>
 					<xs:element name="Type" type="RefrigeratorStyle" minOccurs="0"/>
 					<xs:element minOccurs="0" name="Location" type="RefrigeratorLocation"/>
-					<xs:element name="RatedAnnualkWh" type="RatedAnnualkWh" minOccurs="0"/>
+					<xs:element name="RatedAnnualkWh" type="HPXMLDoubleGreaterThanZero" minOccurs="0"/>
 					<xs:element name="PrimaryIndicator" type="HPXMLBoolean" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>True if it is the primary refrigerator</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="Volume" type="Volume" minOccurs="0">
+					<xs:element name="Volume" type="HPXMLDoubleGreaterThanZero" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>[cu.ft.]</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="FreshVolume" type="Volume">
+					<xs:element minOccurs="0" name="FreshVolume" type="HPXMLDoubleGreaterThanZero">
 						<xs:annotation>
 							<xs:documentation>[cu.ft.] Volume of refrigerator for keeping food at less than freezing.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="FrozenVolume" type="Volume">
+					<xs:element minOccurs="0" name="FrozenVolume" type="HPXMLDoubleGreaterThanZero">
 						<xs:annotation>
 							<xs:documentation>[cu.ft.] Freezer Volume</xs:documentation>
 						</xs:annotation>
@@ -619,7 +619,7 @@
 							<xs:documentation>The rated efficiency of the dehumidifier in liters of water removed per kilowatt-hour of energy consumed. The IEF is a new metric used for dehumidifiers as of 2019 that incorporates energy consumed when the fan is running while the refrigeration system is off and standby power consumption, in addition to the energy consumed by the refrigeration system. [L/kWh]</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="DehumidistatSetpoint" type="Fraction">
+					<xs:element minOccurs="0" name="DehumidistatSetpoint" type="HPXMLFractionInclusive">
 						<xs:annotation>
 							<xs:documentation>Enter the setpoint as a fractional number between 0 and 1, i.e. 60% RH = 0.6.</xs:documentation>
 						</xs:annotation>
@@ -639,7 +639,7 @@
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
-					<xs:element minOccurs="0" name="FractionDehumidificationLoadServed" type="Fraction"/>
+					<xs:element minOccurs="0" name="FractionDehumidificationLoadServed" type="HPXMLFractionInclusive"/>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -672,8 +672,8 @@
 	<xs:element name="SoftwareInfo">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="SoftwareProgramUsed" type="SoftwareProgramUsed" minOccurs="0"/>
-				<xs:element name="SoftwareProgramVersion" type="SoftwareProgramVersion" minOccurs="0"/>
+				<xs:element name="SoftwareProgramUsed" type="HPXMLString" minOccurs="0"/>
+				<xs:element name="SoftwareProgramVersion" type="HPXMLString" minOccurs="0"/>
 				<xs:element ref="extension" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attribute name="dataSource" type="DataSource"/>
@@ -693,8 +693,8 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element minOccurs="0" name="Qualification" type="AuditorQualification" maxOccurs="unbounded"/>
-						<xs:element minOccurs="0" name="StateWhereQualificationHeld" type="StateCode"/>
-						<xs:element minOccurs="0" name="YearsExperience" type="IntegerGreaterThanOrEqualToZero"/>
+						<xs:element minOccurs="0" name="StateWhereQualificationHeld" type="HPXMLString"/>
+						<xs:element minOccurs="0" name="YearsExperience" type="HPXMLIntegerGreaterThanOrEqualToZero"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -704,7 +704,7 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element maxOccurs="unbounded" minOccurs="0" name="Qualification" type="ImplementerQualification"/>
-						<xs:element minOccurs="0" name="StateWhereQualificationHeld" type="StateCode"/>
+						<xs:element minOccurs="0" name="StateWhereQualificationHeld" type="HPXMLString"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -740,18 +740,18 @@
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element name="SpaceName" type="HPXMLString" minOccurs="0"/>
-						<xs:element minOccurs="0" name="NumberOfBedrooms" type="IntegerGreaterThanOrEqualToZero"/>
-						<xs:element minOccurs="0" name="FloorArea" type="SurfaceArea">
+						<xs:element minOccurs="0" name="NumberOfBedrooms" type="HPXMLIntegerGreaterThanOrEqualToZero"/>
+						<xs:element minOccurs="0" name="FloorArea" type="HPXMLDoubleGreaterThanZero">
 							<xs:annotation>
 								<xs:documentation>[sq.ft.]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="Volume" type="Volume">
+						<xs:element minOccurs="0" name="Volume" type="HPXMLDoubleGreaterThanZero">
 							<xs:annotation>
 								<xs:documentation>[cu.ft.]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="CeilingHeight" type="LengthMeasurement">
+						<xs:element minOccurs="0" name="CeilingHeight" type="HPXMLDoubleGreaterThanOrEqualToZero">
 							<xs:annotation>
 								<xs:documentation>[ft]</xs:documentation>
 							</xs:annotation>
@@ -791,7 +791,7 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element name="Hours" type="Hours" minOccurs="0"/>
+									<xs:element name="Hours" type="HPXMLInteger" minOccurs="0"/>
 									<xs:element minOccurs="0" name="ComponentsAirSealed">
 										<xs:complexType>
 											<xs:sequence>
@@ -962,7 +962,7 @@
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
 									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
-									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
+									<xs:element minOccurs="0" name="Area" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Surface area of the roof itself</xs:documentation>
 										</xs:annotation>
@@ -975,12 +975,12 @@
 									</xs:element>
 									<xs:element minOccurs="0" name="RoofType" type="RoofType"/>
 									<xs:element minOccurs="0" name="RoofColor" type="WallAndRoofColor"/>
-									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
-									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
+									<xs:element minOccurs="0" name="SolarAbsorptance" type="HPXMLFractionInclusive"/>
+									<xs:element minOccurs="0" name="Emittance" type="HPXMLFractionInclusive"/>
 									<xs:element minOccurs="0" name="InteriorFinish" type="InteriorFinishInfo"/>
 									<xs:element minOccurs="0" name="Rafters" type="StudProperties"/>
 									<xs:element minOccurs="0" name="DeckType" type="DeckType"/>
-									<xs:element minOccurs="0" name="Pitch" type="Pitch">
+									<xs:element minOccurs="0" name="Pitch" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>Pitch of roof ?/12</xs:documentation>
 										</xs:annotation>
@@ -1008,7 +1008,7 @@
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
 									<xs:element minOccurs="0" name="ExteriorAdjacentTo" type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
-									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
+									<xs:element minOccurs="0" name="Area" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
@@ -1019,15 +1019,15 @@
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Perimeter" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Perimeter" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[ft]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="Siding" type="Siding"/>
 									<xs:element minOccurs="0" name="Color" type="WallAndRoofColor"/>
-									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
-									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
+									<xs:element minOccurs="0" name="SolarAbsorptance" type="HPXMLFractionInclusive"/>
+									<xs:element minOccurs="0" name="Emittance" type="HPXMLFractionInclusive"/>
 									<xs:element minOccurs="0" name="Insulation" type="InsulationInfo"/>
 									<xs:element minOccurs="0" name="FloorJoists" type="StudProperties"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
@@ -1059,12 +1059,12 @@
 									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="AtticWallType" type="AtticWallType"/>
 									<xs:element name="WallType" type="WallType" minOccurs="0"/>
-									<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Thickness" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[in] Thickness of the entire wall assembly, including any siding, sheathing, continuous insulation, and interior finish.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
+									<xs:element minOccurs="0" name="Area" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Gross wall area</xs:documentation>
 										</xs:annotation>
@@ -1078,8 +1078,8 @@
 									<xs:element minOccurs="0" name="Studs" type="StudProperties"/>
 									<xs:element minOccurs="0" name="Siding" type="Siding"/>
 									<xs:element minOccurs="0" name="Color" type="WallAndRoofColor"/>
-									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
-									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
+									<xs:element minOccurs="0" name="SolarAbsorptance" type="HPXMLFractionInclusive"/>
+									<xs:element minOccurs="0" name="Emittance" type="HPXMLFractionInclusive"/>
 									<xs:element minOccurs="0" name="InteriorFinish" type="InteriorFinishInfo"/>
 									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
@@ -1110,17 +1110,17 @@
 									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo" minOccurs="0"/>
 									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="Type" type="FoundationWallType"/>
-									<xs:element minOccurs="0" name="Length" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Length" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[ft] Total length of foundation wall</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Height" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Height" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[ft] Total height in feet of foundation wall</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
+									<xs:element minOccurs="0" name="Area" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
@@ -1131,12 +1131,12 @@
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Thickness" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[in] Thickness of the foundation wall structural element (e.g., concrete), excluding any interior framing and continuous insulation.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="DepthBelowGrade" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="DepthBelowGrade" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[ft] Depth below grade of foundation wall</xs:documentation>
 										</xs:annotation>
@@ -1181,7 +1181,7 @@
 									<xs:element minOccurs="0" name="FloorJoists" type="StudProperties"/>
 									<xs:element minOccurs="0" name="FloorTrusses" type="StudProperties"/>
 									<xs:element minOccurs="0" name="FloorCovering" type="FloorCovering"/>
-									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
+									<xs:element minOccurs="0" name="Area" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
@@ -1209,32 +1209,32 @@
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
 									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
-									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
+									<xs:element minOccurs="0" name="Area" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Area of the slab</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Thickness" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[in] Thickness of the foundation slab structural element (e.g., concrete), excluding any floor coverings and continuous insulation.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Perimeter" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Perimeter" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[ft] Length of slab perimeter.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="ExposedPerimeter" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="ExposedPerimeter" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[ft] Perimeter of the slab exposed to ambient conditions</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="OnGradeExposedPerimeter" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="OnGradeExposedPerimeter" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[ft] Perimeter of slab measured in feet that is on-grade (2 ft. below grade or less) and exposed to ambient conditions.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="DepthBelowGrade" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="DepthBelowGrade" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[ft] Depth from the top of the slab surface to grade</xs:documentation>
 										</xs:annotation>
@@ -1263,7 +1263,7 @@
 								<xs:sequence>
 									<xs:group ref="WindowInfo"/>
 									<xs:element minOccurs="0" name="WindowType" type="WindowType"/>
-									<xs:element minOccurs="0" name="WindowtoWallRatio" type="Fraction"/>
+									<xs:element minOccurs="0" name="WindowtoWallRatio" type="HPXMLFractionInclusive"/>
 									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
@@ -1294,7 +1294,7 @@
 								<xs:sequence>
 									<xs:group ref="WindowInfo"/>
 									<xs:element minOccurs="0" name="SolarTube" type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="Pitch" type="Pitch">
+									<xs:element minOccurs="0" name="Pitch" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>Pitch of skylight ?/12</xs:documentation>
 										</xs:annotation>
@@ -1330,8 +1330,8 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference"/>
-									<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero"/>
-									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
+									<xs:element minOccurs="0" name="Count" type="HPXMLIntegerGreaterThanZero"/>
+									<xs:element minOccurs="0" name="Area" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Total door surface area for this group of doors</xs:documentation>
 										</xs:annotation>
@@ -1346,7 +1346,7 @@
 									<xs:element name="DoorMaterial" type="DoorMaterial" minOccurs="0"/>
 									<xs:element minOccurs="0" name="WeatherStripping" type="HPXMLBoolean"/>
 									<xs:element name="StormDoor" type="HPXMLBoolean" minOccurs="0"/>
-									<xs:element name="RValue" type="RValue" minOccurs="0"/>
+									<xs:element name="RValue" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0"/>
 									<xs:element minOccurs="0" name="LeakinessDescription" type="BuildingLeakiness"/>
 									<xs:element minOccurs="0" name="PerformanceClass" type="PerformanceClass"/>
 									<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="DoorThirdPartyCertifications"/>
@@ -1420,17 +1420,17 @@
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="ConditionedFloorAreaServed" type="SurfaceArea">
+									<xs:element minOccurs="0" name="ConditionedFloorAreaServed" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Conditioned floor area that this distribution system serves.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AnnualHeatingDistributionSystemEfficiency" type="FractionExcludingZero">
+									<xs:element minOccurs="0" name="AnnualHeatingDistributionSystemEfficiency" type="HPXMLFractionExcludingZero">
 										<xs:annotation>
 											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for heating, the DSE may be approximated by equation 3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use History. Enter values as a fractional number between 0 and 1, i.e. 80% = 0.8</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AnnualCoolingDistributionSystemEfficiency" type="FractionExcludingZero">
+									<xs:element minOccurs="0" name="AnnualCoolingDistributionSystemEfficiency" type="HPXMLFractionExcludingZero">
 										<xs:annotation>
 											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for cooling, the DSE may be approximated by equation 3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use History. Enter values as a fractional number between 0 and 1, i.e. 80% = 0.8</xs:documentation>
 										</xs:annotation>
@@ -1477,7 +1477,7 @@
 												<xs:element minOccurs="0" ref="ConnectedDevice"/>
 												<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
 												<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
-												<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero">
+												<xs:element minOccurs="0" name="Count" type="HPXMLIntegerGreaterThanZero">
 													<xs:annotation>
 														<xs:documentation>Number of similar ventilation fans (e.g., bath fans).</xs:documentation>
 													</xs:annotation>
@@ -1556,7 +1556,7 @@
 														<xs:documentation>[sones] as tested in field</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="TotalRecoveryEfficiency" type="FractionExcludingZero">
+												<xs:element minOccurs="0" name="TotalRecoveryEfficiency" type="HPXMLFractionExcludingZero">
 													<xs:annotation>
 														<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by electric
 															consumption, case heat loss or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential
@@ -1564,7 +1564,7 @@
 															(hvi.org).</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="SensibleRecoveryEfficiency" type="FractionExcludingZero">
+												<xs:element minOccurs="0" name="SensibleRecoveryEfficiency" type="HPXMLFractionExcludingZero">
 													<xs:annotation>
 														<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by electric consumption, case heat loss or heat gain,
 															air leakage, airflow mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test),
@@ -1572,7 +1572,7 @@
 															the Home Ventilating Institute (hvi.org).</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="AdjustedTotalRecoveryEfficiency" type="FractionExcludingZero">
+												<xs:element minOccurs="0" name="AdjustedTotalRecoveryEfficiency" type="HPXMLFractionExcludingZero">
 													<xs:annotation>
 														<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by case heat loss
 															or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential total energy that could be
@@ -1581,7 +1581,7 @@
 															Ventilating Institute (hvi.org).</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="AdjustedSensibleRecoveryEfficiency" type="FractionExcludingZero">
+												<xs:element minOccurs="0" name="AdjustedSensibleRecoveryEfficiency" type="HPXMLFractionExcludingZero">
 													<xs:annotation>
 														<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by case heat loss or heat gain, air leakage, airflow
 															mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test), as a percent of the
@@ -1646,10 +1646,10 @@
 									<xs:element name="FuelType" type="FuelType" minOccurs="0"/>
 									<xs:element name="WaterHeaterType" type="WaterHeaterType" minOccurs="0"/>
 									<xs:element name="Location" type="UnitLocation" minOccurs="0"/>
-									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
-									<xs:element name="ModelYear" type="Year" minOccurs="0"/>
-									<xs:element name="Manufacturer" type="Manufacturer" minOccurs="0"/>
-									<xs:element name="ModelNumber" type="Model" minOccurs="0"/>
+									<xs:element minOccurs="0" name="YearInstalled" type="HPXMLInteger"/>
+									<xs:element name="ModelYear" type="HPXMLInteger" minOccurs="0"/>
+									<xs:element name="Manufacturer" type="HPXMLString" minOccurs="0"/>
+									<xs:element name="ModelNumber" type="HPXMLString" minOccurs="0"/>
 									<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="IsSharedSystem" type="HPXMLBoolean">
@@ -1658,29 +1658,29 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="NumberofUnitsServed" type="HPXMLInteger"/>
-									<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction">
+									<xs:element minOccurs="0" name="PerformanceAdjustment" type="HPXMLFractionInclusive">
 										<xs:annotation>
 											<xs:documentation>A multiplier on the performance of the system. A value of 1 implies no performance adjustment.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="ThirdPartyCertification" type="DHWThirdPartyCertification" maxOccurs="unbounded"/>
-									<xs:element name="TankVolume" type="Volume" minOccurs="0">
+									<xs:element name="TankVolume" type="HPXMLDoubleGreaterThanZero" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[gal] Nominal capacity</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="MeasuredTankVolume" type="Volume" minOccurs="0">
+									<xs:element name="MeasuredTankVolume" type="HPXMLDoubleGreaterThanZero" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[gal] Measured capacity</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FractionDHWLoadServed" type="Fraction"/>
-									<xs:element name="HeatingCapacity" type="Capacity" minOccurs="0">
+									<xs:element minOccurs="0" name="FractionDHWLoadServed" type="HPXMLFractionInclusive"/>
+									<xs:element name="HeatingCapacity" type="HPXMLDouble" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[Btuh] For a heat pump water heater, the capacity of the heat pump.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="BackupHeatingCapacity" type="Capacity" minOccurs="0">
+									<xs:element name="BackupHeatingCapacity" type="HPXMLDouble" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[Btuh] The capacity of the electric resistance heating in a heat pump water heater.</xs:documentation>
 										</xs:annotation>
@@ -1698,7 +1698,7 @@
 												430, Subpart B, Appendix E.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HeatPumpCOP" type="Efficiency">
+									<xs:element minOccurs="0" name="HeatPumpCOP" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>The dimensionless coefficient of performance, used to measure the efficiency of a commercial heat pump water heater.</xs:documentation>
 										</xs:annotation>
@@ -1721,7 +1721,7 @@
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="FirstHourRating" type="Volume">
+									<xs:element minOccurs="0" name="FirstHourRating" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[gal per hour] An estimate of the maximum volume of hot water in gallons that a storage water heater can supply within an hour that begins
 												with the water heater fully heated.</xs:documentation>
@@ -1732,7 +1732,7 @@
 											<xs:documentation>A water heater's usage bin is derived from its First Hour Rating (FHR) as part of the Uniform Energy Factor (UEF) testing procedures.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="GallonsPerMinute" type="Volume">
+									<xs:element minOccurs="0" name="GallonsPerMinute" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[gal per minute] The amount of gallons per minute of hot water that can be supplied by an instantaneous water heater while maintaining a
 												nominal temperature rise of 77&#176;F during steady state operation.</xs:documentation>
@@ -1744,7 +1744,7 @@
 												DOE testing procedure.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ThermalEfficiency" type="ThermalEfficiency" minOccurs="0"/>
+									<xs:element name="ThermalEfficiency" type="HPXMLFractionExcludingZero" minOccurs="0"/>
 									<xs:element minOccurs="0" name="WaterHeaterInsulation">
 										<xs:complexType>
 											<xs:sequence>
@@ -1752,8 +1752,8 @@
 													<xs:complexType>
 														<xs:sequence>
 															<xs:element minOccurs="0" name="InsulationMaterial" type="InsulationMaterial"/>
-															<xs:element name="JacketRValue" type="RValue" minOccurs="0"/>
-															<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+															<xs:element name="JacketRValue" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0"/>
+															<xs:element minOccurs="0" name="Thickness" type="HPXMLDoubleGreaterThanOrEqualToZero">
 																<xs:annotation>
 																	<xs:documentation>[in]</xs:documentation>
 																</xs:annotation>
@@ -1771,8 +1771,8 @@
 													<xs:complexType>
 														<xs:sequence>
 															<xs:element minOccurs="0" name="InsulationMaterial" type="InsulationMaterial"/>
-															<xs:element name="TankWallRValue" type="RValue" minOccurs="0"/>
-															<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+															<xs:element name="TankWallRValue" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0"/>
+															<xs:element minOccurs="0" name="Thickness" type="HPXMLDoubleGreaterThanOrEqualToZero">
 																<xs:annotation>
 																	<xs:documentation>[in]</xs:documentation>
 																</xs:annotation>
@@ -1792,7 +1792,7 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element name="MeetsACCA5QIHVACSpecification" type="HPXMLBoolean" minOccurs="0"/>
-									<xs:element name="HotWaterTemperature" type="Temperature" minOccurs="0">
+									<xs:element name="HotWaterTemperature" type="HPXMLDouble" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg F]</xs:documentation>
 										</xs:annotation>
@@ -1860,7 +1860,7 @@
 												<xs:element name="Standard">
 													<xs:complexType>
 														<xs:sequence>
-															<xs:element minOccurs="0" name="PipingLength" type="LengthMeasurement">
+															<xs:element minOccurs="0" name="PipingLength" type="HPXMLDoubleGreaterThanOrEqualToZero">
 																<xs:annotation>
 																	<xs:documentation>Measured length of hot water piping from the hot water heater to the farthest hot water fixture, measured
 																		longitudinally from plans, assuming the hot water piping does not run diagonally, plus 10 feet of piping for each floor level,
@@ -1876,20 +1876,20 @@
 													<xs:complexType>
 														<xs:sequence>
 															<xs:element minOccurs="0" name="ControlType" type="RecirculationControlType"/>
-															<xs:element minOccurs="0" name="RecirculationPipingLoopLength" type="LengthMeasurement">
+															<xs:element minOccurs="0" name="RecirculationPipingLoopLength" type="HPXMLDoubleGreaterThanOrEqualToZero">
 																<xs:annotation>
 																	<xs:documentation>Hot water recirculation loop piping length including both supply and return sides of the loop, measured
 																		longitudinally from plans, assuming the hot water piping does not run diagonally. [ft]</xs:documentation>
 																</xs:annotation>
 															</xs:element>
-															<xs:element minOccurs="0" name="BranchPipingLength" type="LengthMeasurement">
+															<xs:element minOccurs="0" name="BranchPipingLength" type="HPXMLDoubleGreaterThanOrEqualToZero">
 																<xs:annotation>
 																	<xs:documentation>Length of the branch hot water piping from the recirculation loop to the farthest hot water fixture from the
 																		recirculation loop, measured longitudinally from plans, assuming the branch hot water piping does not run diagonally, plus 20
 																		feet of piping for each floor level greater than one plus 10 feet of piping for unconditioned basements. [ft]</xs:documentation>
 																</xs:annotation>
 															</xs:element>
-															<xs:element minOccurs="0" name="PumpPower" type="Power">
+															<xs:element minOccurs="0" name="PumpPower" type="HPXMLDoubleGreaterThanOrEqualToZero">
 																<xs:annotation>
 																	<xs:documentation>[W]</xs:documentation>
 																</xs:annotation>
@@ -1909,7 +1909,7 @@
 											<xs:sequence>
 												<xs:element minOccurs="0" name="FacilitiesConnected" type="DrainWaterHeatRecoveryFacilitiesConnected"/>
 												<xs:element minOccurs="0" name="EqualFlow" type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="Efficiency" type="FractionExcludingZero">
+												<xs:element minOccurs="0" name="Efficiency" type="HPXMLFractionExcludingZero">
 													<xs:annotation>
 														<xs:documentation>Efficiency percent expressed as a fraction from 0-1.</xs:documentation>
 													</xs:annotation>
@@ -1933,7 +1933,7 @@
 										<xs:element name="AttachedToHotWaterDistribution" type="LocalReference"/>
 									</xs:choice>
 									<xs:element minOccurs="1" name="WaterFixtureType" type="WaterFixtureType"/>
-									<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero">
+									<xs:element minOccurs="0" name="Count" type="HPXMLIntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Number of similar water fixtures.</xs:documentation>
 										</xs:annotation>
@@ -1998,7 +1998,7 @@
 									<xs:element minOccurs="0" name="ModelNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" ref="AttachedToZone"/>
 									<xs:element name="SystemType" minOccurs="0" type="SolarThermalSystemType"/>
-									<xs:element name="CollectorArea" type="SurfaceArea" minOccurs="0">
+									<xs:element name="CollectorArea" type="HPXMLDoubleGreaterThanZero" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
@@ -2012,32 +2012,32 @@
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorRatedOpticalEfficiency" type="CollectorRatedOpticalEfficiency">
+									<xs:element minOccurs="0" name="CollectorRatedOpticalEfficiency" type="HPXMLFractionExclusive">
 										<xs:annotation>
 											<xs:documentation>[Btu/h-ft^2-F] Often referred to as Fr-tau-alpha (FRta), this describes the optical efficiency portion of the overall collector efficiency. 
 												In the OG-100 SRCC Certified Solar Thermal Collector Directory, this is the y-intercept of the efficiency curve.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorRatedThermalLosses" type="CollectorRatedThermalLosses">
+									<xs:element minOccurs="0" name="CollectorRatedThermalLosses" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Often referred to as Fr-Ul (FRUl), this describes the collector thermal losses portion of the overall collector efficiency. In the OG-100
 												SRCC Certified Solar Thermal Collector Directory, this is the slope of the efficiency curve.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="StorageVolume" type="Volume">
+									<xs:element minOccurs="0" name="StorageVolume" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[gal]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="ConnectedTo" type="LocalReference"/>
-									<xs:element minOccurs="0" name="SolarFraction" type="SolarFraction">
+									<xs:element minOccurs="0" name="SolarFraction" type="HPXMLFractionExcludingZero">
 										<xs:annotation>
 											<xs:documentation>The Solar Fraction is the portion of the total conventional hot water heating load (delivered energy and tank standby losses). The higher
 												the solar fraction, the greater the solar contribution to water heating, which reduces the energy required by the backup water heater. This value can be
 												found in the OG-300 SRCC Certified Solar Water Heating System Directory.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="SolarEnergyFactor" type="SolarThermalSystemEnergyFactor">
+									<xs:element minOccurs="0" name="SolarEnergyFactor" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>The Solar Energy Factor is defined as the energy delivered by the system divided by the electrical or gas energy put into the system. The
 												higher the number, the more energy efficient. This value can be found in the OG-300 SRCC Certified Solar Water Heating System
@@ -2082,31 +2082,31 @@
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="MaxPowerOutput" type="Power">
+									<xs:element minOccurs="0" name="MaxPowerOutput" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[DC Watts] Peak power as supplied by the manufacturer</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="CollectorArea" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberOfPanels" type="IntegerGreaterThanZero"/>
-									<xs:element minOccurs="0" name="SystemLossesFraction" type="Fraction">
+									<xs:element minOccurs="0" name="NumberOfPanels" type="HPXMLIntegerGreaterThanZero"/>
+									<xs:element minOccurs="0" name="SystemLossesFraction" type="HPXMLFractionInclusive">
 										<xs:annotation>
 											<xs:documentation>System losses can be due to soiling, shading, snow, mismatch, wiring, electrical connections, light-induced degradation, nameplate rating
 												inaccuracies, age, and availability.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="YearModulesManufactured" type="Year"/>
-									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
-									<xs:element minOccurs="0" name="AnnualOutput" type="RatedAnnualkWh">
+									<xs:element minOccurs="0" name="YearModulesManufactured" type="HPXMLInteger"/>
+									<xs:element minOccurs="0" name="YearInstalled" type="HPXMLInteger"/>
+									<xs:element minOccurs="0" name="AnnualOutput" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[kWh] Projected Annual Output for a typical meteorological year as determined by PVWatts or similar. </xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="LevelizedCostOfElectricity" type="Cost">
+									<xs:element minOccurs="0" name="LevelizedCostOfElectricity" type="HPXMLDecimal">
 										<xs:annotation>
 											<xs:documentation>[$] The LCOE is the total cost of installing and operating a project expressed in dollars per kilowatt-hour of electricity generated by
 												the system over its life. Can be calculated with System Advisor Model, a similar software, or through a simplified calculation at
@@ -2124,9 +2124,9 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" name="InverterType" type="InverterType"/>
-									<xs:element minOccurs="0" name="InverterEfficiency" type="FractionExcludingZero"/>
-									<xs:element minOccurs="0" name="YearInverterManufactured" type="Year"/>
-									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
+									<xs:element minOccurs="0" name="InverterEfficiency" type="HPXMLFractionExcludingZero"/>
+									<xs:element minOccurs="0" name="YearInverterManufactured" type="HPXMLInteger"/>
+									<xs:element minOccurs="0" name="YearInstalled" type="HPXMLInteger"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 							</xs:complexType>
@@ -2142,12 +2142,12 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="Manufacturer" type="Manufacturer"/>
-									<xs:element minOccurs="0" name="ModelNumber" type="Model"/>
+									<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
+									<xs:element minOccurs="0" name="ModelNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
-									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
-									<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero">
+									<xs:element minOccurs="0" name="YearInstalled" type="HPXMLInteger"/>
+									<xs:element minOccurs="0" name="Count" type="HPXMLIntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Number of similar batteries.</xs:documentation>
 										</xs:annotation>
@@ -2170,12 +2170,12 @@
 											<xs:documentation>The stored energy that can actually be used. In most cases usable capacity is less than the nominal capacity.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RatedPowerOutput" type="Power">
+									<xs:element minOccurs="0" name="RatedPowerOutput" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[W] The amount of power the battery typically generates under non-peak conditions.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="PeakPowerOutput" type="Power" minOccurs="0">
+									<xs:element name="PeakPowerOutput" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[W] The peak power that the battery can generate for a short period of time.</xs:documentation>
 										</xs:annotation>
@@ -2186,7 +2186,7 @@
 												with a 0.2C discharge current.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RoundTripEfficiency" type="FractionExcludingZero">
+									<xs:element minOccurs="0" name="RoundTripEfficiency" type="HPXMLFractionExcludingZero">
 										<xs:annotation>
 											<xs:documentation>Not all the power that is used to charge the battery is available during discharge. Round trip efficiency is the ratio of the energy put
 												in to the energy retrieved from storage.</xs:documentation>
@@ -2208,30 +2208,30 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanOrEqualToZero"/>
-									<xs:element minOccurs="0" name="Manufacturer" type="Manufacturer"/>
-									<xs:element maxOccurs="1" minOccurs="0" name="ModelNumber" type="Model"/>
+									<xs:element minOccurs="0" name="Count" type="HPXMLIntegerGreaterThanOrEqualToZero"/>
+									<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
+									<xs:element maxOccurs="1" minOccurs="0" name="ModelNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
 									<xs:element minOccurs="0" name="ChargingLevel" type="EVChargingLevel"/>
 									<xs:element minOccurs="0" name="ChargingConnector" type="EVChargingConnector"/>
-									<xs:element maxOccurs="1" minOccurs="0" name="ModelYear" type="Year"/>
-									<xs:element minOccurs="0" name="ACPowerSourceVoltage" type="Voltage">
+									<xs:element maxOccurs="1" minOccurs="0" name="ModelYear" type="HPXMLInteger"/>
+									<xs:element minOccurs="0" name="ACPowerSourceVoltage" type="HPXMLDecimalGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[V] Voltage of the AC power source</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="Amperage" minOccurs="0" type="Current">
+									<xs:element name="Amperage" minOccurs="0" type="HPXMLDecimalGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[A] Max current to electric vehicle</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="ChargingPower" type="Power">
+									<xs:element minOccurs="0" name="ChargingPower" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[W] Maximum charging rate</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="StandbyPower" type="Power">
+									<xs:element minOccurs="0" name="StandbyPower" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[W] Power used by charger when vehicle is not charging</xs:documentation>
 										</xs:annotation>
@@ -2253,9 +2253,9 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" name="Model" type="HPXMLString"/>
-									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
+									<xs:element minOccurs="0" name="YearInstalled" type="HPXMLInteger"/>
 									<xs:element minOccurs="0" name="ThirdPartyCertification" maxOccurs="unbounded" type="WindThirdPartyCertification"/>
-									<xs:element minOccurs="0" name="AWEARatedAnnualEnergy" type="RatedAnnualkWh">
+									<xs:element minOccurs="0" name="AWEARatedAnnualEnergy" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[kWh] the calculated total energy that would be produced during a one-year period with an average wind speed of 5 m/s (11.2
 												mph)</xs:documentation>
@@ -2267,28 +2267,28 @@
 												wind speed of 5 m/s (11.2 mph). </xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AWEARatedPower" type="Power">
+									<xs:element minOccurs="0" name="AWEARatedPower" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[kW] the wind turbine&#8217;s power output at 11 m/s (24.6 mph). Manufacturers may still describe or name their wind turbine models using a
 												nominal power (e.g. 5 kW S-343).</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="PeakPower" type="Power">
+									<xs:element minOccurs="0" name="PeakPower" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[kW] the highest point on the certified power curve.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RotorDiameter" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="RotorDiameter" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[ft]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HubHeight" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="HubHeight" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[ft]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="LevelizedCostOfElectricity" type="Cost">
+									<xs:element minOccurs="0" name="LevelizedCostOfElectricity" type="HPXMLDecimal">
 										<xs:annotation>
 											<xs:documentation>[$] The LCOE is the total cost of installing and operating a project expressed in dollars per kilowatt-hour of electricity generated by
 												the system over its life. Can be calculated with System Advisor Model, a similar software, or through a simplified calculation at
@@ -2340,7 +2340,7 @@
 						<xs:element minOccurs="0" ref="AttachedToSpace"/>
 						<xs:element minOccurs="0" name="Location" type="LightingLocation"/>
 						<xs:element name="Count" type="HPXMLInteger" minOccurs="0"/>
-						<xs:element minOccurs="0" name="FractionofUnitsInLocation" type="Fraction">
+						<xs:element minOccurs="0" name="FractionofUnitsInLocation" type="HPXMLFractionInclusive">
 							<xs:annotation>
 								<xs:documentation>The fraction of lighting units in the specified Location, where all the fractions for the Location sum to 1. If a Location is not specified, fractions
 									apply to the entire building.</xs:documentation>
@@ -2370,7 +2370,7 @@
 								<xs:documentation>[h]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="FloorAreaServed" type="SurfaceArea">
+						<xs:element minOccurs="0" name="FloorAreaServed" type="HPXMLDoubleGreaterThanZero">
 							<xs:annotation>
 								<xs:documentation>[sq.ft.]</xs:documentation>
 							</xs:annotation>
@@ -2407,7 +2407,7 @@
 						<xs:element minOccurs="0" ref="ConnectedDevice"/>
 						<xs:element minOccurs="0" name="AttachedToLightingGroup" type="LocalReference"/>
 						<xs:element name="LightingControlType" type="LightingControls" minOccurs="0"/>
-						<xs:element name="NumberofLightingControls" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+						<xs:element name="NumberofLightingControls" type="HPXMLIntegerGreaterThanOrEqualToZero" minOccurs="0"/>
 						<xs:element name="Location" type="LightingLocation" minOccurs="0"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
@@ -2431,7 +2431,7 @@
 											<xs:documentation>[CFM]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Efficiency" type="Efficiency">
+									<xs:element minOccurs="0" name="Efficiency" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[CFM/watt] The efficiency rating of a ceiling fan as determined by the test procedure defined by the Environmental Protection Agency's
 												ENERGY STAR Testing Facility Guidance Manual: Building a Testing Facility and Performing the Solid State Test Method for ENERGY STAR Qualified Ceiling
@@ -2443,7 +2443,7 @@
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" name="ThirdPartyCertification" type="ApplianceThirdPartyCertifications" maxOccurs="unbounded"/>
-						<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero">
+						<xs:element minOccurs="0" name="Count" type="HPXMLIntegerGreaterThanZero">
 							<xs:annotation>
 								<xs:documentation>Number of similar ceiling fans.</xs:documentation>
 							</xs:annotation>
@@ -2543,7 +2543,7 @@
 								<xs:documentation>Indicates if the pool is above or below ground.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="Volume" type="Volume">
+						<xs:element minOccurs="0" name="Volume" type="HPXMLDoubleGreaterThanZero">
 							<xs:annotation>
 								<xs:documentation>[gal] Volume of pool.</xs:documentation>
 							</xs:annotation>
@@ -2553,12 +2553,12 @@
 								<xs:documentation>Months per year pool is in operation.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="ReturnPipeDiameter" type="LengthMeasurement">
+						<xs:element minOccurs="0" name="ReturnPipeDiameter" type="HPXMLDoubleGreaterThanOrEqualToZero">
 							<xs:annotation>
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="SuctionPipeDiameter" type="LengthMeasurement">
+						<xs:element minOccurs="0" name="SuctionPipeDiameter" type="HPXMLDoubleGreaterThanOrEqualToZero">
 							<xs:annotation>
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
@@ -2602,7 +2602,7 @@
 															or other)</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="EnergyFactor" type="Efficiency">
+												<xs:element minOccurs="0" name="EnergyFactor" type="HPXMLDoubleGreaterThanZero">
 													<xs:annotation>
 														<xs:documentation>[gal/Wh] The measure of overall pool filter pump efficiency in units of gallons per watt-hour, as determined using the
 															applicable test method in Section 4.1.2. Energy factor is analogous to other energy factors such as miles per gallon. Energy factor (EF) is
@@ -2614,14 +2614,14 @@
 														<xs:documentation>The speed setting at which the Energy Factor was measured (ENERGY STAR, 2013).</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="RatedHorsepower" type="Power">
+												<xs:element minOccurs="0" name="RatedHorsepower" type="HPXMLDoubleGreaterThanOrEqualToZero">
 													<xs:annotation>
 														<xs:documentation>The motor power output designed by the manufacturer for a rated RPM, voltage and frequency. May be less than total horsepower
 															where the service factor is greater than 1.0, or equal to total horsepower where the service factor = 1.0 (ANSI/APSP/ICC-15
 															2011).</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="TotalHorsepower" type="Power">
+												<xs:element minOccurs="0" name="TotalHorsepower" type="HPXMLDoubleGreaterThanOrEqualToZero">
 													<xs:annotation>
 														<xs:documentation>The total horsepower, or product of the rated horsepower and the service factor of a motor used on a pool pump (also known as
 															SFHP) based on the maximum continuous duty motor power output rating allowable for the nameplate ambient rating and motor insulation class
@@ -2639,18 +2639,18 @@
 												<xs:element maxOccurs="unbounded" minOccurs="0" name="PumpSpeed">
 													<xs:complexType>
 														<xs:sequence>
-															<xs:element minOccurs="0" name="Power" type="Power">
+															<xs:element minOccurs="0" name="Power" type="HPXMLDoubleGreaterThanOrEqualToZero">
 																<xs:annotation>
 																	<xs:documentation>[W]</xs:documentation>
 																</xs:annotation>
 															</xs:element>
-															<xs:element minOccurs="0" name="MotorNominalSpeed" type="Speed">
+															<xs:element minOccurs="0" name="MotorNominalSpeed" type="HPXMLDoubleGreaterThanOrEqualToZero">
 																<xs:annotation>
 																	<xs:documentation>[Rev/min] The number of revolutions of the motor shaft in a given unit of time, expressed as revolutions per
 																		minute (RPM) (ENERGY STAR, 2013).</xs:documentation>
 																</xs:annotation>
 															</xs:element>
-															<xs:element minOccurs="0" name="FlowRate" type="FlowRate">
+															<xs:element minOccurs="0" name="FlowRate" type="HPXMLDoubleGreaterThanOrEqualToZero">
 																<xs:annotation>
 																	<xs:documentation>[gal/min] The volume of water flowing through the filtration system in a given time, usually measured in gallons
 																		per minute (gpm) (ANSI/APSP/ICC-15 2011).</xs:documentation>
@@ -2733,7 +2733,7 @@
 						<xs:element minOccurs="0" ref="AttachedToSpace"/>
 						<xs:element name="PlugLoadType" type="PlugLoadType" minOccurs="0"/>
 						<xs:element minOccurs="0" name="Location" type="PlugLoadLocation"/>
-						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+						<xs:element name="Count" type="HPXMLIntegerGreaterThanOrEqualToZero" minOccurs="0"/>
 						<xs:element minOccurs="0" name="Load">
 							<xs:complexType>
 								<xs:sequence>
@@ -2755,7 +2755,7 @@
 						<xs:element minOccurs="0" ref="ConnectedDevice"/>
 						<xs:element minOccurs="0" name="ControlsPlugLoad" type="LocalReference"/>
 						<xs:element minOccurs="0" ref="AttachedToSpace"/>
-						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+						<xs:element name="Count" type="HPXMLIntegerGreaterThanOrEqualToZero" minOccurs="0"/>
 						<xs:element name="PlugLoadControlType" minOccurs="0" type="PlugLoadControlType"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
@@ -2770,7 +2770,7 @@
 						<xs:element minOccurs="0" ref="AttachedToSpace"/>
 						<xs:element name="FuelLoadType" type="FuelLoadType" minOccurs="0"/>
 						<xs:element minOccurs="0" name="Location" type="FuelLoadLocation"/>
-						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+						<xs:element name="Count" type="HPXMLIntegerGreaterThanOrEqualToZero" minOccurs="0"/>
 						<xs:element minOccurs="0" name="Load">
 							<xs:complexType>
 								<xs:sequence>
@@ -2835,7 +2835,7 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element name="CAZDepressurizationLimit" type="CAZDepressurizationLimit" minOccurs="0">
+									<xs:element name="CAZDepressurizationLimit" type="HPXMLDouble" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>Pulled from industry standards by users (e.g. BPI Gold Sheet) or via software program</xs:documentation>
 										</xs:annotation>
@@ -2854,7 +2854,7 @@
 												depressurization attained at the time of testing and the base pressure.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="NetPressureChange" type="NetPressureChange" minOccurs="0">
+									<xs:element name="NetPressureChange" type="HPXMLDouble" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>With respect to the baseline pressure (e.g. no fans running, all exterior doors closed, and all interior doors opened)</xs:documentation>
 										</xs:annotation>
@@ -2877,7 +2877,7 @@
 												<xs:element minOccurs="0" name="CombustionVentingSystem" type="RemoteReference"/>
 												<xs:element name="FlueVisualCondition" type="FlueCondition" minOccurs="0"/>
 												<xs:element minOccurs="0" name="FlueConditionNotes" type="HPXMLString"/>
-												<xs:element name="OutsideTemperatureFlueDraftTest" type="Temperature" minOccurs="0">
+												<xs:element name="OutsideTemperatureFlueDraftTest" type="HPXMLDouble" minOccurs="0">
 													<xs:annotation>
 														<xs:documentation>[deg F]</xs:documentation>
 													</xs:annotation>
@@ -2929,7 +2929,7 @@
 														</xs:complexContent>
 													</xs:complexType>
 												</xs:element>
-												<xs:element name="StackTemperature" type="Temperature" minOccurs="0">
+												<xs:element name="StackTemperature" type="HPXMLDouble" minOccurs="0">
 													<xs:annotation>
 														<xs:documentation>[deg F] after 10 minutes run time</xs:documentation>
 													</xs:annotation>
@@ -2967,7 +2967,7 @@
 						<xs:element name="StoveID" type="SystemIdentifiersInfoType"/>
 						<xs:element minOccurs="0" name="StoveFuel" type="FuelType"/>
 						<xs:element name="HeatingStoveProperlyVented" type="HPXMLBoolean" minOccurs="0"/>
-						<xs:element name="COReading" type="COReading" minOccurs="0"/>
+						<xs:element name="COReading" type="HPXMLDouble" minOccurs="0"/>
 						<xs:element minOccurs="0" name="TimeofCOReading" type="HPXMLDateTime"/>
 						<xs:element name="GasLeaksIdentified" type="HPXMLBoolean" minOccurs="0"/>
 						<xs:element name="ActionsTaken" type="HPXMLString" minOccurs="0"/>
@@ -3390,13 +3390,13 @@
 			<xs:element minOccurs="0" ref="AttachedToZone"/>
 			<xs:element minOccurs="0" name="AttachedToCAZ" type="LocalReference"/>
 			<xs:element name="UnitLocation" type="UnitLocation" minOccurs="0"/>
-			<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
-			<xs:element name="ModelYear" type="Year" minOccurs="0"/>
-			<xs:element name="Manufacturer" type="Manufacturer" minOccurs="0"/>
-			<xs:element name="ModelNumber" type="Model" minOccurs="0"/>
+			<xs:element minOccurs="0" name="YearInstalled" type="HPXMLInteger"/>
+			<xs:element name="ModelYear" type="HPXMLInteger" minOccurs="0"/>
+			<xs:element name="Manufacturer" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="ModelNumber" type="HPXMLString" minOccurs="0"/>
 			<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
-			<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction">
+			<xs:element minOccurs="0" name="PerformanceAdjustment" type="HPXMLFractionInclusive">
 				<xs:annotation>
 					<xs:documentation>A multiplier on the performance of the system. A value of 1 implies no performance adjustment.</xs:documentation>
 				</xs:annotation>
@@ -3444,19 +3444,19 @@
 				<xs:sequence minOccurs="1" maxOccurs="1">
 					<xs:element name="HeatingSystemType" type="HeatingSystemType" minOccurs="0"/>
 					<xs:element name="HeatingSystemFuel" type="FuelType" minOccurs="0"/>
-					<xs:element name="HeatingInputRating" type="Capacity" minOccurs="0">
+					<xs:element name="HeatingInputRating" type="HPXMLDouble" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>[Btuh] Input Heating Capacity</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="HeatingCapacity" type="Capacity" minOccurs="0">
+					<xs:element name="HeatingCapacity" type="HPXMLDouble" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>[Btuh] Output Heating Capacity</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element minOccurs="0" name="AnnualHeatingEfficiency" type="HeatingEfficiencyType" maxOccurs="unbounded"/>
-					<xs:element name="FractionHeatLoadServed" type="Fraction" minOccurs="0"/>
-					<xs:element minOccurs="0" name="FloorAreaServed" type="SurfaceArea">
+					<xs:element name="FractionHeatLoadServed" type="HPXMLFractionInclusive" minOccurs="0"/>
+					<xs:element minOccurs="0" name="FloorAreaServed" type="HPXMLDoubleGreaterThanZero">
 						<xs:annotation>
 							<xs:documentation>[sq.ft.]</xs:documentation>
 						</xs:annotation>
@@ -3602,28 +3602,28 @@
 				<xs:sequence minOccurs="0">
 					<xs:element name="HeatPumpType" type="HeatPumpType" minOccurs="0"/>
 					<xs:element minOccurs="0" name="HeatPumpFuel" type="FuelType"/>
-					<xs:element name="HeatingCapacity" type="Capacity" minOccurs="0">
+					<xs:element name="HeatingCapacity" type="HPXMLDouble" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>[Btuh] Output heating capacity; typically the nameplate capacity at 47F.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="HeatingCapacity17F" type="Capacity">
+					<xs:element minOccurs="0" name="HeatingCapacity17F" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>[Btuh] Output heating capacity at 17F from AHRI database.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="CoolingCapacity" type="Capacity">
+					<xs:element minOccurs="0" name="CoolingCapacity" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>[Btuh] Output cooling capacity</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element minOccurs="0" name="CompressorType" type="CompressorType"/>
-					<xs:element minOccurs="0" name="CompressorLockoutTemperature" type="Temperature">
+					<xs:element minOccurs="0" name="CompressorLockoutTemperature" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>[deg F] Temperature below which the compressor is disabled, often to prevent damage or occupant comfort issues. The default is the manufacturer's minimum operating temperature, but the value may be set higher. For a duel-fuel heat pump, use the BackupHeatingSwitchoverTemperature element.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="CoolingSensibleHeatFraction" type="Fraction"/>
+					<xs:element minOccurs="0" name="CoolingSensibleHeatFraction" type="HPXMLFractionInclusive"/>
 					<xs:element minOccurs="0" name="BackupType" type="HeatPumpBackupType">
 						<xs:annotation>
 							<xs:documentation>Whether the heat pump backup is integrated into the unit (describe in BackupSystemFuel, BackupAnnualHeatingEfficiency, BackupHeatingCapacity), or a
@@ -3637,29 +3637,29 @@
 					</xs:element>
 					<xs:element name="BackupSystemFuel" type="FuelType" minOccurs="0"/>
 					<xs:element name="BackupAnnualHeatingEfficiency" minOccurs="0" type="HeatingEfficiencyType" maxOccurs="unbounded"/>
-					<xs:element minOccurs="0" name="BackupHeatingInputRating" type="Capacity">
+					<xs:element minOccurs="0" name="BackupHeatingInputRating" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>[Btuh] Input heating capacity</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="BackupHeatingCapacity" type="Capacity">
+					<xs:element minOccurs="0" name="BackupHeatingCapacity" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>[Btuh] Output heating capacity</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="BackupHeatingSwitchoverTemperature" type="Temperature">
+					<xs:element minOccurs="0" name="BackupHeatingSwitchoverTemperature" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>[deg F] Temperature at which the backup heating is activated and the compressor is disabled in, e.g., a dual-fuel heat pump.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="BackupHeatingLockoutTemperature" type="Temperature">
+					<xs:element minOccurs="0" name="BackupHeatingLockoutTemperature" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>[deg F] Temperature above which the backup heating is disabled, often to prevent backup heating usage during recovery from a thermostat heating setback. For a duel-fuel heat pump, use the BackupHeatingSwitchoverTemperature element.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="FractionHeatLoadServed" type="Fraction" minOccurs="0"/>
-					<xs:element name="FractionCoolLoadServed" type="Fraction" minOccurs="0"/>
-					<xs:element minOccurs="0" name="FloorAreaServed" type="SurfaceArea">
+					<xs:element name="FractionHeatLoadServed" type="HPXMLFractionInclusive" minOccurs="0"/>
+					<xs:element name="FractionCoolLoadServed" type="HPXMLFractionInclusive" minOccurs="0"/>
+					<xs:element minOccurs="0" name="FloorAreaServed" type="HPXMLDoubleGreaterThanZero">
 						<xs:annotation>
 							<xs:documentation>[sq.ft.]</xs:documentation>
 						</xs:annotation>
@@ -3692,20 +3692,20 @@
 				<xs:sequence>
 					<xs:element name="CoolingSystemType" type="CoolingSystemType" minOccurs="0"/>
 					<xs:element minOccurs="0" name="CoolingSystemFuel" type="FuelType"/>
-					<xs:element minOccurs="0" name="CoolingCapacity" type="Capacity">
+					<xs:element minOccurs="0" name="CoolingCapacity" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>[Btuh] Output cooling capacity</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element minOccurs="0" name="CompressorType" type="CompressorType"/>
-					<xs:element name="FractionCoolLoadServed" type="Fraction" minOccurs="0"/>
-					<xs:element minOccurs="0" name="FloorAreaServed" type="SurfaceArea">
+					<xs:element name="FractionCoolLoadServed" type="HPXMLFractionInclusive" minOccurs="0"/>
+					<xs:element minOccurs="0" name="FloorAreaServed" type="HPXMLDoubleGreaterThanZero">
 						<xs:annotation>
 							<xs:documentation>[sq.ft.]</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element minOccurs="0" name="SensibleHeatFraction" type="Fraction"/>
+					<xs:element minOccurs="0" name="SensibleHeatFraction" type="HPXMLFractionInclusive"/>
 					<xs:element minOccurs="0" name="CoolingDetailedPerformanceData">
 						<xs:complexType>
 							<xs:sequence>
@@ -3731,7 +3731,7 @@
 			<xs:element minOccurs="0" name="BoreholesOrTrenches">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero"/>
+						<xs:element minOccurs="0" name="Count" type="HPXMLIntegerGreaterThanZero"/>
 						<xs:element minOccurs="0" name="Length" type="HPXMLDouble">
 							<xs:annotation>
 								<xs:documentation>[ft] Length of each borehole (vertical) or trench (horizontal)</xs:documentation>
@@ -3798,7 +3798,7 @@
 	<xs:complexType name="CoolingEfficiencyType">
 		<xs:sequence>
 			<xs:element name="Units" type="CoolingEfficiencyUnits"/>
-			<xs:element name="Value" type="Efficiency"/>
+			<xs:element name="Value" type="HPXMLDoubleGreaterThanZero"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
@@ -3809,14 +3809,14 @@
 					<xs:documentation>For AFUE and Percent enter values as a fractional number between 0 and 1, i.e. 80% = 0.8</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Value" type="Efficiency"/>
+			<xs:element name="Value" type="HPXMLDoubleGreaterThanZero"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="BatteryCapacityType">
 		<xs:sequence>
 			<xs:element name="Units" type="BatteryCapacityUnits"> </xs:element>
-			<xs:element name="Value" type="BatteryCapacity">
+			<xs:element name="Value" type="HPXMLDecimalGreaterThanZero">
 				<xs:annotation>
 					<xs:documentation>Ah is computed by multiplying the discharge current (Amps) by the discharge time (hours). kWh is computed by multiplying the power output (kW) by the discharge time (hours).</xs:documentation>
 				</xs:annotation>
@@ -3837,26 +3837,26 @@
 	</xs:complexType>
 	<xs:complexType name="HydronicDistributionInfo">
 		<xs:sequence>
-			<xs:element name="FractionHydronicPipeInsulated" type="Fraction" minOccurs="0"/>
-			<xs:element minOccurs="0" name="PipeRValue" type="RValue"/>
-			<xs:element minOccurs="0" name="PipeInsulationThickness" type="LengthMeasurement">
+			<xs:element name="FractionHydronicPipeInsulated" type="HPXMLFractionInclusive" minOccurs="0"/>
+			<xs:element minOccurs="0" name="PipeRValue" type="HPXMLDoubleGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="PipeInsulationThickness" type="HPXMLDoubleGreaterThanOrEqualToZero">
 				<xs:annotation>
 					<xs:documentation>[in]</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="PipeLength" type="LengthMeasurement">
+			<xs:element minOccurs="0" name="PipeLength" type="HPXMLDoubleGreaterThanOrEqualToZero">
 				<xs:annotation>
 					<xs:documentation>[ft]</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element minOccurs="0" name="PipeDiameter" type="PipeDiameterType"/>
 			<xs:element name="HydronicDistributionType" type="HydronicDistributionType" minOccurs="0"/>
-			<xs:element minOccurs="0" name="SupplyTemperature" type="Temperature">
+			<xs:element minOccurs="0" name="SupplyTemperature" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[degF]</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="ReturnTemperature" type="Temperature">
+			<xs:element minOccurs="0" name="ReturnTemperature" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[degF]</xs:documentation>
 				</xs:annotation>
@@ -3892,12 +3892,12 @@
 						<xs:element name="DuctType" type="DuctType" minOccurs="0"/>
 						<xs:element name="DuctMaterial" type="DuctMaterial" minOccurs="0"/>
 						<xs:element minOccurs="0" name="DuctInsulationMaterial" type="InsulationMaterial"/>
-						<xs:element name="DuctInsulationRValue" type="RValue" minOccurs="0">
+						<xs:element name="DuctInsulationRValue" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0">
 							<xs:annotation>
 								<xs:documentation>This should exclude the exterior air film -- e.g., use zero for uninsulated ducts. For ducts buried in insulation, this should only represent any surrounding insulation duct wrap and not the entire attic insulation R-value.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DuctInsulationThickness" type="LengthMeasurement">
+						<xs:element minOccurs="0" name="DuctInsulationThickness" type="HPXMLDoubleGreaterThanOrEqualToZero">
 							<xs:annotation>
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
@@ -3908,19 +3908,19 @@
 								<xs:documentation>Describes ducts buried in, e.g., attic loose-fill insulation. Partially buried ducts have insulation that does not cover the top of the ducts. Fully buried ducts have insulation that just covers the top of the ducts. Deeply buried ducts have insulation that continues above the top of the ducts. See https://basc.pnnl.gov/resource-guides/ducts-buried-attic-insulation for more information.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DuctEffectiveRValue" type="RValue">
+						<xs:element minOccurs="0" name="DuctEffectiveRValue" type="HPXMLDoubleGreaterThanOrEqualToZero">
 							<xs:annotation>
 								<xs:documentation>The overall effective R-value. Includes the exterior air film as well as other effects such as adjustments for insulation wrapped around round ducts, or ducts buried in attic insulation.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element name="DuctLocation" type="DuctLocation" minOccurs="0"/>
-						<xs:element minOccurs="0" name="FractionDuctArea" type="Fraction">
+						<xs:element minOccurs="0" name="FractionDuctArea" type="HPXMLFractionInclusive">
 							<xs:annotation>
 								<xs:documentation>If a DuctType of supply or return is specified above, this is the fraction of the supply or return duct area. If DuctType is omitted above, this is
 									the fraction of the total duct area. </xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DuctSurfaceArea" type="SurfaceArea">
+						<xs:element minOccurs="0" name="DuctSurfaceArea" type="HPXMLDoubleGreaterThanZero">
 							<xs:annotation>
 								<xs:documentation>[sq.ft.]</xs:documentation>
 							</xs:annotation>
@@ -3930,7 +3930,7 @@
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="NumberofReturnRegisters" type="IntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="NumberofReturnRegisters" type="HPXMLIntegerGreaterThanOrEqualToZero"/>
 			<xs:element minOccurs="0" name="TotalExternalStaticPressureMeasurement">
 				<xs:complexType>
 					<xs:sequence>
@@ -3966,9 +3966,9 @@
 	<xs:complexType name="IncentiveDetailsType">
 		<xs:sequence>
 			<xs:element name="IncentiveType" type="SystemIdentifiersInfoType"/>
-			<xs:element name="FundingSourceCode" type="FundingSourceCode" minOccurs="0"/>
-			<xs:element name="FundingSourceName" type="FundingSourceName" minOccurs="0"/>
-			<xs:element name="IncentiveAmount" type="IncentiveAmount" minOccurs="0"/>
+			<xs:element name="FundingSourceCode" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="FundingSourceName" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="IncentiveAmount" type="HPXMLDecimal" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -4001,17 +4001,17 @@
 									<xs:element minOccurs="0" name="PublicTransportation">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="DistanceFromSubway" type="LengthMeasurement">
+												<xs:element minOccurs="0" name="DistanceFromSubway" type="HPXMLDoubleGreaterThanOrEqualToZero">
 													<xs:annotation>
 														<xs:documentation>[ft]</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="DistanceFromBus" type="LengthMeasurement">
+												<xs:element minOccurs="0" name="DistanceFromBus" type="HPXMLDoubleGreaterThanOrEqualToZero">
 													<xs:annotation>
 														<xs:documentation>[ft]</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="DistanceFromTrain" type="LengthMeasurement">
+												<xs:element minOccurs="0" name="DistanceFromTrain" type="HPXMLDoubleGreaterThanOrEqualToZero">
 													<xs:annotation>
 														<xs:documentation>[ft]</xs:documentation>
 													</xs:annotation>
@@ -4020,7 +4020,7 @@
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="WalkingScore" type="IntegerGreaterThanOrEqualToZero"/>
+									<xs:element minOccurs="0" name="WalkingScore" type="HPXMLIntegerGreaterThanOrEqualToZero"/>
 									<xs:element minOccurs="0" name="WalkingScoreSource" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="FuelTypesAvailable">
 										<xs:annotation>
@@ -4056,27 +4056,27 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:element minOccurs="0" name="HouseholdType" type="HouseholdType"/>
-									<xs:element minOccurs="0" name="YearOccupied" type="Year">
+									<xs:element minOccurs="0" name="YearOccupied" type="HPXMLInteger">
 										<xs:annotation>
 											<xs:documentation>The year the current occupants moved into the building</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="ResidentPopulationType" type="ResidentPopulationType"/>
 									<xs:element minOccurs="0" name="Occupancy" type="Occupancy"/>
-									<xs:element name="NumberofResidents" type="PeopleCount" minOccurs="0"/>
-									<xs:element minOccurs="0" name="NumberofAdults" type="PeopleCount">
+									<xs:element name="NumberofResidents" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0"/>
+									<xs:element minOccurs="0" name="NumberofAdults" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>18 or older</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofChildren" type="IntegerGreaterThanOrEqualToZero">
+									<xs:element minOccurs="0" name="NumberofChildren" type="HPXMLIntegerGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>less than 18 years old</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="PubliclySubsidized" type="HPXMLBoolean"/>
 									<xs:element minOccurs="0" name="LowIncome" type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="OccupantIncomeRange" type="FractionGreaterThanOne">
+									<xs:element minOccurs="0" name="OccupantIncomeRange" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>Percentage as a fraction (50% = 0.5)</xs:documentation>
 										</xs:annotation>
@@ -4095,9 +4095,9 @@
 						<xs:element minOccurs="0" name="BuildingConstruction">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element name="YearBuilt" type="Year" minOccurs="0"/>
+									<xs:element name="YearBuilt" type="HPXMLInteger" minOccurs="0"/>
 									<xs:element minOccurs="0" name="YearBuiltKnownOrEstimated" type="KnownOrEstimated"/>
-									<xs:element minOccurs="0" name="YearofLastRemodel" type="Year"/>
+									<xs:element minOccurs="0" name="YearofLastRemodel" type="HPXMLInteger"/>
 									<xs:element name="ResidentialFacilityType" type="ResidentialFacilityType" minOccurs="0"/>
 									<xs:element minOccurs="0" name="PassiveSolar" type="HPXMLBoolean">
 										<xs:annotation>
@@ -4106,61 +4106,61 @@
 												http://www.eere.energy.gov/basics/buildings/passive_solar_design.html)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="BuildingHeight" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="BuildingHeight" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[ft] height of building</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofUnits" type="IntegerGreaterThanZero">
+									<xs:element minOccurs="0" name="NumberofUnits" type="HPXMLIntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Number of dwelling units represented by the HPXML Building element. Used as a multiplier.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofUnitsInBuilding" type="IntegerGreaterThanZero">
+									<xs:element minOccurs="0" name="NumberofUnitsInBuilding" type="HPXMLIntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Total number of dwelling units in the physical building.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofFloors" type="NumberOfFloorsType">
+									<xs:element minOccurs="0" name="NumberofFloors" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>Total number of floors including a basement, whether conditioned or unconditioned</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofConditionedFloors" type="NumberOfFloorsType">
+									<xs:element minOccurs="0" name="NumberofConditionedFloors" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>Number of floors that are heated/cooled including a basement</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofConditionedFloorsAboveGrade" type="NumberOfFloorsType">
+									<xs:element minOccurs="0" name="NumberofConditionedFloorsAboveGrade" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>Number of floors above grade that are heated/cooled</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="AverageCeilingHeight" type="LengthMeasurement" minOccurs="0">
+									<xs:element name="AverageCeilingHeight" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[ft] Average distance from the floor to the ceiling</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FloorToFloorHeight" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="FloorToFloorHeight" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[ft] distance between floors</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofRooms" type="IntegerGreaterThanZero"/>
-									<xs:element name="NumberofBedrooms" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
-									<xs:element name="NumberofBathrooms" type="IntegerGreaterThanZero" minOccurs="0"/>
-									<xs:element minOccurs="0" name="NumberofCompleteBathrooms" type="IntegerGreaterThanZero">
+									<xs:element minOccurs="0" name="NumberofRooms" type="HPXMLIntegerGreaterThanZero"/>
+									<xs:element name="NumberofBedrooms" type="HPXMLIntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+									<xs:element name="NumberofBathrooms" type="HPXMLIntegerGreaterThanZero" minOccurs="0"/>
+									<xs:element minOccurs="0" name="NumberofCompleteBathrooms" type="HPXMLIntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Number of bathrooms with a tub or shower</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="BuildingFootprintArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="BuildingFootprintArea" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="FootprintShape" type="FootprintShape"/>
-									<xs:element minOccurs="0" name="GrossFloorArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="GrossFloorArea" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Gross floor area (based on ASHRAE definition) is the sum of the floor areas of the spaces within the building, including
 												basements, mezzanine and intermediate&#8208;floored tiers, and penthouses with headroom height of 7.5 ft (2.2 meters) or greater. Measurements must be taken
@@ -4170,7 +4170,7 @@
 												vehicles.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NetFloorArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="NetFloorArea" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] The floor area of an occupiable space defined by the inside surfaces of its walls but excluding shafts, column enclosures, and
 												other permanently enclosed, inaccessible, and unoccupiable areas. Obstructions in the space such as furnishings, display or storage racks, and other
@@ -4178,33 +4178,33 @@
 												area.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ConditionedFloorArea" type="SurfaceArea" minOccurs="0">
+									<xs:element name="ConditionedFloorArea" type="HPXMLDoubleGreaterThanZero" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] All finished space that is within the (insulated) conditioned space boundary (that is, within the insulated envelope), regardless
 												of HVAC configuration.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FinishedFloorArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="FinishedFloorArea" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Floor area of home that is finished and assumed to be occupied.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="NumberofStoriesAboveGrade" type="IntegerGreaterThanZero" minOccurs="0"/>
-									<xs:element minOccurs="0" name="CooledFloorArea" type="SurfaceArea">
+									<xs:element name="NumberofStoriesAboveGrade" type="HPXMLIntegerGreaterThanZero" minOccurs="0"/>
+									<xs:element minOccurs="0" name="CooledFloorArea" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] The total area of all enclosed spaces measured to the internal face of the external walls. Included are areas of sloping surfaces
 												such as staircases, galleries, raked auditoria, and tiered terraces where the area taken is from the area on the plan. Excluded are areas that are not
 												enclosed such as open floors, covered ways and balconies.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HeatedFloorArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="HeatedFloorArea" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] The total area of all enclosed spaces measured to the internal face of the external walls. Included are areas of sloping surfaces
 												such as staircases, galleries, raked auditoria, and tiered terraces where the area taken is from the area on the plan. Excluded are areas that are not
 												enclosed such as open floors, covered ways and balconies.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="UnconditionedFloorArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="UnconditionedFloorArea" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] An enclosed space within a building that does not meet the requirements of a conditioned space. Spaces that have no control over
 												thermal conditions but intentionally or unintentionally receive thermal energy from adjacent spaces are considered unconditioned spaces (such as an
@@ -4212,7 +4212,7 @@
 												unconditioned spaces (such as a parking garage with no thermal comfort criteria).</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="BuildingVolume" type="Volume">
+									<xs:element minOccurs="0" name="BuildingVolume" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[cu.ft.] A volume of a building surrounded by solid surfaces such as walls, roofs, floors, fenestration, and doors where the total opening
 												area to the outside can be reduced to less than 1% of the Gross Interior Floor Area of the space. Spaces that are temporarily enclosed such as patios
@@ -4220,7 +4220,7 @@
 												building.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ConditionedBuildingVolume" type="Volume" minOccurs="0">
+									<xs:element name="ConditionedBuildingVolume" type="HPXMLDoubleGreaterThanZero" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[cu.ft.] Volume inside the building envelope of the conditioned spaces. This metric can be calculated as the volume of the building if
 												every space is conditioned or on a floor-by-floor basis. For spaces with vertical walls and horizontal ceilings and floors, this is calculated as the
@@ -4240,10 +4240,10 @@
 											<xs:documentation>Primary attic type of building</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="AverageAtticRValue" type="RValue" minOccurs="0"/>
-									<xs:element name="AverageWallRValue" type="RValue" minOccurs="0"/>
-									<xs:element name="AverageFloorRValue" type="RValue" minOccurs="0"/>
-									<xs:element name="AverageDuctRValue" type="RValue" minOccurs="0"/>
+									<xs:element name="AverageAtticRValue" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0"/>
+									<xs:element name="AverageWallRValue" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0"/>
+									<xs:element name="AverageFloorRValue" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0"/>
+									<xs:element name="AverageDuctRValue" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0"/>
 									<xs:element minOccurs="0" name="GaragePresent" type="HPXMLBoolean"/>
 									<xs:element minOccurs="0" name="GarageLocation" type="GarageLocation"/>
 									<xs:element minOccurs="0" name="SpaceAboveGarage" type="SpaceAboveGarage"/>
@@ -4274,7 +4274,7 @@
 						<xs:element name="TermiteZone" type="TermiteZone" minOccurs="0"/>
 						<xs:element name="HurricaneZone" type="HPXMLBoolean" minOccurs="0"/>
 						<xs:element name="FloodZone" type="HPXMLBoolean" minOccurs="0"/>
-						<xs:element name="EarthquakeZone" type="EarthquakeZone" minOccurs="0"/>
+						<xs:element name="EarthquakeZone" type="HPXMLBoolean" minOccurs="0"/>
 						<xs:element maxOccurs="unbounded" minOccurs="0" name="WeatherStation" type="WeatherStation">
 							<xs:annotation>
 								<xs:documentation>Weather location used in model simulation and/or utility bill regression analysis</xs:documentation>
@@ -4357,7 +4357,7 @@
 												both.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Year" type="Year">
+									<xs:element minOccurs="0" name="Year" type="HPXMLInteger">
 										<xs:annotation>
 											<xs:documentation>The year the certification or verification was awarded.</xs:documentation>
 										</xs:annotation>
@@ -4386,34 +4386,34 @@
 	<xs:complexType name="ProjectDetailsType">
 		<xs:sequence>
 			<xs:element maxOccurs="unbounded" minOccurs="0" ref="ExternalResource"/>
-			<xs:element name="ProgramName" type="ProgramName" minOccurs="0"/>
+			<xs:element name="ProgramName" type="HPXMLString" minOccurs="0"/>
 			<xs:element maxOccurs="1" minOccurs="0" ref="ContractorSystemIdentifiers"/>
-			<xs:element minOccurs="0" name="ProgramSponsor" type="ProgramSponsor"/>
-			<xs:element name="ProjectType" type="ProjectType" minOccurs="0"/>
-			<xs:element name="Title" type="Title" minOccurs="0"/>
+			<xs:element minOccurs="0" name="ProgramSponsor" type="HPXMLString"/>
+			<xs:element name="ProjectType" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="Title" type="HPXMLString" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="ProjectStatus"/>
-			<xs:element name="Notes" type="Notes" minOccurs="0"/>
-			<xs:element name="StartDate" type="StartDate" minOccurs="0">
+			<xs:element name="Notes" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="StartDate" type="HPXMLDate" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Start date of project</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="CompleteDateEstimated" type="CompleteDateEstimated" minOccurs="0">
+			<xs:element name="CompleteDateEstimated" type="HPXMLDate" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Estimated completion date of project</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="CompleteDateActual" type="CompleteDateActual" minOccurs="0">
+			<xs:element name="CompleteDateActual" type="HPXMLDate" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Actual completion date of project</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="Hours" type="Hours">
+			<xs:element minOccurs="0" name="Hours" type="HPXMLInteger">
 				<xs:annotation>
 					<xs:documentation>Amount of time spent by contractor on this stage of the project</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="FeeCost" type="Cost">
+			<xs:element minOccurs="0" name="FeeCost" type="HPXMLDecimal">
 				<xs:annotation>
 					<xs:documentation>Cost of any fees associated with the audit or other project activities</xs:documentation>
 				</xs:annotation>
@@ -4447,8 +4447,8 @@
 	</xs:complexType>
 	<xs:complexType name="TotalCostType">
 		<xs:sequence>
-			<xs:element name="TotalCostHealthSafetyMeasures" type="TotalCostHealthSafetyMeasures" minOccurs="1"/>
-			<xs:element name="TotalCostQualEnergyMeasures" type="TotalCostQualEnergyMeasures" minOccurs="1"/>
+			<xs:element name="TotalCostHealthSafetyMeasures" type="HPXMLDouble" minOccurs="1"/>
+			<xs:element name="TotalCostQualEnergyMeasures" type="HPXMLDouble" minOccurs="1"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
@@ -4466,21 +4466,21 @@
 				</xs:complexType>
 			</xs:element>
 			<xs:element maxOccurs="unbounded" minOccurs="0" ref="ExternalResource"/>
-			<xs:element name="MeasureCode" type="MeasureCode" minOccurs="0"/>
-			<xs:element name="MeasureDescription" type="MeasureDescription" minOccurs="0"/>
+			<xs:element name="MeasureCode" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="MeasureDescription" type="HPXMLString" minOccurs="0"/>
 			<xs:element minOccurs="0" name="Quantity">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element name="Units" type="HPXMLString"/>
-						<xs:element name="Value" type="Quantity"/>
+						<xs:element name="Value" type="HPXMLDecimal"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Location" type="UnitLocation" minOccurs="0"/>
-			<xs:element name="EstimatedLife" type="EstimatedLife" minOccurs="0"/>
-			<xs:element name="InstallationDate" type="InstallationDate" minOccurs="0"/>
-			<xs:element name="Cost" type="Cost" minOccurs="0"/>
+			<xs:element name="EstimatedLife" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="InstallationDate" type="HPXMLDate" minOccurs="0"/>
+			<xs:element name="Cost" type="HPXMLDecimal" minOccurs="0"/>
 			<xs:element name="UnitPricingIndicator" type="HPXMLBoolean" minOccurs="0"/>
 			<xs:element minOccurs="0" name="Incentives">
 				<xs:complexType>
@@ -4496,15 +4496,15 @@
 						<xs:element maxOccurs="unbounded" name="ResourcesSaved">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element name="ResourceTypeCode" type="ResourceTypeCode"/>
-									<xs:element name="LoadProfile" type="LoadProfile" minOccurs="0">
+									<xs:element name="ResourceTypeCode" type="HPXMLString"/>
+									<xs:element name="LoadProfile" type="HPXMLString" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>A load profile is created using measurements of a customer's electricity use at regular intervals, typically one hour or less, and
 												provides an accurate representation of a customer's usage pattern over time.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="Quantity" type="Quantity"/>
-									<xs:element name="AnnualAmount" type="AnnualAmount" minOccurs="0"/>
+									<xs:element name="Quantity" type="HPXMLDecimal"/>
+									<xs:element name="AnnualAmount" type="HPXMLString" minOccurs="0"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -4516,8 +4516,8 @@
 			</xs:element>
 			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType" maxOccurs="2"/>
 			<xs:element maxOccurs="2" minOccurs="0" name="WaterSavingsInfo" type="WaterSavingsType"/>
-			<xs:element minOccurs="0" name="CustomerNotes" type="Notes"/>
-			<xs:element minOccurs="0" name="WorkscopeNotes" type="Notes"/>
+			<xs:element minOccurs="0" name="CustomerNotes" type="HPXMLString"/>
+			<xs:element minOccurs="0" name="WorkscopeNotes" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="Status" type="ImprovementStatusType"/>
 			<xs:element minOccurs="0" name="NotInstalledReasonCode" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="InstallingContractor" type="RemoteReference"/>
@@ -4529,7 +4529,7 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element name="QAStatus" type="TestResultType"/>
-						<xs:element name="QAComments" type="Notes"/>
+						<xs:element name="QAComments" type="HPXMLString"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -4611,13 +4611,13 @@
 								<xs:documentation>For Percent enter values as a fractional number, i.e. 30% = 0.3</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="Value" type="MeasuredDuctLeakage" minOccurs="0"/>
+						<xs:element name="Value" type="HPXMLDouble" minOccurs="0"/>
 						<xs:element minOccurs="0" name="TotalOrToOutside" type="DuctLeakageTotalOrToOutside"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="EffectiveLeakageArea" type="SurfaceArea">
+			<xs:element minOccurs="0" name="EffectiveLeakageArea" type="HPXMLDoubleGreaterThanZero">
 				<xs:annotation>
 					<xs:documentation>The Leakage Area is defined in TECBLAST as the size of a sharp edged orifice which would leak at the same flow rate as the measured leakage, if the orifice were
 						subjected to the Test Pressure. Leakage Area [sq in] = Duct System Leakage Rate [CFM] / (1.06 * (Test Pressure [Pa]) ^ 0.5)</xs:documentation>
@@ -4879,12 +4879,12 @@
 					<xs:documentation>Type of stud, joist, etc. (2x4, 2x6, etc)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="Spacing" type="LengthMeasurement">
+			<xs:element minOccurs="0" name="Spacing" type="HPXMLDoubleGreaterThanOrEqualToZero">
 				<xs:annotation>
 					<xs:documentation>[in] Spacing on center</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="FramingFactor" type="Fraction"/>
+			<xs:element minOccurs="0" name="FramingFactor" type="HPXMLFractionInclusive"/>
 			<xs:element minOccurs="0" name="Material" type="StudMaterial"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
@@ -4893,9 +4893,9 @@
 	<xs:complexType name="TelephoneInfoType">
 		<xs:sequence>
 			<xs:element name="TelephoneType" type="TelephoneTypeCode" minOccurs="0"/>
-			<xs:element name="TelephoneNumber" type="TelephoneNumber"/>
+			<xs:element name="TelephoneNumber" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="PreferredContactMethod" type="HPXMLBoolean"/>
-			<xs:element name="TelephoneExtension" type="TelephoneExtension" minOccurs="0"/>
+			<xs:element name="TelephoneExtension" type="HPXMLString" minOccurs="0"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -4903,7 +4903,7 @@
 	<xs:complexType name="EmailInfoType">
 		<xs:sequence>
 			<xs:element name="EmailType" type="EmailTypeCode" minOccurs="0"/>
-			<xs:element name="EmailAddress" type="EmailAddress"/>
+			<xs:element name="EmailAddress" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="PreferredContactMethod" type="HPXMLBoolean"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
@@ -4934,12 +4934,12 @@
 	<xs:group name="WindowInfo">
 		<xs:sequence>
 			<xs:group ref="SystemInfo"/>
-			<xs:element name="Area" type="SurfaceArea" minOccurs="0">
+			<xs:element name="Area" type="HPXMLDoubleGreaterThanZero" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[sq.ft.] Total window surface area for this group of windows</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero">
+			<xs:element minOccurs="0" name="Count" type="HPXMLIntegerGreaterThanZero">
 				<xs:annotation>
 					<xs:documentation>Number of windows in the group</xs:documentation>
 				</xs:annotation>
@@ -4955,16 +4955,16 @@
 			<xs:element minOccurs="0" name="GlassType" type="GlassType"/>
 			<xs:element minOccurs="0" name="GasFill" type="GasFill"/>
 			<xs:element name="Condition" type="WindowCondition" minOccurs="0"/>
-			<xs:element name="UFactor" type="UFactor" minOccurs="0"/>
-			<xs:element name="SHGC" type="SHGC" minOccurs="0"/>
-			<xs:element minOccurs="0" name="VisibleTransmittance" type="Fraction"/>
+			<xs:element name="UFactor" type="HPXMLDoubleGreaterThanZero" minOccurs="0"/>
+			<xs:element name="SHGC" type="HPXMLFractionExclusive" minOccurs="0"/>
+			<xs:element minOccurs="0" name="VisibleTransmittance" type="HPXMLFractionInclusive"/>
 			<xs:element name="NFRCCertified" type="HPXMLBoolean" minOccurs="0"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="WindowThirdPartyCertification"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="WindowFilm">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
-						<xs:element minOccurs="0" name="ShadingCoefficient" type="Fraction">
+						<xs:element minOccurs="0" name="ShadingCoefficient" type="HPXMLFractionInclusive">
 							<xs:annotation>
 								<xs:documentation>Shading coefficients are defined as a multiplier on transmittance: 1 is transparent, 0 is opaque. </xs:documentation>
 							</xs:annotation>
@@ -4979,13 +4979,13 @@
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element minOccurs="0" name="Type" type="ExteriorShading"/>
-						<xs:element minOccurs="0" name="SummerShadingCoefficient" type="Fraction">
+						<xs:element minOccurs="0" name="SummerShadingCoefficient" type="HPXMLFractionInclusive">
 							<xs:annotation>
 								<xs:documentation>The shading coefficient to apply during the summer months. Shading coefficients are defined as a multiplier on transmittance: 1 is transparent, 0 is
 									opaque. </xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="WinterShadingCoefficient" type="Fraction">
+						<xs:element minOccurs="0" name="WinterShadingCoefficient" type="HPXMLFractionInclusive">
 							<xs:annotation>
 								<xs:documentation>The shading coefficient to apply during the winter months. Shading coefficients are defined as a multiplier on transmittance: 1 is transparent, 0 is
 									opaque. </xs:documentation>
@@ -5004,13 +5004,13 @@
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element minOccurs="0" name="Type" type="InteriorShading"/>
-						<xs:element minOccurs="0" name="SummerShadingCoefficient" type="Fraction">
+						<xs:element minOccurs="0" name="SummerShadingCoefficient" type="HPXMLFractionInclusive">
 							<xs:annotation>
 								<xs:documentation>The shading coefficient to apply during the summer months. Shading coefficients are defined as a multiplier on transmittance: 1 is transparent, 0 is
 									opaque. </xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="WinterShadingCoefficient" type="Fraction">
+						<xs:element minOccurs="0" name="WinterShadingCoefficient" type="HPXMLFractionInclusive">
 							<xs:annotation>
 								<xs:documentation>The shading coefficient to apply during the winter months. Shading coefficients are defined as a multiplier on transmittance: 1 is transparent, 0 is
 									opaque. </xs:documentation>
@@ -5043,7 +5043,7 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
-						<xs:element minOccurs="0" name="RValue" type="RValue"/>
+						<xs:element minOccurs="0" name="RValue" type="HPXMLDoubleGreaterThanOrEqualToZero"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -5052,17 +5052,17 @@
 			<xs:element minOccurs="0" name="Overhangs">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="Depth" type="LengthMeasurement">
+						<xs:element name="Depth" type="HPXMLDoubleGreaterThanOrEqualToZero">
 							<xs:annotation>
 								<xs:documentation>[ft] Depth of overhang</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DistanceToTopOfWindow" type="LengthMeasurement">
+						<xs:element minOccurs="0" name="DistanceToTopOfWindow" type="HPXMLDoubleGreaterThanOrEqualToZero">
 							<xs:annotation>
 								<xs:documentation>[ft] Vertical distance from overhang to top of window</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DistanceToBottomOfWindow" type="LengthMeasurement">
+						<xs:element minOccurs="0" name="DistanceToBottomOfWindow" type="HPXMLDoubleGreaterThanOrEqualToZero">
 							<xs:annotation>
 								<xs:documentation>[ft] Vertical distance from overhang to bottom of window</xs:documentation>
 							</xs:annotation>
@@ -5159,7 +5159,7 @@
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
-						<xs:element name="JobRole" type="JobRole" minOccurs="0"/>
+						<xs:element name="JobRole" type="HPXMLString" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="ID" type="xs:int" use="required"/>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -5193,7 +5193,7 @@
 			<xs:element minOccurs="0" name="Date" type="HPXMLDate"/>
 			<xs:element minOccurs="0" name="BusinessConductingTest" type="RemoteReference"/>
 			<xs:element minOccurs="0" name="IndividualConductingTest" type="RemoteReference"/>
-			<xs:element minOccurs="0" name="OutsideTemperature" type="Temperature">
+			<xs:element minOccurs="0" name="OutsideTemperature" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[deg F]</xs:documentation>
 				</xs:annotation>
@@ -5206,12 +5206,12 @@
 					<xs:documentation>This element is intended to describe the type of infiltration measured, e.g., for an individual single-family attached or multifamily dwelling unit. Either whole building or single unit infiltration can be measured. For single unit infiltration, leakage can occur through exterior surfaces, interior surfaces, or both. For example, guarded tests measure unit exterior leakage, unguarded or compartmentalization tests measure unit total leakage, and combining both tests can measure unit interior leakage.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="HousePressure" type="HousePressure" minOccurs="0">
+			<xs:element name="HousePressure" type="HPXMLDoubleGreaterThanZero" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[Pa] with respect to outside</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="FanPressure" type="FanPressure" minOccurs="0">
+			<xs:element name="FanPressure" type="HPXMLDouble" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[Pa]</xs:documentation>
 				</xs:annotation>
@@ -5222,7 +5222,7 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element name="UnitofMeasure" type="BuildingAirLeakageUnit" minOccurs="0"/>
-						<xs:element name="AirLeakage" type="BuildingAirLeakage" minOccurs="0"/>
+						<xs:element name="AirLeakage" type="HPXMLDoubleGreaterThanZero" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -5521,32 +5521,32 @@
 			<xs:element minOccurs="0" ref="ConnectedDevice"/>
 			<xs:element minOccurs="0" ref="AttachedToZone"/>
 			<xs:element name="ControlType" type="ThermostatType" minOccurs="0"/>
-			<xs:element name="SetpointTempHeatingSeason" type="Temperature" minOccurs="0">
+			<xs:element name="SetpointTempHeatingSeason" type="HPXMLDouble" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[deg F]</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="SetbackTempHeatingSeason" type="Temperature" minOccurs="0">
+			<xs:element name="SetbackTempHeatingSeason" type="HPXMLDouble" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[deg F]</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="TotalSetbackHoursperWeekHeating" type="Hours" minOccurs="0">
+			<xs:element name="TotalSetbackHoursperWeekHeating" type="HPXMLInteger" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[hours]</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="SetupTempCoolingSeason" type="Temperature" minOccurs="0">
+			<xs:element name="SetupTempCoolingSeason" type="HPXMLDouble" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[deg F]</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="SetpointTempCoolingSeason" type="Temperature" minOccurs="0">
+			<xs:element name="SetpointTempCoolingSeason" type="HPXMLDouble" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[deg F]</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="TotalSetupHoursperWeekCooling" type="Hours" minOccurs="0">
+			<xs:element name="TotalSetupHoursperWeekCooling" type="HPXMLInteger" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[hours]</xs:documentation>
 				</xs:annotation>
@@ -5554,12 +5554,12 @@
 			<xs:element minOccurs="0" name="HotWaterResetControl" type="HotWaterResetControl"/>
 			<xs:element minOccurs="0" name="HeatLowered" type="HVACControlTypeAdjustments"/>
 			<xs:element minOccurs="0" name="ACAdjusted" type="HVACControlTypeAdjustments"/>
-			<xs:element minOccurs="0" name="FractionThermostaticRadiatorValves" type="Fraction">
+			<xs:element minOccurs="0" name="FractionThermostaticRadiatorValves" type="HPXMLFractionInclusive">
 				<xs:annotation>
 					<xs:documentation>Fraction of rooms controlled by thermostatic radiator valves</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="FractionElectronicZoneValves" type="Fraction">
+			<xs:element minOccurs="0" name="FractionElectronicZoneValves" type="HPXMLFractionInclusive">
 				<xs:annotation>
 					<xs:documentation>Percent of rooms controlled by electronic zone valves with thermostats</xs:documentation>
 				</xs:annotation>
@@ -5613,8 +5613,8 @@
 					<xs:documentation>Year and month of the last tune and repair for this HVAC equipment.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="NumberofCoilsReplaced" type="IntegerGreaterThanOrEqualToZero"/>
-			<xs:element minOccurs="0" name="NumberofAirHandlersReplaced" type="IntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="NumberofCoilsReplaced" type="HPXMLIntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="NumberofAirHandlersReplaced" type="HPXMLIntegerGreaterThanOrEqualToZero"/>
 			<xs:element minOccurs="0" name="AirFilter">
 				<xs:complexType>
 					<xs:sequence>
@@ -5667,10 +5667,10 @@
 	<xs:complexType name="WaterHeaterImprovementInfo">
 		<xs:sequence>
 			<xs:element name="JacketInstalledIndicator" type="HPXMLBoolean" minOccurs="0"/>
-			<xs:element name="DispositionofExistingSystem" type="DispositionofExistingSystem" minOccurs="0"/>
+			<xs:element name="DispositionofExistingSystem" type="HPXMLString" minOccurs="0"/>
 			<xs:element name="RepairsDescription" type="HPXMLString" minOccurs="0" maxOccurs="unbounded"/>
-			<xs:element name="PipeInsulated" type="PipeInsulated" minOccurs="0"/>
-			<xs:element name="LengthofPipeInsulated" type="LengthMeasurement" minOccurs="0">
+			<xs:element name="PipeInsulated" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="LengthofPipeInsulated" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[ft]</xs:documentation>
 				</xs:annotation>
@@ -5869,7 +5869,7 @@
 			<xs:group ref="SystemInfo"/>
 			<xs:element name="Name" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="City" nillable="true" type="HPXMLString"/>
-			<xs:element minOccurs="0" name="State" type="StateCode"/>
+			<xs:element minOccurs="0" name="State" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="WBAN" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="WMO" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="Type" type="WeatherStationType"/>
@@ -5880,14 +5880,14 @@
 	</xs:complexType>
 	<xs:complexType name="PipeInsulationType">
 		<xs:sequence>
-			<xs:element name="PipeRValue" type="RValue" minOccurs="0"/>
-			<xs:element minOccurs="0" name="PipeLengthInsulated" type="LengthMeasurement">
+			<xs:element name="PipeRValue" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0"/>
+			<xs:element minOccurs="0" name="PipeLengthInsulated" type="HPXMLDoubleGreaterThanOrEqualToZero">
 				<xs:annotation>
 					<xs:documentation>[ft]</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element minOccurs="0" name="PipeDiameterInsulated" type="PipeDiameterType"/>
-			<xs:element name="FractionPipeInsulation" type="Fraction" minOccurs="0">
+			<xs:element name="FractionPipeInsulation" type="HPXMLFractionInclusive" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Fraction of total pipe insulated</xs:documentation>
 				</xs:annotation>
@@ -5974,7 +5974,7 @@
 	<xs:complexType name="VentilationType">
 		<xs:sequence>
 			<xs:element name="UnitofMeasure" type="VentilationUnit" minOccurs="0"/>
-			<xs:element name="Value" type="BuildingAirLeakage" minOccurs="0"/>
+			<xs:element name="Value" type="HPXMLDoubleGreaterThanZero" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
@@ -5984,7 +5984,7 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element name="Dimension" type="DiameterDimension"/>
-						<xs:element name="Value" type="LengthMeasurement">
+						<xs:element name="Value" type="HPXMLDoubleGreaterThanOrEqualToZero">
 							<xs:annotation>
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
@@ -6034,27 +6034,27 @@
 	<xs:complexType name="CoolingPerformanceDataPoint">
 		<xs:sequence>
 			<xs:element maxOccurs="unbounded" minOccurs="0" ref="ExternalResource"/>
-			<xs:element name="OutdoorTemperature" type="Temperature" minOccurs="0">
+			<xs:element name="OutdoorTemperature" type="HPXMLDouble" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[F] drybulb</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="IndoorTemperature" type="Temperature">
+			<xs:element minOccurs="0" name="IndoorTemperature" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[F] drybulb</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="IndoorWetbulbTemperature" type="Temperature">
+			<xs:element minOccurs="0" name="IndoorWetbulbTemperature" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[F] wetbulb</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="Capacity" type="Capacity">
+			<xs:element minOccurs="0" name="Capacity" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[Btuh] output capacity</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="CapacityFractionOfNominal" type="FractionGreaterThanOne">
+			<xs:element minOccurs="0" name="CapacityFractionOfNominal" type="HPXMLDoubleGreaterThanOrEqualToZero">
 				<xs:annotation>
 					<xs:documentation>Fraction of the nominal output capacity</xs:documentation>
 				</xs:annotation>
@@ -6072,22 +6072,22 @@
 	<xs:complexType name="HeatingPerformanceDataPoint">
 		<xs:sequence>
 			<xs:element maxOccurs="unbounded" minOccurs="0" ref="ExternalResource"/>
-			<xs:element name="OutdoorTemperature" type="Temperature" minOccurs="0">
+			<xs:element name="OutdoorTemperature" type="HPXMLDouble" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[F] drybulb</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="IndoorTemperature" type="Temperature">
+			<xs:element minOccurs="0" name="IndoorTemperature" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[F] drybulb</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="Capacity" type="Capacity">
+			<xs:element minOccurs="0" name="Capacity" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[Btuh] output capacity</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="CapacityFractionOfNominal" type="FractionGreaterThanOne">
+			<xs:element minOccurs="0" name="CapacityFractionOfNominal" type="HPXMLDoubleGreaterThanOrEqualToZero">
 				<xs:annotation>
 					<xs:documentation>Fraction of the nominal output capacity</xs:documentation>
 				</xs:annotation>
@@ -6143,6 +6143,30 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+	<xs:simpleType name="HPXMLDoubleGreaterThanZero_simple">
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="HPXMLDoubleGreaterThanZero">
+		<xs:simpleContent>
+			<xs:extension base="HPXMLDoubleGreaterThanZero_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="HPXMLDoubleGreaterThanOrEqualToZero_simple">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="HPXMLDoubleGreaterThanOrEqualToZero">
+		<xs:simpleContent>
+			<xs:extension base="HPXMLDoubleGreaterThanOrEqualToZero_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:complexType name="HPXMLDecimal">
 		<xs:simpleContent>
 			<xs:extension base="xs:decimal">
@@ -6150,9 +6174,93 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+	<xs:simpleType name="HPXMLDecimalGreaterThanZero_simple">
+		<xs:restriction base="xs:decimal">
+			<xs:minInclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="HPXMLDecimalGreaterThanZero">
+		<xs:simpleContent>
+			<xs:extension base="HPXMLDecimalGreaterThanZero_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="HPXMLFractionInclusive_simple">
+		<xs:annotation>
+			<xs:documentation>A fraction that has to be between 0 and 1 inclusive</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+			<xs:maxInclusive value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="HPXMLFractionInclusive">
+		<xs:simpleContent>
+			<xs:extension base="HPXMLFractionInclusive_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="HPXMLFractionExcludingZero_simple">
+		<xs:annotation>
+			<xs:documentation>A fraction that has to be between 0 exclusive and 1 inclusive</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+			<xs:maxInclusive value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="HPXMLFractionExcludingZero">
+		<xs:simpleContent>
+			<xs:extension base="HPXMLFractionExcludingZero_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="HPXMLFractionExclusive_simple">
+		<xs:annotation>
+			<xs:documentation>A fraction that has to be between 0 and 1 exclusive</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+			<xs:maxExclusive value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="HPXMLFractionExclusive">
+		<xs:simpleContent>
+			<xs:extension base="HPXMLFractionExclusive_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:complexType name="HPXMLInteger">
 		<xs:simpleContent>
 			<xs:extension base="xs:integer">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="HPXMLIntegerGreaterThanZero_simple">
+		<xs:restriction base="xs:integer">
+			<xs:minExclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="HPXMLIntegerGreaterThanZero">
+		<xs:simpleContent>
+			<xs:extension base="HPXMLIntegerGreaterThanZero_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="HPXMLIntegerGreaterThanOrEqualToZero_simple">
+		<xs:restriction base="xs:integer">
+			<xs:minInclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="HPXMLIntegerGreaterThanOrEqualToZero">
+		<xs:simpleContent>
+			<xs:extension base="HPXMLIntegerGreaterThanOrEqualToZero_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -6177,16 +6285,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="StateCode_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="StateCode">
-		<xs:simpleContent>
-			<xs:extension base="StateCode_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="ZipCode_simple">
 		<xs:restriction base="xs:string">
 			<xs:pattern value="[0-9]{5}(-[0-9]{4})?"/>
@@ -6199,37 +6297,7 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="USPSBarCode_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="USPSBarCode">
-		<xs:simpleContent>
-			<xs:extension base="USPSBarCode_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<!--Name Information Below-->
-	<xs:simpleType name="PrefixName_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="PrefixName">
-		<xs:simpleContent>
-			<xs:extension base="PrefixName_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="SuffixName_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="SuffixName">
-		<xs:simpleContent>
-			<xs:extension base="SuffixName_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="IndividualType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="owner-occupant"/>
@@ -6276,26 +6344,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="TelephoneNumber_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="TelephoneNumber">
-		<xs:simpleContent>
-			<xs:extension base="TelephoneNumber_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="TelephoneExtension_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="TelephoneExtension">
-		<xs:simpleContent>
-			<xs:extension base="TelephoneExtension_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<!--Email Information Below-->
 	<xs:simpleType name="EmailTypeCode_simple">
 		<xs:restriction base="xs:string">
@@ -6311,90 +6359,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="EmailAddress_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="EmailAddress">
-		<xs:simpleContent>
-			<xs:extension base="EmailAddress_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<!--System Identifiers Below-->
-	<xs:simpleType name="SendingSystemIdentifierType_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="SendingSystemIdentifierType">
-		<xs:simpleContent>
-			<xs:extension base="SendingSystemIdentifierType_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="SendingSystemIdentifierValue_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="SendingSystemIdentifierValue">
-		<xs:simpleContent>
-			<xs:extension base="SendingSystemIdentifierValue_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="ReceivingSystemIdentifierType_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="ReceivingSystemIdentifierType">
-		<xs:simpleContent>
-			<xs:extension base="ReceivingSystemIdentifierType_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="ReceivingSystemIdentifierValue_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="ReceivingSystemIdentifierValue">
-		<xs:simpleContent>
-			<xs:extension base="ReceivingSystemIdentifierValue_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<!--XMLTransaction Header Information Below-->
-	<xs:simpleType name="XMLType_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="XMLType">
-		<xs:simpleContent>
-			<xs:extension base="XMLType_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="XMLGeneratedBy_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="XMLGeneratedBy">
-		<xs:simpleContent>
-			<xs:extension base="XMLGeneratedBy_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="CreatedDateAndTime_simple">
-		<xs:restriction base="xs:dateTime"/>
-	</xs:simpleType>
-	<xs:complexType name="CreatedDateAndTime">
-		<xs:simpleContent>
-			<xs:extension base="CreatedDateAndTime_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<!--Utility Information Below-->
-	<!--Misc Data Fields Below-->
 	<!--Air Infiltration Below-->
 	<xs:simpleType name="BuildingLeakiness_simple">
 		<xs:restriction base="xs:string">
@@ -6421,18 +6385,6 @@
 	<xs:complexType name="WindConditions">
 		<xs:simpleContent>
 			<xs:extension base="WindConditions_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="BuildingAirLeakage_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="BuildingAirLeakage">
-		<xs:simpleContent>
-			<xs:extension base="BuildingAirLeakage_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -6467,16 +6419,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="FanPressure_simple">
-		<xs:restriction base="xs:double"/>
-	</xs:simpleType>
-	<xs:complexType name="FanPressure">
-		<xs:simpleContent>
-			<xs:extension base="FanPressure_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="FanRingUsed_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="open"/>
@@ -6500,18 +6442,6 @@
 	<xs:complexType name="TypeofBlowerDoorTest">
 		<xs:simpleContent>
 			<xs:extension base="TypeofBlowerDoorTest_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="HousePressure_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="HousePressure">
-		<xs:simpleContent>
-			<xs:extension base="HousePressure_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -6596,16 +6526,6 @@
 	<xs:complexType name="ClimateZoneIECC">
 		<xs:simpleContent>
 			<xs:extension base="ClimateZoneIECC_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="EarthquakeZone_simple">
-		<xs:restriction base="xs:boolean"/>
-	</xs:simpleType>
-	<xs:complexType name="EarthquakeZone">
-		<xs:simpleContent>
-			<xs:extension base="EarthquakeZone_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -6717,42 +6637,6 @@
 	<xs:complexType name="OrientationType">
 		<xs:simpleContent>
 			<xs:extension base="OrientationType_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="NumberOfFloorsType_simple">
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="NumberOfFloorsType">
-		<xs:simpleContent>
-			<xs:extension base="NumberOfFloorsType_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="IntegerGreaterThanZero_simple">
-		<xs:restriction base="xs:integer">
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="IntegerGreaterThanZero">
-		<xs:simpleContent>
-			<xs:extension base="IntegerGreaterThanZero_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="IntegerGreaterThanOrEqualToZero_simple">
-		<xs:restriction base="xs:integer">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="IntegerGreaterThanOrEqualToZero">
-		<xs:simpleContent>
-			<xs:extension base="IntegerGreaterThanOrEqualToZero_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -6912,16 +6796,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="Year_simple">
-		<xs:restriction base="xs:integer"/>
-	</xs:simpleType>
-	<xs:complexType name="Year">
-		<xs:simpleContent>
-			<xs:extension base="Year_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<!-- Make sure to update FuelType with changes to this list as well. -->
 	<xs:simpleType name="ConsumptionType_simple">
 		<xs:restriction base="xs:string">
@@ -7055,16 +6929,6 @@
 	<xs:complexType name="PeakSeason">
 		<xs:simpleContent>
 			<xs:extension base="PeakSeason_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="COReading_simple">
-		<xs:restriction base="xs:double"/>
-	</xs:simpleType>
-	<xs:complexType name="COReading">
-		<xs:simpleContent>
-			<xs:extension base="COReading_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -7344,31 +7208,7 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="RValue_simple">
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="RValue">
-		<xs:simpleContent>
-			<xs:extension base="RValue_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<!--Insulation Below-->
-	<xs:simpleType name="AssemblyRValue_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="AssemblyRValue">
-		<xs:simpleContent>
-			<xs:extension base="AssemblyRValue_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="DoorThirdPartyCertifications_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Energy Star"/>
@@ -7745,19 +7585,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="SHGC_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-			<xs:maxExclusive value="1"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="SHGC">
-		<xs:simpleContent>
-			<xs:extension base="SHGC_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="InteriorShading_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="light blinds"/>
@@ -7796,18 +7623,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="UFactor_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="UFactor">
-		<xs:simpleContent>
-			<xs:extension base="UFactor_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<!--Combustion Appliance Tests Below-->
 	<xs:simpleType name="FlueCondition_simple">
 		<xs:restriction base="xs:string">
@@ -7823,16 +7638,6 @@
 		</xs:simpleContent>
 	</xs:complexType>
 	<!--Combustion Appliance Zone Test Below-->
-	<xs:simpleType name="CAZDepressurizationLimit_simple">
-		<xs:restriction base="xs:double"/>
-	</xs:simpleType>
-	<xs:complexType name="CAZDepressurizationLimit">
-		<xs:simpleContent>
-			<xs:extension base="CAZDepressurizationLimit_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="OpenClosed_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="open"/>
@@ -7855,16 +7660,6 @@
 	<xs:complexType name="DepressurizationFindingPoorCase">
 		<xs:simpleContent>
 			<xs:extension base="DepressurizationFindingPoorCase_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="NetPressureChange_simple">
-		<xs:restriction base="xs:double"/>
-	</xs:simpleType>
-	<xs:complexType name="NetPressureChange">
-		<xs:simpleContent>
-			<xs:extension base="NetPressureChange_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -7944,18 +7739,6 @@
 	<xs:complexType name="DistrictSteamType">
 		<xs:simpleContent>
 			<xs:extension base="DistrictSteamType_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Efficiency_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="Efficiency">
-		<xs:simpleContent>
-			<xs:extension base="Efficiency_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -8166,16 +7949,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="MeasuredDuctLeakage_simple">
-		<xs:restriction base="xs:double"/>
-	</xs:simpleType>
-	<xs:complexType name="MeasuredDuctLeakage">
-		<xs:simpleContent>
-			<xs:extension base="MeasuredDuctLeakage_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<!--HVAC System Below-->
 	<xs:simpleType name="AirHandlerStaticPressureMeasurementLocation_simple">
 		<xs:restriction base="xs:string">
@@ -8204,16 +7977,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="Capacity_simple">
-		<xs:restriction base="xs:double"/>
-	</xs:simpleType>
-	<xs:complexType name="Capacity">
-		<xs:simpleContent>
-			<xs:extension base="Capacity_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="HVACMaintenanceSchedule_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="none"/>
@@ -8232,36 +7995,6 @@
 	<xs:complexType name="HVACMaintenanceSchedule">
 		<xs:simpleContent>
 			<xs:extension base="HVACMaintenanceSchedule_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="DispositionofExistingSystem_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="DispositionofExistingSystem">
-		<xs:simpleContent>
-			<xs:extension base="DispositionofExistingSystem_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Manufacturer_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="Manufacturer">
-		<xs:simpleContent>
-			<xs:extension base="Manufacturer_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Model_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="Model">
-		<xs:simpleContent>
-			<xs:extension base="Model_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -8301,16 +8034,6 @@
 		</xs:simpleContent>
 	</xs:complexType>
 	<!--Thermostats Below-->
-	<xs:simpleType name="Temperature_simple">
-		<xs:restriction base="xs:double"/>
-	</xs:simpleType>
-	<xs:complexType name="Temperature">
-		<xs:simpleContent>
-			<xs:extension base="Temperature_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="ThermostatType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="programmable thermostat"/>
@@ -8341,16 +8064,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="Hours_simple">
-		<xs:restriction base="xs:integer"/>
-	</xs:simpleType>
-	<xs:complexType name="Hours">
-		<xs:simpleContent>
-			<xs:extension base="Hours_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<!--Water Heating System Below-->
 	<xs:simpleType name="EnergyFactor_simple">
 		<xs:restriction base="xs:double">
@@ -8365,16 +8078,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="PipeInsulated_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="PipeInsulated">
-		<xs:simpleContent>
-			<xs:extension base="PipeInsulated_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="RecoveryEfficiency_simple">
 		<xs:restriction base="xs:double">
 			<xs:minExclusive value="0"/>
@@ -8384,41 +8087,6 @@
 	<xs:complexType name="RecoveryEfficiency">
 		<xs:simpleContent>
 			<xs:extension base="RecoveryEfficiency_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Volume_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="Volume">
-		<xs:simpleContent>
-			<xs:extension base="Volume_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="ThermalEfficiency_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-			<xs:maxInclusive value="1"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="ThermalEfficiency">
-		<xs:simpleContent>
-			<xs:extension base="ThermalEfficiency_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="ProjectType_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="ProjectType">
-		<xs:simpleContent>
-			<xs:extension base="ProjectType_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -8456,74 +8124,6 @@
 	<xs:complexType name="DishwasherType">
 		<xs:simpleContent>
 			<xs:extension base="DishwasherType_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="RatedAnnualkWh_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="RatedAnnualkWh">
-		<xs:simpleContent>
-			<xs:extension base="RatedAnnualkWh_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="RatedWaterGalPerCycle_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="RatedWaterGalPerCycle">
-		<xs:simpleContent>
-			<xs:extension base="RatedWaterGalPerCycle_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<!--Freezer Below-->
-	<!--Refrigerators Below-->
-	<!--Energy Savings Information Below-->
-	<xs:simpleType name="TotalCostHealthSafetyMeasures_simple">
-		<xs:restriction base="xs:double"/>
-	</xs:simpleType>
-	<xs:complexType name="TotalCostHealthSafetyMeasures">
-		<xs:simpleContent>
-			<xs:extension base="TotalCostHealthSafetyMeasures_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="TotalCostQualEnergyMeasures_simple">
-		<xs:restriction base="xs:double"/>
-	</xs:simpleType>
-	<xs:complexType name="TotalCostQualEnergyMeasures">
-		<xs:simpleContent>
-			<xs:extension base="TotalCostQualEnergyMeasures_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<!--Software Information Below-->
-	<xs:simpleType name="SoftwareProgramUsed_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="SoftwareProgramUsed">
-		<xs:simpleContent>
-			<xs:extension base="SoftwareProgramUsed_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="SoftwareProgramVersion_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="SoftwareProgramVersion">
-		<xs:simpleContent>
-			<xs:extension base="SoftwareProgramVersion_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -8755,18 +8355,6 @@
 	<xs:complexType name="GrossOrNet">
 		<xs:simpleContent>
 			<xs:extension base="GrossOrNet_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="SurfaceArea_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="SurfaceArea">
-		<xs:simpleContent>
-			<xs:extension base="SurfaceArea_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -9197,240 +8785,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="ResourceTypeCode_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="ResourceTypeCode">
-		<xs:simpleContent>
-			<xs:extension base="ResourceTypeCode_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Quantity_simple">
-		<xs:restriction base="xs:decimal"/>
-	</xs:simpleType>
-	<xs:complexType name="Quantity">
-		<xs:simpleContent>
-			<xs:extension base="Quantity_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="ProgramName_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="ProgramName">
-		<xs:simpleContent>
-			<xs:extension base="ProgramName_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Title_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="Title">
-		<xs:simpleContent>
-			<xs:extension base="Title_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="StartDate_simple">
-		<xs:restriction base="xs:date"/>
-	</xs:simpleType>
-	<xs:complexType name="StartDate">
-		<xs:simpleContent>
-			<xs:extension base="StartDate_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="CompleteDateEstimated_simple">
-		<xs:restriction base="xs:date"/>
-	</xs:simpleType>
-	<xs:complexType name="CompleteDateEstimated">
-		<xs:simpleContent>
-			<xs:extension base="CompleteDateEstimated_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="CompleteDateActual_simple">
-		<xs:restriction base="xs:date"/>
-	</xs:simpleType>
-	<xs:complexType name="CompleteDateActual">
-		<xs:simpleContent>
-			<xs:extension base="CompleteDateActual_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Notes_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="Notes">
-		<xs:simpleContent>
-			<xs:extension base="Notes_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="MeasureCode_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="MeasureCode">
-		<xs:simpleContent>
-			<xs:extension base="MeasureCode_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="MeasureDescription_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="MeasureDescription">
-		<xs:simpleContent>
-			<xs:extension base="MeasureDescription_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="EstimatedLife_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="EstimatedLife">
-		<xs:simpleContent>
-			<xs:extension base="EstimatedLife_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="InstallationDate_simple">
-		<xs:restriction base="xs:date"/>
-	</xs:simpleType>
-	<xs:complexType name="InstallationDate">
-		<xs:simpleContent>
-			<xs:extension base="InstallationDate_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Cost_simple">
-		<xs:restriction base="xs:decimal"/>
-	</xs:simpleType>
-	<xs:complexType name="Cost">
-		<xs:simpleContent>
-			<xs:extension base="Cost_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="FundingSourceCode_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="FundingSourceCode">
-		<xs:simpleContent>
-			<xs:extension base="FundingSourceCode_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="FundingSourceName_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="FundingSourceName">
-		<xs:simpleContent>
-			<xs:extension base="FundingSourceName_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="IncentiveAmount_simple">
-		<xs:restriction base="xs:decimal"/>
-	</xs:simpleType>
-	<xs:complexType name="IncentiveAmount">
-		<xs:simpleContent>
-			<xs:extension base="IncentiveAmount_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="LoadProfile_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="LoadProfile">
-		<xs:simpleContent>
-			<xs:extension base="LoadProfile_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="AnnualAmount_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="AnnualAmount">
-		<xs:simpleContent>
-			<xs:extension base="AnnualAmount_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="JobRole_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="JobRole">
-		<xs:simpleContent>
-			<xs:extension base="JobRole_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Fraction_simple">
-		<xs:annotation>
-			<xs:documentation>A fraction that has to be between 0 and 1 inclusive</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-			<xs:maxInclusive value="1"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="Fraction">
-		<xs:simpleContent>
-			<xs:extension base="Fraction_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="FractionExcludingZero_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-			<xs:maxInclusive value="1"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="FractionExcludingZero">
-		<xs:simpleContent>
-			<xs:extension base="FractionExcludingZero_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="FractionGreaterThanOne_simple">
-		<xs:annotation>
-			<xs:documentation>A fraction that can be greater than one (ie 110%)</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="FractionGreaterThanOne">
-		<xs:simpleContent>
-			<xs:extension base="FractionGreaterThanOne_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="ImprovementStatusType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Installed"/>
@@ -9566,18 +8920,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="LengthMeasurement_simple">
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="LengthMeasurement">
-		<xs:simpleContent>
-			<xs:extension base="LengthMeasurement_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="InsulationGrade_simple">
 		<xs:restriction base="xs:integer">
 			<xs:minInclusive value="1"/>
@@ -9603,18 +8945,6 @@
 	<xs:complexType name="FloorCovering">
 		<xs:simpleContent>
 			<xs:extension base="FloorCovering_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Pitch_simple">
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="Pitch">
-		<xs:simpleContent>
-			<xs:extension base="Pitch_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -9686,42 +9016,6 @@
 	<xs:complexType name="EVChargingConnector">
 		<xs:simpleContent>
 			<xs:extension base="EVChargingConnector_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Current_simple">
-		<xs:restriction base="xs:decimal">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="Current">
-		<xs:simpleContent>
-			<xs:extension base="Current_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Voltage_simple">
-		<xs:restriction base="xs:decimal">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="Voltage">
-		<xs:simpleContent>
-			<xs:extension base="Voltage_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Power_simple">
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="Power">
-		<xs:simpleContent>
-			<xs:extension base="Power_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -9901,16 +9195,6 @@
 	<xs:complexType name="eGridRegions">
 		<xs:simpleContent>
 			<xs:extension base="eGridRegions_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="ProgramSponsor_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="ProgramSponsor">
-		<xs:simpleContent>
-			<xs:extension base="ProgramSponsor_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -10105,30 +9389,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="Speed_simple">
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="Speed">
-		<xs:simpleContent>
-			<xs:extension base="Speed_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="FlowRate_simple">
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="FlowRate">
-		<xs:simpleContent>
-			<xs:extension base="FlowRate_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="PoolCleanerType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="robotic"/>
@@ -10277,18 +9537,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="PeopleCount_simple">
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="PeopleCount">
-		<xs:simpleContent>
-			<xs:extension base="PeopleCount_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="WindThirdPartyCertification_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="AWEA 9.1-2009"/>
@@ -10340,32 +9588,6 @@
 	<xs:complexType name="MERV">
 		<xs:simpleContent>
 			<xs:extension base="MERV_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="SolarAbsorptance_simple">
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-			<xs:maxInclusive value="1"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="SolarAbsorptance">
-		<xs:simpleContent>
-			<xs:extension base="SolarAbsorptance_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Emittance_simple">
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-			<xs:maxInclusive value="1"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="Emittance">
-		<xs:simpleContent>
-			<xs:extension base="Emittance_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -10453,18 +9675,6 @@
 	<xs:complexType name="BatteryType">
 		<xs:simpleContent>
 			<xs:extension base="BatteryType_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="BatteryCapacity_simple">
-		<xs:restriction base="xs:decimal">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="BatteryCapacity">
-		<xs:simpleContent>
-			<xs:extension base="BatteryCapacity_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -10589,44 +9799,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="CollectorRatedThermalLosses_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="CollectorRatedThermalLosses">
-		<xs:simpleContent>
-			<xs:extension base="CollectorRatedThermalLosses_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="SolarFraction_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-			<xs:maxInclusive value="1"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="SolarFraction">
-		<xs:simpleContent>
-			<xs:extension base="SolarFraction_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="CollectorRatedOpticalEfficiency_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-			<xs:maxExclusive value="1"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="CollectorRatedOpticalEfficiency">
-		<xs:simpleContent>
-			<xs:extension base="CollectorRatedOpticalEfficiency_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="PVModuleType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="standard"/>
@@ -10709,18 +9881,6 @@
 	<xs:complexType name="ExternalResourceType">
 		<xs:simpleContent>
 			<xs:extension base="ExternalResourceType_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="SolarThermalSystemEnergyFactor_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="SolarThermalSystemEnergyFactor">
-		<xs:simpleContent>
-			<xs:extension base="SolarThermalSystemEnergyFactor_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -1411,12 +1411,12 @@
 											<xs:documentation>[sq.ft.] Conditioned floor area that this distribution system serves.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AnnualHeatingDistributionSystemEfficiency" type="HPXMLFractionExcludingZero">
+									<xs:element minOccurs="0" name="AnnualHeatingDistributionSystemEfficiency" type="HPXMLFractionGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for heating, the DSE may be approximated by equation 3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use History. Enter values as a fractional number between 0 and 1, i.e. 80% = 0.8</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AnnualCoolingDistributionSystemEfficiency" type="HPXMLFractionExcludingZero">
+									<xs:element minOccurs="0" name="AnnualCoolingDistributionSystemEfficiency" type="HPXMLFractionGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for cooling, the DSE may be approximated by equation 3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use History. Enter values as a fractional number between 0 and 1, i.e. 80% = 0.8</xs:documentation>
 										</xs:annotation>
@@ -1542,7 +1542,7 @@
 														<xs:documentation>[sones] as tested in field</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="TotalRecoveryEfficiency" type="HPXMLFractionExcludingZero">
+												<xs:element minOccurs="0" name="TotalRecoveryEfficiency" type="HPXMLFractionGreaterThanZero">
 													<xs:annotation>
 														<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by electric
 															consumption, case heat loss or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential
@@ -1550,7 +1550,7 @@
 															(hvi.org).</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="SensibleRecoveryEfficiency" type="HPXMLFractionExcludingZero">
+												<xs:element minOccurs="0" name="SensibleRecoveryEfficiency" type="HPXMLFractionGreaterThanZero">
 													<xs:annotation>
 														<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by electric consumption, case heat loss or heat gain,
 															air leakage, airflow mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test),
@@ -1558,7 +1558,7 @@
 															the Home Ventilating Institute (hvi.org).</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="AdjustedTotalRecoveryEfficiency" type="HPXMLFractionExcludingZero">
+												<xs:element minOccurs="0" name="AdjustedTotalRecoveryEfficiency" type="HPXMLFractionGreaterThanZero">
 													<xs:annotation>
 														<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by case heat loss
 															or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential total energy that could be
@@ -1567,7 +1567,7 @@
 															Ventilating Institute (hvi.org).</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="AdjustedSensibleRecoveryEfficiency" type="HPXMLFractionExcludingZero">
+												<xs:element minOccurs="0" name="AdjustedSensibleRecoveryEfficiency" type="HPXMLFractionGreaterThanZero">
 													<xs:annotation>
 														<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by case heat loss or heat gain, air leakage, airflow
 															mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test), as a percent of the
@@ -1730,7 +1730,7 @@
 												DOE testing procedure.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ThermalEfficiency" type="HPXMLFractionExcludingZero" minOccurs="0"/>
+									<xs:element name="ThermalEfficiency" type="HPXMLFractionGreaterThanZero" minOccurs="0"/>
 									<xs:element minOccurs="0" name="WaterHeaterInsulation">
 										<xs:complexType>
 											<xs:sequence>
@@ -1895,7 +1895,7 @@
 											<xs:sequence>
 												<xs:element minOccurs="0" name="FacilitiesConnected" type="DrainWaterHeatRecoveryFacilitiesConnected"/>
 												<xs:element minOccurs="0" name="EqualFlow" type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="Efficiency" type="HPXMLFractionExcludingZero">
+												<xs:element minOccurs="0" name="Efficiency" type="HPXMLFractionGreaterThanZero">
 													<xs:annotation>
 														<xs:documentation>Efficiency percent expressed as a fraction from 0-1.</xs:documentation>
 													</xs:annotation>
@@ -2016,7 +2016,7 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="ConnectedTo" type="LocalReference"/>
-									<xs:element minOccurs="0" name="SolarFraction" type="HPXMLFractionExcludingZero">
+									<xs:element minOccurs="0" name="SolarFraction" type="HPXMLFractionGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>The Solar Fraction is the portion of the total conventional hot water heating load (delivered energy and tank standby losses). The higher
 												the solar fraction, the greater the solar contribution to water heating, which reduces the energy required by the backup water heater. This value can be
@@ -2110,7 +2110,7 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" name="InverterType" type="InverterType"/>
-									<xs:element minOccurs="0" name="InverterEfficiency" type="HPXMLFractionExcludingZero"/>
+									<xs:element minOccurs="0" name="InverterEfficiency" type="HPXMLFractionGreaterThanZero"/>
 									<xs:element minOccurs="0" name="YearInverterManufactured" type="HPXMLInteger"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="HPXMLInteger"/>
 									<xs:element ref="extension" minOccurs="0"/>
@@ -2172,7 +2172,7 @@
 												with a 0.2C discharge current.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RoundTripEfficiency" type="HPXMLFractionExcludingZero">
+									<xs:element minOccurs="0" name="RoundTripEfficiency" type="HPXMLFractionGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Not all the power that is used to charge the battery is available during discharge. Round trip efficiency is the ratio of the energy put
 												in to the energy retrieved from storage.</xs:documentation>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -7,9 +7,9 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="XMLType" type="XMLType"/>
-				<xs:element name="XMLGeneratedBy" type="XMLGeneratedBy"/>
-				<xs:element name="CreatedDateAndTime" type="CreatedDateAndTime"/>
+				<xs:element name="XMLType" type="HPXMLString"/>
+				<xs:element name="XMLGeneratedBy" type="HPXMLString"/>
+				<xs:element name="CreatedDateAndTime" type="HPXMLDateTime"/>
 				<xs:element name="Transaction" type="TransactionType"/>
 				<xs:element minOccurs="0" ref="extension"/>
 			</xs:sequence>
@@ -25,9 +25,9 @@
 			<xs:element name="Address1" type="HPXMLString" minOccurs="0"/>
 			<xs:element name="Address2" type="HPXMLString" minOccurs="0"/>
 			<xs:element name="CityMunicipality" type="HPXMLString" minOccurs="0"/>
-			<xs:element name="StateCode" type="StateCode" minOccurs="0"/>
+			<xs:element name="StateCode" type="HPXMLString" minOccurs="0"/>
 			<xs:element name="ZipCode" type="ZipCode" minOccurs="0"/>
-			<xs:element name="USPSBarCode" type="USPSBarCode" minOccurs="0"/>
+			<xs:element name="USPSBarCode" type="HPXMLString" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -64,10 +64,10 @@
 				systems, and have it identified in the two systems. Also, there is an id attribute to define a local id to be used internally. </xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType" minOccurs="0"/>
-			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue" minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType" minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue" minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierType" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierValue" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierType" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierValue" type="HPXMLString" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="id" type="xs:ID" use="required">
 			<xs:annotation>
@@ -91,10 +91,10 @@
 				elements in other xml transactions.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType" minOccurs="0"/>
-			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue" minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType" minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue" minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierType" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierValue" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierType" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierValue" type="HPXMLString" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="idref" type="xs:IDREF">
 			<xs:annotation>
@@ -142,11 +142,11 @@
 			<xs:element name="Name">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="PrefixName" type="PrefixName" minOccurs="0"/>
+						<xs:element name="PrefixName" type="HPXMLString" minOccurs="0"/>
 						<xs:element name="FirstName" type="HPXMLString"/>
 						<xs:element name="MiddleName" type="HPXMLString" minOccurs="0"/>
 						<xs:element name="LastName" type="HPXMLString"/>
-						<xs:element name="SuffixName" type="SuffixName" minOccurs="0"/>
+						<xs:element name="SuffixName" type="HPXMLString" minOccurs="0"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -215,7 +215,7 @@
 			<xs:group ref="SystemInfo"/>
 			<xs:element minOccurs="0" name="InsulationGrade" type="InsulationGrade"/>
 			<xs:element minOccurs="0" name="InsulationCondition" type="InsulationCondition"/>
-			<xs:element minOccurs="0" name="AssemblyEffectiveRValue" type="AssemblyRValue">
+			<xs:element minOccurs="0" name="AssemblyEffectiveRValue" type="HPXMLDoubleGreaterThanZero">
 				<xs:annotation>
 					<xs:documentation>This should indicate the effective R-value of the complete assembly including any air films or other treatments. For below-grade surfaces adjacent to ground, it should not include the insulating effect of the ground.</xs:documentation>
 				</xs:annotation>
@@ -268,8 +268,8 @@
 		<xs:sequence>
 			<xs:element name="InstallationType" type="InstallationType" minOccurs="0"/>
 			<xs:element name="InsulationMaterial" type="InsulationMaterial" minOccurs="0"/>
-			<xs:element name="NominalRValue" type="RValue" minOccurs="0"/>
-			<xs:element name="Thickness" type="LengthMeasurement" minOccurs="0">
+			<xs:element name="NominalRValue" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0"/>
+			<xs:element name="Thickness" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[in]</xs:documentation>
 				</xs:annotation>
@@ -290,12 +290,12 @@
 		<xs:complexContent>
 			<xs:extension base="InsulationLayerInfoBase">
 				<xs:sequence>
-					<xs:element name="DistanceToTopOfInsulation" type="LengthMeasurement" minOccurs="0">
+					<xs:element name="DistanceToTopOfInsulation" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>[ft] Vertical distance from top of foundation wall to top of insulation.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="DistanceToBottomOfInsulation" type="LengthMeasurement" minOccurs="0">
+					<xs:element name="DistanceToBottomOfInsulation" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>[ft] Vertical distance from top of foundation wall to bottom of insulation.</xs:documentation>
 						</xs:annotation>
@@ -309,7 +309,7 @@
 		<xs:complexContent>
 			<xs:extension base="InsulationLayerInfoBase">
 				<xs:sequence>
-					<xs:element name="InsulationDepth" type="LengthMeasurement" minOccurs="0">
+					<xs:element name="InsulationDepth" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>[ft] Depth from top of slab to bottom of vertical slab perimeter insulation</xs:documentation>
 						</xs:annotation>
@@ -323,7 +323,7 @@
 		<xs:complexContent>
 			<xs:extension base="InsulationLayerInfoBase">
 				<xs:sequence>
-					<xs:element name="InsulationWidth" type="LengthMeasurement" minOccurs="0">
+					<xs:element name="InsulationWidth" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>[ft] Width from slab edge inward of horizontal under-slab insulation</xs:documentation>
 						</xs:annotation>
@@ -341,7 +341,7 @@
 	<xs:complexType name="InteriorFinishInfo">
 		<xs:sequence>
 			<xs:element minOccurs="0" name="Type" type="InteriorFinish"/>
-			<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+			<xs:element minOccurs="0" name="Thickness" type="HPXMLDoubleGreaterThanOrEqualToZero">
 				<xs:annotation>
 					<xs:documentation>[in]</xs:documentation>
 				</xs:annotation>
@@ -359,12 +359,12 @@
 			<xs:group ref="SystemInfo"/>
 			<xs:element minOccurs="0" ref="ConnectedDevice"/>
 			<xs:element minOccurs="0" ref="AttachedToSpace"/>
-			<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
-			<xs:element name="Manufacturer" type="Manufacturer" minOccurs="0"/>
-			<xs:element name="ModelNumber" type="Model" minOccurs="0"/>
+			<xs:element name="Count" type="HPXMLIntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+			<xs:element name="Manufacturer" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="ModelNumber" type="HPXMLString" minOccurs="0"/>
 			<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
-			<xs:element name="ModelYear" type="Year" minOccurs="0"/>
+			<xs:element name="ModelYear" type="HPXMLInteger" minOccurs="0"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="ApplianceThirdPartyCertifications"/>
 			<xs:element minOccurs="0" name="IsSharedAppliance" type="HPXMLBoolean">
 				<xs:annotation>
@@ -401,7 +401,7 @@
 					</xs:element>
 					<xs:element maxOccurs="unbounded" minOccurs="0" name="ControlType" type="ClothesDryerControlType"/>
 					<xs:element minOccurs="0" name="Vented" type="HPXMLBoolean"/>
-					<xs:element minOccurs="0" name="VentedFlowRate" type="FlowRate"/>
+					<xs:element minOccurs="0" name="VentedFlowRate" type="HPXMLDoubleGreaterThanOrEqualToZero"/>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -444,7 +444,7 @@
 							<xs:documentation>loads/week of actual usage by the occupants; use LabelUsage instead for the loads/week on the EnergyGuide label</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="RatedAnnualkWh" type="RatedAnnualkWh">
+					<xs:element minOccurs="0" name="RatedAnnualkWh" type="HPXMLDoubleGreaterThanZero">
 						<xs:annotation>
 							<xs:documentation>kWh/yr</xs:documentation>
 						</xs:annotation>
@@ -492,10 +492,10 @@
 					<xs:element minOccurs="0" name="Fuel" type="FuelType"/>
 					<xs:element name="HeatDryDefaultOff" type="HPXMLBoolean" minOccurs="0"/>
 					<xs:element name="AuxillaryWaterHeaterDefaultOff" type="HPXMLBoolean" minOccurs="0"/>
-					<xs:element minOccurs="0" name="RatedAnnualkWh" type="RatedAnnualkWh"/>
+					<xs:element minOccurs="0" name="RatedAnnualkWh" type="HPXMLDoubleGreaterThanZero"/>
 					<xs:element minOccurs="0" name="EnergyFactor" type="EnergyFactor"/>
-					<xs:element minOccurs="0" name="RatedWaterGalPerCycle" type="RatedWaterGalPerCycle"/>
-					<xs:element minOccurs="0" name="PlaceSettingCapacity" type="IntegerGreaterThanZero"/>
+					<xs:element minOccurs="0" name="RatedWaterGalPerCycle" type="HPXMLDoubleGreaterThanZero"/>
+					<xs:element minOccurs="0" name="PlaceSettingCapacity" type="HPXMLIntegerGreaterThanZero"/>
 					<xs:element minOccurs="0" name="Usage" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>loads/week of actual usage by the occupants; use LabelUsage instead for the loads/week on the EnergyGuide label</xs:documentation>
@@ -531,9 +531,9 @@
 			<xs:extension base="ApplianceTypeSummaryInfo">
 				<xs:sequence>
 					<xs:element minOccurs="0" name="Location" type="RefrigeratorLocation"/>
-					<xs:element name="RatedAnnualkWh" type="RatedAnnualkWh" minOccurs="0"/>
+					<xs:element name="RatedAnnualkWh" type="HPXMLDoubleGreaterThanZero" minOccurs="0"/>
 					<xs:element name="Configuration" type="FreezerStyle" minOccurs="0"/>
-					<xs:element name="Volume" type="Volume" minOccurs="0">
+					<xs:element name="Volume" type="HPXMLDoubleGreaterThanZero" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>[cu.ft.]</xs:documentation>
 						</xs:annotation>
@@ -549,23 +549,23 @@
 				<xs:sequence>
 					<xs:element name="Type" type="RefrigeratorStyle" minOccurs="0"/>
 					<xs:element minOccurs="0" name="Location" type="RefrigeratorLocation"/>
-					<xs:element name="RatedAnnualkWh" type="RatedAnnualkWh" minOccurs="0"/>
+					<xs:element name="RatedAnnualkWh" type="HPXMLDoubleGreaterThanZero" minOccurs="0"/>
 					<xs:element name="PrimaryIndicator" type="HPXMLBoolean" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>True if it is the primary refrigerator</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="Volume" type="Volume" minOccurs="0">
+					<xs:element name="Volume" type="HPXMLDoubleGreaterThanZero" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>[cu.ft.]</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="FreshVolume" type="Volume">
+					<xs:element minOccurs="0" name="FreshVolume" type="HPXMLDoubleGreaterThanZero">
 						<xs:annotation>
 							<xs:documentation>[cu.ft.] Volume of refrigerator for keeping food at less than freezing.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="FrozenVolume" type="Volume">
+					<xs:element minOccurs="0" name="FrozenVolume" type="HPXMLDoubleGreaterThanZero">
 						<xs:annotation>
 							<xs:documentation>[cu.ft.] Freezer Volume</xs:documentation>
 						</xs:annotation>
@@ -605,7 +605,7 @@
 							<xs:documentation>The rated efficiency of the dehumidifier in liters of water removed per kilowatt-hour of energy consumed. The IEF is a new metric used for dehumidifiers as of 2019 that incorporates energy consumed when the fan is running while the refrigeration system is off and standby power consumption, in addition to the energy consumed by the refrigeration system. [L/kWh]</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="DehumidistatSetpoint" type="Fraction">
+					<xs:element minOccurs="0" name="DehumidistatSetpoint" type="HPXMLFractionInclusive">
 						<xs:annotation>
 							<xs:documentation>Enter the setpoint as a fractional number between 0 and 1, i.e. 60% RH = 0.6.</xs:documentation>
 						</xs:annotation>
@@ -625,7 +625,7 @@
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
-					<xs:element minOccurs="0" name="FractionDehumidificationLoadServed" type="Fraction"/>
+					<xs:element minOccurs="0" name="FractionDehumidificationLoadServed" type="HPXMLFractionInclusive"/>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -658,8 +658,8 @@
 	<xs:element name="SoftwareInfo">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="SoftwareProgramUsed" type="SoftwareProgramUsed" minOccurs="0"/>
-				<xs:element name="SoftwareProgramVersion" type="SoftwareProgramVersion" minOccurs="0"/>
+				<xs:element name="SoftwareProgramUsed" type="HPXMLString" minOccurs="0"/>
+				<xs:element name="SoftwareProgramVersion" type="HPXMLString" minOccurs="0"/>
 				<xs:element ref="extension" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attribute name="dataSource" type="DataSource"/>
@@ -679,8 +679,8 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element minOccurs="0" name="Qualification" type="AuditorQualification" maxOccurs="unbounded"/>
-						<xs:element minOccurs="0" name="StateWhereQualificationHeld" type="StateCode"/>
-						<xs:element minOccurs="0" name="YearsExperience" type="IntegerGreaterThanOrEqualToZero"/>
+						<xs:element minOccurs="0" name="StateWhereQualificationHeld" type="HPXMLString"/>
+						<xs:element minOccurs="0" name="YearsExperience" type="HPXMLIntegerGreaterThanOrEqualToZero"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -690,7 +690,7 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element maxOccurs="unbounded" minOccurs="0" name="Qualification" type="ImplementerQualification"/>
-						<xs:element minOccurs="0" name="StateWhereQualificationHeld" type="StateCode"/>
+						<xs:element minOccurs="0" name="StateWhereQualificationHeld" type="HPXMLString"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -726,18 +726,18 @@
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element name="SpaceName" type="HPXMLString" minOccurs="0"/>
-						<xs:element minOccurs="0" name="NumberOfBedrooms" type="IntegerGreaterThanOrEqualToZero"/>
-						<xs:element minOccurs="0" name="FloorArea" type="SurfaceArea">
+						<xs:element minOccurs="0" name="NumberOfBedrooms" type="HPXMLIntegerGreaterThanOrEqualToZero"/>
+						<xs:element minOccurs="0" name="FloorArea" type="HPXMLDoubleGreaterThanZero">
 							<xs:annotation>
 								<xs:documentation>[sq.ft.]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="Volume" type="Volume">
+						<xs:element minOccurs="0" name="Volume" type="HPXMLDoubleGreaterThanZero">
 							<xs:annotation>
 								<xs:documentation>[cu.ft.]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="CeilingHeight" type="LengthMeasurement">
+						<xs:element minOccurs="0" name="CeilingHeight" type="HPXMLDoubleGreaterThanOrEqualToZero">
 							<xs:annotation>
 								<xs:documentation>[ft]</xs:documentation>
 							</xs:annotation>
@@ -777,7 +777,7 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element name="Hours" type="Hours" minOccurs="0"/>
+									<xs:element name="Hours" type="HPXMLInteger" minOccurs="0"/>
 									<xs:element minOccurs="0" name="ComponentsAirSealed">
 										<xs:complexType>
 											<xs:sequence>
@@ -948,7 +948,7 @@
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
 									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
-									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
+									<xs:element minOccurs="0" name="Area" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Surface area of the roof itself</xs:documentation>
 										</xs:annotation>
@@ -961,12 +961,12 @@
 									</xs:element>
 									<xs:element minOccurs="0" name="RoofType" type="RoofType"/>
 									<xs:element minOccurs="0" name="RoofColor" type="WallAndRoofColor"/>
-									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
-									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
+									<xs:element minOccurs="0" name="SolarAbsorptance" type="HPXMLFractionInclusive"/>
+									<xs:element minOccurs="0" name="Emittance" type="HPXMLFractionInclusive"/>
 									<xs:element minOccurs="0" name="InteriorFinish" type="InteriorFinishInfo"/>
 									<xs:element minOccurs="0" name="Rafters" type="StudProperties"/>
 									<xs:element minOccurs="0" name="DeckType" type="DeckType"/>
-									<xs:element minOccurs="0" name="Pitch" type="Pitch">
+									<xs:element minOccurs="0" name="Pitch" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>Pitch of roof ?/12</xs:documentation>
 										</xs:annotation>
@@ -994,7 +994,7 @@
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
 									<xs:element minOccurs="0" name="ExteriorAdjacentTo" type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
-									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
+									<xs:element minOccurs="0" name="Area" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
@@ -1005,15 +1005,15 @@
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Perimeter" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Perimeter" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[ft]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="Siding" type="Siding"/>
 									<xs:element minOccurs="0" name="Color" type="WallAndRoofColor"/>
-									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
-									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
+									<xs:element minOccurs="0" name="SolarAbsorptance" type="HPXMLFractionInclusive"/>
+									<xs:element minOccurs="0" name="Emittance" type="HPXMLFractionInclusive"/>
 									<xs:element minOccurs="0" name="Insulation" type="InsulationInfo"/>
 									<xs:element minOccurs="0" name="FloorJoists" type="StudProperties"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
@@ -1045,12 +1045,12 @@
 									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="AtticWallType" type="AtticWallType"/>
 									<xs:element name="WallType" type="WallType" minOccurs="0"/>
-									<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Thickness" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[in] Thickness of the entire wall assembly, including any siding, sheathing, continuous insulation, and interior finish.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
+									<xs:element minOccurs="0" name="Area" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Gross wall area</xs:documentation>
 										</xs:annotation>
@@ -1064,8 +1064,8 @@
 									<xs:element minOccurs="0" name="Studs" type="StudProperties"/>
 									<xs:element minOccurs="0" name="Siding" type="Siding"/>
 									<xs:element minOccurs="0" name="Color" type="WallAndRoofColor"/>
-									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
-									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
+									<xs:element minOccurs="0" name="SolarAbsorptance" type="HPXMLFractionInclusive"/>
+									<xs:element minOccurs="0" name="Emittance" type="HPXMLFractionInclusive"/>
 									<xs:element minOccurs="0" name="InteriorFinish" type="InteriorFinishInfo"/>
 									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
@@ -1096,17 +1096,17 @@
 									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo" minOccurs="0"/>
 									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="Type" type="FoundationWallType"/>
-									<xs:element minOccurs="0" name="Length" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Length" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[ft] Total length of foundation wall</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Height" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Height" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[ft] Total height in feet of foundation wall</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
+									<xs:element minOccurs="0" name="Area" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
@@ -1117,12 +1117,12 @@
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Thickness" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[in] Thickness of the foundation wall structural element (e.g., concrete), excluding any interior framing and continuous insulation.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="DepthBelowGrade" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="DepthBelowGrade" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[ft] Depth below grade of foundation wall</xs:documentation>
 										</xs:annotation>
@@ -1167,7 +1167,7 @@
 									<xs:element minOccurs="0" name="FloorJoists" type="StudProperties"/>
 									<xs:element minOccurs="0" name="FloorTrusses" type="StudProperties"/>
 									<xs:element minOccurs="0" name="FloorCovering" type="FloorCovering"/>
-									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
+									<xs:element minOccurs="0" name="Area" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
@@ -1195,32 +1195,32 @@
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
 									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
-									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
+									<xs:element minOccurs="0" name="Area" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Area of the slab</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Thickness" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[in] Thickness of the foundation slab structural element (e.g., concrete), excluding any floor coverings and continuous insulation.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Perimeter" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Perimeter" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[ft] Length of slab perimeter.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="ExposedPerimeter" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="ExposedPerimeter" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[ft] Perimeter of the slab exposed to ambient conditions</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="OnGradeExposedPerimeter" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="OnGradeExposedPerimeter" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[ft] Perimeter of slab measured in feet that is on-grade (2 ft. below grade or less) and exposed to ambient conditions.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="DepthBelowGrade" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="DepthBelowGrade" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[ft] Depth from the top of the slab surface to grade</xs:documentation>
 										</xs:annotation>
@@ -1249,7 +1249,7 @@
 								<xs:sequence>
 									<xs:group ref="WindowInfo"/>
 									<xs:element minOccurs="0" name="WindowType" type="WindowType"/>
-									<xs:element minOccurs="0" name="WindowtoWallRatio" type="Fraction"/>
+									<xs:element minOccurs="0" name="WindowtoWallRatio" type="HPXMLFractionInclusive"/>
 									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
@@ -1280,7 +1280,7 @@
 								<xs:sequence>
 									<xs:group ref="WindowInfo"/>
 									<xs:element minOccurs="0" name="SolarTube" type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="Pitch" type="Pitch">
+									<xs:element minOccurs="0" name="Pitch" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>Pitch of skylight ?/12</xs:documentation>
 										</xs:annotation>
@@ -1316,8 +1316,8 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference"/>
-									<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero"/>
-									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
+									<xs:element minOccurs="0" name="Count" type="HPXMLIntegerGreaterThanZero"/>
+									<xs:element minOccurs="0" name="Area" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Total door surface area for this group of doors</xs:documentation>
 										</xs:annotation>
@@ -1332,7 +1332,7 @@
 									<xs:element name="DoorMaterial" type="DoorMaterial" minOccurs="0"/>
 									<xs:element minOccurs="0" name="WeatherStripping" type="HPXMLBoolean"/>
 									<xs:element name="StormDoor" type="HPXMLBoolean" minOccurs="0"/>
-									<xs:element name="RValue" type="RValue" minOccurs="0"/>
+									<xs:element name="RValue" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0"/>
 									<xs:element minOccurs="0" name="LeakinessDescription" type="BuildingLeakiness"/>
 									<xs:element minOccurs="0" name="PerformanceClass" type="PerformanceClass"/>
 									<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="DoorThirdPartyCertifications"/>
@@ -1406,17 +1406,17 @@
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="ConditionedFloorAreaServed" type="SurfaceArea">
+									<xs:element minOccurs="0" name="ConditionedFloorAreaServed" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Conditioned floor area that this distribution system serves.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AnnualHeatingDistributionSystemEfficiency" type="FractionExcludingZero">
+									<xs:element minOccurs="0" name="AnnualHeatingDistributionSystemEfficiency" type="HPXMLFractionExcludingZero">
 										<xs:annotation>
 											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for heating, the DSE may be approximated by equation 3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use History. Enter values as a fractional number between 0 and 1, i.e. 80% = 0.8</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AnnualCoolingDistributionSystemEfficiency" type="FractionExcludingZero">
+									<xs:element minOccurs="0" name="AnnualCoolingDistributionSystemEfficiency" type="HPXMLFractionExcludingZero">
 										<xs:annotation>
 											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for cooling, the DSE may be approximated by equation 3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use History. Enter values as a fractional number between 0 and 1, i.e. 80% = 0.8</xs:documentation>
 										</xs:annotation>
@@ -1463,7 +1463,7 @@
 												<xs:element minOccurs="0" ref="ConnectedDevice"/>
 												<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
 												<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
-												<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero">
+												<xs:element minOccurs="0" name="Count" type="HPXMLIntegerGreaterThanZero">
 													<xs:annotation>
 														<xs:documentation>Number of similar ventilation fans (e.g., bath fans).</xs:documentation>
 													</xs:annotation>
@@ -1542,7 +1542,7 @@
 														<xs:documentation>[sones] as tested in field</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="TotalRecoveryEfficiency" type="FractionExcludingZero">
+												<xs:element minOccurs="0" name="TotalRecoveryEfficiency" type="HPXMLFractionExcludingZero">
 													<xs:annotation>
 														<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by electric
 															consumption, case heat loss or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential
@@ -1550,7 +1550,7 @@
 															(hvi.org).</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="SensibleRecoveryEfficiency" type="FractionExcludingZero">
+												<xs:element minOccurs="0" name="SensibleRecoveryEfficiency" type="HPXMLFractionExcludingZero">
 													<xs:annotation>
 														<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by electric consumption, case heat loss or heat gain,
 															air leakage, airflow mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test),
@@ -1558,7 +1558,7 @@
 															the Home Ventilating Institute (hvi.org).</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="AdjustedTotalRecoveryEfficiency" type="FractionExcludingZero">
+												<xs:element minOccurs="0" name="AdjustedTotalRecoveryEfficiency" type="HPXMLFractionExcludingZero">
 													<xs:annotation>
 														<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by case heat loss
 															or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential total energy that could be
@@ -1567,7 +1567,7 @@
 															Ventilating Institute (hvi.org).</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="AdjustedSensibleRecoveryEfficiency" type="FractionExcludingZero">
+												<xs:element minOccurs="0" name="AdjustedSensibleRecoveryEfficiency" type="HPXMLFractionExcludingZero">
 													<xs:annotation>
 														<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by case heat loss or heat gain, air leakage, airflow
 															mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test), as a percent of the
@@ -1632,10 +1632,10 @@
 									<xs:element name="FuelType" type="FuelType" minOccurs="0"/>
 									<xs:element name="WaterHeaterType" type="WaterHeaterType" minOccurs="0"/>
 									<xs:element name="Location" type="UnitLocation" minOccurs="0"/>
-									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
-									<xs:element name="ModelYear" type="Year" minOccurs="0"/>
-									<xs:element name="Manufacturer" type="Manufacturer" minOccurs="0"/>
-									<xs:element name="ModelNumber" type="Model" minOccurs="0"/>
+									<xs:element minOccurs="0" name="YearInstalled" type="HPXMLInteger"/>
+									<xs:element name="ModelYear" type="HPXMLInteger" minOccurs="0"/>
+									<xs:element name="Manufacturer" type="HPXMLString" minOccurs="0"/>
+									<xs:element name="ModelNumber" type="HPXMLString" minOccurs="0"/>
 									<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="IsSharedSystem" type="HPXMLBoolean">
@@ -1644,29 +1644,29 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="NumberofUnitsServed" type="HPXMLInteger"/>
-									<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction">
+									<xs:element minOccurs="0" name="PerformanceAdjustment" type="HPXMLFractionInclusive">
 										<xs:annotation>
 											<xs:documentation>A multiplier on the performance of the system. A value of 1 implies no performance adjustment.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="ThirdPartyCertification" type="DHWThirdPartyCertification" maxOccurs="unbounded"/>
-									<xs:element name="TankVolume" type="Volume" minOccurs="0">
+									<xs:element name="TankVolume" type="HPXMLDoubleGreaterThanZero" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[gal] Nominal capacity</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="MeasuredTankVolume" type="Volume" minOccurs="0">
+									<xs:element name="MeasuredTankVolume" type="HPXMLDoubleGreaterThanZero" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[gal] Measured capacity</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FractionDHWLoadServed" type="Fraction"/>
-									<xs:element name="HeatingCapacity" type="Capacity" minOccurs="0">
+									<xs:element minOccurs="0" name="FractionDHWLoadServed" type="HPXMLFractionInclusive"/>
+									<xs:element name="HeatingCapacity" type="HPXMLDouble" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[Btuh] For a heat pump water heater, the capacity of the heat pump.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="BackupHeatingCapacity" type="Capacity" minOccurs="0">
+									<xs:element name="BackupHeatingCapacity" type="HPXMLDouble" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[Btuh] The capacity of the electric resistance heating in a heat pump water heater.</xs:documentation>
 										</xs:annotation>
@@ -1684,7 +1684,7 @@
 												430, Subpart B, Appendix E.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HeatPumpCOP" type="Efficiency">
+									<xs:element minOccurs="0" name="HeatPumpCOP" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>The dimensionless coefficient of performance, used to measure the efficiency of a commercial heat pump water heater.</xs:documentation>
 										</xs:annotation>
@@ -1707,7 +1707,7 @@
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="FirstHourRating" type="Volume">
+									<xs:element minOccurs="0" name="FirstHourRating" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[gal per hour] An estimate of the maximum volume of hot water in gallons that a storage water heater can supply within an hour that begins
 												with the water heater fully heated.</xs:documentation>
@@ -1718,7 +1718,7 @@
 											<xs:documentation>A water heater's usage bin is derived from its First Hour Rating (FHR) as part of the Uniform Energy Factor (UEF) testing procedures.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="GallonsPerMinute" type="Volume">
+									<xs:element minOccurs="0" name="GallonsPerMinute" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[gal per minute] The amount of gallons per minute of hot water that can be supplied by an instantaneous water heater while maintaining a
 												nominal temperature rise of 77°F during steady state operation.</xs:documentation>
@@ -1730,7 +1730,7 @@
 												DOE testing procedure.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ThermalEfficiency" type="ThermalEfficiency" minOccurs="0"/>
+									<xs:element name="ThermalEfficiency" type="HPXMLFractionExcludingZero" minOccurs="0"/>
 									<xs:element minOccurs="0" name="WaterHeaterInsulation">
 										<xs:complexType>
 											<xs:sequence>
@@ -1738,8 +1738,8 @@
 													<xs:complexType>
 														<xs:sequence>
 															<xs:element minOccurs="0" name="InsulationMaterial" type="InsulationMaterial"/>
-															<xs:element name="JacketRValue" type="RValue" minOccurs="0"/>
-															<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+															<xs:element name="JacketRValue" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0"/>
+															<xs:element minOccurs="0" name="Thickness" type="HPXMLDoubleGreaterThanOrEqualToZero">
 																<xs:annotation>
 																	<xs:documentation>[in]</xs:documentation>
 																</xs:annotation>
@@ -1757,8 +1757,8 @@
 													<xs:complexType>
 														<xs:sequence>
 															<xs:element minOccurs="0" name="InsulationMaterial" type="InsulationMaterial"/>
-															<xs:element name="TankWallRValue" type="RValue" minOccurs="0"/>
-															<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+															<xs:element name="TankWallRValue" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0"/>
+															<xs:element minOccurs="0" name="Thickness" type="HPXMLDoubleGreaterThanOrEqualToZero">
 																<xs:annotation>
 																	<xs:documentation>[in]</xs:documentation>
 																</xs:annotation>
@@ -1778,7 +1778,7 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element name="MeetsACCA5QIHVACSpecification" type="HPXMLBoolean" minOccurs="0"/>
-									<xs:element name="HotWaterTemperature" type="Temperature" minOccurs="0">
+									<xs:element name="HotWaterTemperature" type="HPXMLDouble" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg F]</xs:documentation>
 										</xs:annotation>
@@ -1846,7 +1846,7 @@
 												<xs:element name="Standard">
 													<xs:complexType>
 														<xs:sequence>
-															<xs:element minOccurs="0" name="PipingLength" type="LengthMeasurement">
+															<xs:element minOccurs="0" name="PipingLength" type="HPXMLDoubleGreaterThanOrEqualToZero">
 																<xs:annotation>
 																	<xs:documentation>Measured length of hot water piping from the hot water heater to the farthest hot water fixture, measured
 																		longitudinally from plans, assuming the hot water piping does not run diagonally, plus 10 feet of piping for each floor level,
@@ -1862,20 +1862,20 @@
 													<xs:complexType>
 														<xs:sequence>
 															<xs:element minOccurs="0" name="ControlType" type="RecirculationControlType"/>
-															<xs:element minOccurs="0" name="RecirculationPipingLoopLength" type="LengthMeasurement">
+															<xs:element minOccurs="0" name="RecirculationPipingLoopLength" type="HPXMLDoubleGreaterThanOrEqualToZero">
 																<xs:annotation>
 																	<xs:documentation>Hot water recirculation loop piping length including both supply and return sides of the loop, measured
 																		longitudinally from plans, assuming the hot water piping does not run diagonally. [ft]</xs:documentation>
 																</xs:annotation>
 															</xs:element>
-															<xs:element minOccurs="0" name="BranchPipingLength" type="LengthMeasurement">
+															<xs:element minOccurs="0" name="BranchPipingLength" type="HPXMLDoubleGreaterThanOrEqualToZero">
 																<xs:annotation>
 																	<xs:documentation>Length of the branch hot water piping from the recirculation loop to the farthest hot water fixture from the
 																		recirculation loop, measured longitudinally from plans, assuming the branch hot water piping does not run diagonally, plus 20
 																		feet of piping for each floor level greater than one plus 10 feet of piping for unconditioned basements. [ft]</xs:documentation>
 																</xs:annotation>
 															</xs:element>
-															<xs:element minOccurs="0" name="PumpPower" type="Power">
+															<xs:element minOccurs="0" name="PumpPower" type="HPXMLDoubleGreaterThanOrEqualToZero">
 																<xs:annotation>
 																	<xs:documentation>[W]</xs:documentation>
 																</xs:annotation>
@@ -1895,7 +1895,7 @@
 											<xs:sequence>
 												<xs:element minOccurs="0" name="FacilitiesConnected" type="DrainWaterHeatRecoveryFacilitiesConnected"/>
 												<xs:element minOccurs="0" name="EqualFlow" type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="Efficiency" type="FractionExcludingZero">
+												<xs:element minOccurs="0" name="Efficiency" type="HPXMLFractionExcludingZero">
 													<xs:annotation>
 														<xs:documentation>Efficiency percent expressed as a fraction from 0-1.</xs:documentation>
 													</xs:annotation>
@@ -1919,7 +1919,7 @@
 										<xs:element name="AttachedToHotWaterDistribution" type="LocalReference"/>
 									</xs:choice>
 									<xs:element minOccurs="1" name="WaterFixtureType" type="WaterFixtureType"/>
-									<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero">
+									<xs:element minOccurs="0" name="Count" type="HPXMLIntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Number of similar water fixtures.</xs:documentation>
 										</xs:annotation>
@@ -1984,7 +1984,7 @@
 									<xs:element minOccurs="0" name="ModelNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" ref="AttachedToZone"/>
 									<xs:element name="SystemType" minOccurs="0" type="SolarThermalSystemType"/>
-									<xs:element name="CollectorArea" type="SurfaceArea" minOccurs="0">
+									<xs:element name="CollectorArea" type="HPXMLDoubleGreaterThanZero" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
@@ -1998,32 +1998,32 @@
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorRatedOpticalEfficiency" type="CollectorRatedOpticalEfficiency">
+									<xs:element minOccurs="0" name="CollectorRatedOpticalEfficiency" type="HPXMLFractionExclusive">
 										<xs:annotation>
 											<xs:documentation>[Btu/h-ft^2-F] Often referred to as Fr-tau-alpha (FRta), this describes the optical efficiency portion of the overall collector efficiency. 
 												In the OG-100 SRCC Certified Solar Thermal Collector Directory, this is the y-intercept of the efficiency curve.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorRatedThermalLosses" type="CollectorRatedThermalLosses">
+									<xs:element minOccurs="0" name="CollectorRatedThermalLosses" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Often referred to as Fr-Ul (FRUl), this describes the collector thermal losses portion of the overall collector efficiency. In the OG-100
 												SRCC Certified Solar Thermal Collector Directory, this is the slope of the efficiency curve.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="StorageVolume" type="Volume">
+									<xs:element minOccurs="0" name="StorageVolume" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[gal]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="ConnectedTo" type="LocalReference"/>
-									<xs:element minOccurs="0" name="SolarFraction" type="SolarFraction">
+									<xs:element minOccurs="0" name="SolarFraction" type="HPXMLFractionExcludingZero">
 										<xs:annotation>
 											<xs:documentation>The Solar Fraction is the portion of the total conventional hot water heating load (delivered energy and tank standby losses). The higher
 												the solar fraction, the greater the solar contribution to water heating, which reduces the energy required by the backup water heater. This value can be
 												found in the OG-300 SRCC Certified Solar Water Heating System Directory.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="SolarEnergyFactor" type="SolarThermalSystemEnergyFactor">
+									<xs:element minOccurs="0" name="SolarEnergyFactor" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>The Solar Energy Factor is defined as the energy delivered by the system divided by the electrical or gas energy put into the system. The
 												higher the number, the more energy efficient. This value can be found in the OG-300 SRCC Certified Solar Water Heating System
@@ -2068,31 +2068,31 @@
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="MaxPowerOutput" type="Power">
+									<xs:element minOccurs="0" name="MaxPowerOutput" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[DC Watts] Peak power as supplied by the manufacturer</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="CollectorArea" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberOfPanels" type="IntegerGreaterThanZero"/>
-									<xs:element minOccurs="0" name="SystemLossesFraction" type="Fraction">
+									<xs:element minOccurs="0" name="NumberOfPanels" type="HPXMLIntegerGreaterThanZero"/>
+									<xs:element minOccurs="0" name="SystemLossesFraction" type="HPXMLFractionInclusive">
 										<xs:annotation>
 											<xs:documentation>System losses can be due to soiling, shading, snow, mismatch, wiring, electrical connections, light-induced degradation, nameplate rating
 												inaccuracies, age, and availability.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="YearModulesManufactured" type="Year"/>
-									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
-									<xs:element minOccurs="0" name="AnnualOutput" type="RatedAnnualkWh">
+									<xs:element minOccurs="0" name="YearModulesManufactured" type="HPXMLInteger"/>
+									<xs:element minOccurs="0" name="YearInstalled" type="HPXMLInteger"/>
+									<xs:element minOccurs="0" name="AnnualOutput" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[kWh] Projected Annual Output for a typical meteorological year as determined by PVWatts or similar. </xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="LevelizedCostOfElectricity" type="Cost">
+									<xs:element minOccurs="0" name="LevelizedCostOfElectricity" type="HPXMLDecimal">
 										<xs:annotation>
 											<xs:documentation>[$] The LCOE is the total cost of installing and operating a project expressed in dollars per kilowatt-hour of electricity generated by
 												the system over its life. Can be calculated with System Advisor Model, a similar software, or through a simplified calculation at
@@ -2110,9 +2110,9 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" name="InverterType" type="InverterType"/>
-									<xs:element minOccurs="0" name="InverterEfficiency" type="FractionExcludingZero"/>
-									<xs:element minOccurs="0" name="YearInverterManufactured" type="Year"/>
-									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
+									<xs:element minOccurs="0" name="InverterEfficiency" type="HPXMLFractionExcludingZero"/>
+									<xs:element minOccurs="0" name="YearInverterManufactured" type="HPXMLInteger"/>
+									<xs:element minOccurs="0" name="YearInstalled" type="HPXMLInteger"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 							</xs:complexType>
@@ -2128,12 +2128,12 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="Manufacturer" type="Manufacturer"/>
-									<xs:element minOccurs="0" name="ModelNumber" type="Model"/>
+									<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
+									<xs:element minOccurs="0" name="ModelNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
-									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
-									<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero">
+									<xs:element minOccurs="0" name="YearInstalled" type="HPXMLInteger"/>
+									<xs:element minOccurs="0" name="Count" type="HPXMLIntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Number of similar batteries.</xs:documentation>
 										</xs:annotation>
@@ -2156,12 +2156,12 @@
 											<xs:documentation>The stored energy that can actually be used. In most cases usable capacity is less than the nominal capacity.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RatedPowerOutput" type="Power">
+									<xs:element minOccurs="0" name="RatedPowerOutput" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[W] The amount of power the battery typically generates under non-peak conditions.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="PeakPowerOutput" type="Power" minOccurs="0">
+									<xs:element name="PeakPowerOutput" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[W] The peak power that the battery can generate for a short period of time.</xs:documentation>
 										</xs:annotation>
@@ -2172,7 +2172,7 @@
 												with a 0.2C discharge current.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RoundTripEfficiency" type="FractionExcludingZero">
+									<xs:element minOccurs="0" name="RoundTripEfficiency" type="HPXMLFractionExcludingZero">
 										<xs:annotation>
 											<xs:documentation>Not all the power that is used to charge the battery is available during discharge. Round trip efficiency is the ratio of the energy put
 												in to the energy retrieved from storage.</xs:documentation>
@@ -2194,30 +2194,30 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanOrEqualToZero"/>
-									<xs:element minOccurs="0" name="Manufacturer" type="Manufacturer"/>
-									<xs:element maxOccurs="1" minOccurs="0" name="ModelNumber" type="Model"/>
+									<xs:element minOccurs="0" name="Count" type="HPXMLIntegerGreaterThanOrEqualToZero"/>
+									<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
+									<xs:element maxOccurs="1" minOccurs="0" name="ModelNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
 									<xs:element minOccurs="0" name="ChargingLevel" type="EVChargingLevel"/>
 									<xs:element minOccurs="0" name="ChargingConnector" type="EVChargingConnector"/>
-									<xs:element maxOccurs="1" minOccurs="0" name="ModelYear" type="Year"/>
-									<xs:element minOccurs="0" name="ACPowerSourceVoltage" type="Voltage">
+									<xs:element maxOccurs="1" minOccurs="0" name="ModelYear" type="HPXMLInteger"/>
+									<xs:element minOccurs="0" name="ACPowerSourceVoltage" type="HPXMLDecimalGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[V] Voltage of the AC power source</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="Amperage" minOccurs="0" type="Current">
+									<xs:element name="Amperage" minOccurs="0" type="HPXMLDecimalGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[A] Max current to electric vehicle</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="ChargingPower" type="Power">
+									<xs:element minOccurs="0" name="ChargingPower" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[W] Maximum charging rate</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="StandbyPower" type="Power">
+									<xs:element minOccurs="0" name="StandbyPower" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[W] Power used by charger when vehicle is not charging</xs:documentation>
 										</xs:annotation>
@@ -2239,9 +2239,9 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" name="Model" type="HPXMLString"/>
-									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
+									<xs:element minOccurs="0" name="YearInstalled" type="HPXMLInteger"/>
 									<xs:element minOccurs="0" name="ThirdPartyCertification" maxOccurs="unbounded" type="WindThirdPartyCertification"/>
-									<xs:element minOccurs="0" name="AWEARatedAnnualEnergy" type="RatedAnnualkWh">
+									<xs:element minOccurs="0" name="AWEARatedAnnualEnergy" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[kWh] the calculated total energy that would be produced during a one-year period with an average wind speed of 5 m/s (11.2
 												mph)</xs:documentation>
@@ -2253,28 +2253,28 @@
 												wind speed of 5 m/s (11.2 mph). </xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AWEARatedPower" type="Power">
+									<xs:element minOccurs="0" name="AWEARatedPower" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[kW] the wind turbine’s power output at 11 m/s (24.6 mph). Manufacturers may still describe or name their wind turbine models using a
 												nominal power (e.g. 5 kW S-343).</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="PeakPower" type="Power">
+									<xs:element minOccurs="0" name="PeakPower" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[kW] the highest point on the certified power curve.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RotorDiameter" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="RotorDiameter" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[ft]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HubHeight" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="HubHeight" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[ft]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="LevelizedCostOfElectricity" type="Cost">
+									<xs:element minOccurs="0" name="LevelizedCostOfElectricity" type="HPXMLDecimal">
 										<xs:annotation>
 											<xs:documentation>[$] The LCOE is the total cost of installing and operating a project expressed in dollars per kilowatt-hour of electricity generated by
 												the system over its life. Can be calculated with System Advisor Model, a similar software, or through a simplified calculation at
@@ -2326,7 +2326,7 @@
 						<xs:element minOccurs="0" ref="AttachedToSpace"/>
 						<xs:element minOccurs="0" name="Location" type="LightingLocation"/>
 						<xs:element name="Count" type="HPXMLInteger" minOccurs="0"/>
-						<xs:element minOccurs="0" name="FractionofUnitsInLocation" type="Fraction">
+						<xs:element minOccurs="0" name="FractionofUnitsInLocation" type="HPXMLFractionInclusive">
 							<xs:annotation>
 								<xs:documentation>The fraction of lighting units in the specified Location, where all the fractions for the Location sum to 1. If a Location is not specified, fractions
 									apply to the entire building.</xs:documentation>
@@ -2356,7 +2356,7 @@
 								<xs:documentation>[h]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="FloorAreaServed" type="SurfaceArea">
+						<xs:element minOccurs="0" name="FloorAreaServed" type="HPXMLDoubleGreaterThanZero">
 							<xs:annotation>
 								<xs:documentation>[sq.ft.]</xs:documentation>
 							</xs:annotation>
@@ -2393,7 +2393,7 @@
 						<xs:element minOccurs="0" ref="ConnectedDevice"/>
 						<xs:element minOccurs="0" name="AttachedToLightingGroup" type="LocalReference"/>
 						<xs:element name="LightingControlType" type="LightingControls" minOccurs="0"/>
-						<xs:element name="NumberofLightingControls" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+						<xs:element name="NumberofLightingControls" type="HPXMLIntegerGreaterThanOrEqualToZero" minOccurs="0"/>
 						<xs:element name="Location" type="LightingLocation" minOccurs="0"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
@@ -2417,7 +2417,7 @@
 											<xs:documentation>[CFM]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Efficiency" type="Efficiency">
+									<xs:element minOccurs="0" name="Efficiency" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[CFM/watt] The efficiency rating of a ceiling fan as determined by the test procedure defined by the Environmental Protection Agency's
 												ENERGY STAR Testing Facility Guidance Manual: Building a Testing Facility and Performing the Solid State Test Method for ENERGY STAR Qualified Ceiling
@@ -2429,7 +2429,7 @@
 							</xs:complexType>
 						</xs:element>
 						<xs:element minOccurs="0" name="ThirdPartyCertification" type="ApplianceThirdPartyCertifications" maxOccurs="unbounded"/>
-						<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero">
+						<xs:element minOccurs="0" name="Count" type="HPXMLIntegerGreaterThanZero">
 							<xs:annotation>
 								<xs:documentation>Number of similar ceiling fans.</xs:documentation>
 							</xs:annotation>
@@ -2529,7 +2529,7 @@
 								<xs:documentation>Indicates if the pool is above or below ground.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="Volume" type="Volume">
+						<xs:element minOccurs="0" name="Volume" type="HPXMLDoubleGreaterThanZero">
 							<xs:annotation>
 								<xs:documentation>[gal] Volume of pool.</xs:documentation>
 							</xs:annotation>
@@ -2539,12 +2539,12 @@
 								<xs:documentation>Months per year pool is in operation.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="ReturnPipeDiameter" type="LengthMeasurement">
+						<xs:element minOccurs="0" name="ReturnPipeDiameter" type="HPXMLDoubleGreaterThanOrEqualToZero">
 							<xs:annotation>
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="SuctionPipeDiameter" type="LengthMeasurement">
+						<xs:element minOccurs="0" name="SuctionPipeDiameter" type="HPXMLDoubleGreaterThanOrEqualToZero">
 							<xs:annotation>
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
@@ -2588,7 +2588,7 @@
 															or other)</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="EnergyFactor" type="Efficiency">
+												<xs:element minOccurs="0" name="EnergyFactor" type="HPXMLDoubleGreaterThanZero">
 													<xs:annotation>
 														<xs:documentation>[gal/Wh] The measure of overall pool filter pump efficiency in units of gallons per watt-hour, as determined using the
 															applicable test method in Section 4.1.2. Energy factor is analogous to other energy factors such as miles per gallon. Energy factor (EF) is
@@ -2600,14 +2600,14 @@
 														<xs:documentation>The speed setting at which the Energy Factor was measured (ENERGY STAR, 2013).</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="RatedHorsepower" type="Power">
+												<xs:element minOccurs="0" name="RatedHorsepower" type="HPXMLDoubleGreaterThanOrEqualToZero">
 													<xs:annotation>
 														<xs:documentation>The motor power output designed by the manufacturer for a rated RPM, voltage and frequency. May be less than total horsepower
 															where the service factor is greater than 1.0, or equal to total horsepower where the service factor = 1.0 (ANSI/APSP/ICC-15
 															2011).</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="TotalHorsepower" type="Power">
+												<xs:element minOccurs="0" name="TotalHorsepower" type="HPXMLDoubleGreaterThanOrEqualToZero">
 													<xs:annotation>
 														<xs:documentation>The total horsepower, or product of the rated horsepower and the service factor of a motor used on a pool pump (also known as
 															SFHP) based on the maximum continuous duty motor power output rating allowable for the nameplate ambient rating and motor insulation class
@@ -2625,18 +2625,18 @@
 												<xs:element maxOccurs="unbounded" minOccurs="0" name="PumpSpeed">
 													<xs:complexType>
 														<xs:sequence>
-															<xs:element minOccurs="0" name="Power" type="Power">
+															<xs:element minOccurs="0" name="Power" type="HPXMLDoubleGreaterThanOrEqualToZero">
 																<xs:annotation>
 																	<xs:documentation>[W]</xs:documentation>
 																</xs:annotation>
 															</xs:element>
-															<xs:element minOccurs="0" name="MotorNominalSpeed" type="Speed">
+															<xs:element minOccurs="0" name="MotorNominalSpeed" type="HPXMLDoubleGreaterThanOrEqualToZero">
 																<xs:annotation>
 																	<xs:documentation>[Rev/min] The number of revolutions of the motor shaft in a given unit of time, expressed as revolutions per
 																		minute (RPM) (ENERGY STAR, 2013).</xs:documentation>
 																</xs:annotation>
 															</xs:element>
-															<xs:element minOccurs="0" name="FlowRate" type="FlowRate">
+															<xs:element minOccurs="0" name="FlowRate" type="HPXMLDoubleGreaterThanOrEqualToZero">
 																<xs:annotation>
 																	<xs:documentation>[gal/min] The volume of water flowing through the filtration system in a given time, usually measured in gallons
 																		per minute (gpm) (ANSI/APSP/ICC-15 2011).</xs:documentation>
@@ -2719,7 +2719,7 @@
 						<xs:element minOccurs="0" ref="AttachedToSpace"/>
 						<xs:element name="PlugLoadType" type="PlugLoadType" minOccurs="0"/>
 						<xs:element minOccurs="0" name="Location" type="PlugLoadLocation"/>
-						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+						<xs:element name="Count" type="HPXMLIntegerGreaterThanOrEqualToZero" minOccurs="0"/>
 						<xs:element minOccurs="0" name="Load">
 							<xs:complexType>
 								<xs:sequence>
@@ -2741,7 +2741,7 @@
 						<xs:element minOccurs="0" ref="ConnectedDevice"/>
 						<xs:element minOccurs="0" name="ControlsPlugLoad" type="LocalReference"/>
 						<xs:element minOccurs="0" ref="AttachedToSpace"/>
-						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+						<xs:element name="Count" type="HPXMLIntegerGreaterThanOrEqualToZero" minOccurs="0"/>
 						<xs:element name="PlugLoadControlType" minOccurs="0" type="PlugLoadControlType"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
@@ -2756,7 +2756,7 @@
 						<xs:element minOccurs="0" ref="AttachedToSpace"/>
 						<xs:element name="FuelLoadType" type="FuelLoadType" minOccurs="0"/>
 						<xs:element minOccurs="0" name="Location" type="FuelLoadLocation"/>
-						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+						<xs:element name="Count" type="HPXMLIntegerGreaterThanOrEqualToZero" minOccurs="0"/>
 						<xs:element minOccurs="0" name="Load">
 							<xs:complexType>
 								<xs:sequence>
@@ -2821,7 +2821,7 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element name="CAZDepressurizationLimit" type="CAZDepressurizationLimit" minOccurs="0">
+									<xs:element name="CAZDepressurizationLimit" type="HPXMLDouble" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>Pulled from industry standards by users (e.g. BPI Gold Sheet) or via software program</xs:documentation>
 										</xs:annotation>
@@ -2840,7 +2840,7 @@
 												depressurization attained at the time of testing and the base pressure.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="NetPressureChange" type="NetPressureChange" minOccurs="0">
+									<xs:element name="NetPressureChange" type="HPXMLDouble" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>With respect to the baseline pressure (e.g. no fans running, all exterior doors closed, and all interior doors opened)</xs:documentation>
 										</xs:annotation>
@@ -2863,7 +2863,7 @@
 												<xs:element minOccurs="0" name="CombustionVentingSystem" type="RemoteReference"/>
 												<xs:element name="FlueVisualCondition" type="FlueCondition" minOccurs="0"/>
 												<xs:element minOccurs="0" name="FlueConditionNotes" type="HPXMLString"/>
-												<xs:element name="OutsideTemperatureFlueDraftTest" type="Temperature" minOccurs="0">
+												<xs:element name="OutsideTemperatureFlueDraftTest" type="HPXMLDouble" minOccurs="0">
 													<xs:annotation>
 														<xs:documentation>[deg F]</xs:documentation>
 													</xs:annotation>
@@ -2915,7 +2915,7 @@
 														</xs:complexContent>
 													</xs:complexType>
 												</xs:element>
-												<xs:element name="StackTemperature" type="Temperature" minOccurs="0">
+												<xs:element name="StackTemperature" type="HPXMLDouble" minOccurs="0">
 													<xs:annotation>
 														<xs:documentation>[deg F] after 10 minutes run time</xs:documentation>
 													</xs:annotation>
@@ -2953,7 +2953,7 @@
 						<xs:element name="StoveID" type="SystemIdentifiersInfoType"/>
 						<xs:element minOccurs="0" name="StoveFuel" type="FuelType"/>
 						<xs:element name="HeatingStoveProperlyVented" type="HPXMLBoolean" minOccurs="0"/>
-						<xs:element name="COReading" type="COReading" minOccurs="0"/>
+						<xs:element name="COReading" type="HPXMLDouble" minOccurs="0"/>
 						<xs:element minOccurs="0" name="TimeofCOReading" type="HPXMLDateTime"/>
 						<xs:element name="GasLeaksIdentified" type="HPXMLBoolean" minOccurs="0"/>
 						<xs:element name="ActionsTaken" type="HPXMLString" minOccurs="0"/>
@@ -3376,13 +3376,13 @@
 			<xs:element minOccurs="0" ref="AttachedToZone"/>
 			<xs:element minOccurs="0" name="AttachedToCAZ" type="LocalReference"/>
 			<xs:element name="UnitLocation" type="UnitLocation" minOccurs="0"/>
-			<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
-			<xs:element name="ModelYear" type="Year" minOccurs="0"/>
-			<xs:element name="Manufacturer" type="Manufacturer" minOccurs="0"/>
-			<xs:element name="ModelNumber" type="Model" minOccurs="0"/>
+			<xs:element minOccurs="0" name="YearInstalled" type="HPXMLInteger"/>
+			<xs:element name="ModelYear" type="HPXMLInteger" minOccurs="0"/>
+			<xs:element name="Manufacturer" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="ModelNumber" type="HPXMLString" minOccurs="0"/>
 			<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
-			<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction">
+			<xs:element minOccurs="0" name="PerformanceAdjustment" type="HPXMLFractionInclusive">
 				<xs:annotation>
 					<xs:documentation>A multiplier on the performance of the system. A value of 1 implies no performance adjustment.</xs:documentation>
 				</xs:annotation>
@@ -3430,19 +3430,19 @@
 				<xs:sequence minOccurs="1" maxOccurs="1">
 					<xs:element name="HeatingSystemType" type="HeatingSystemType" minOccurs="0"/>
 					<xs:element name="HeatingSystemFuel" type="FuelType" minOccurs="0"/>
-					<xs:element name="HeatingInputRating" type="Capacity" minOccurs="0">
+					<xs:element name="HeatingInputRating" type="HPXMLDouble" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>[Btuh] Input Heating Capacity</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="HeatingCapacity" type="Capacity" minOccurs="0">
+					<xs:element name="HeatingCapacity" type="HPXMLDouble" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>[Btuh] Output Heating Capacity</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element minOccurs="0" name="AnnualHeatingEfficiency" type="HeatingEfficiencyType" maxOccurs="unbounded"/>
-					<xs:element name="FractionHeatLoadServed" type="Fraction" minOccurs="0"/>
-					<xs:element minOccurs="0" name="FloorAreaServed" type="SurfaceArea">
+					<xs:element name="FractionHeatLoadServed" type="HPXMLFractionInclusive" minOccurs="0"/>
+					<xs:element minOccurs="0" name="FloorAreaServed" type="HPXMLDoubleGreaterThanZero">
 						<xs:annotation>
 							<xs:documentation>[sq.ft.]</xs:documentation>
 						</xs:annotation>
@@ -3588,28 +3588,28 @@
 				<xs:sequence minOccurs="0">
 					<xs:element name="HeatPumpType" type="HeatPumpType" minOccurs="0"/>
 					<xs:element minOccurs="0" name="HeatPumpFuel" type="FuelType"/>
-					<xs:element name="HeatingCapacity" type="Capacity" minOccurs="0">
+					<xs:element name="HeatingCapacity" type="HPXMLDouble" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>[Btuh] Output heating capacity; typically the nameplate capacity at 47F.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="HeatingCapacity17F" type="Capacity">
+					<xs:element minOccurs="0" name="HeatingCapacity17F" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>[Btuh] Output heating capacity at 17F from AHRI database.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="CoolingCapacity" type="Capacity">
+					<xs:element minOccurs="0" name="CoolingCapacity" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>[Btuh] Output cooling capacity</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element minOccurs="0" name="CompressorType" type="CompressorType"/>
-					<xs:element minOccurs="0" name="CompressorLockoutTemperature" type="Temperature">
+					<xs:element minOccurs="0" name="CompressorLockoutTemperature" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>[deg F] Temperature below which the compressor is disabled, often to prevent damage or occupant comfort issues. The default is the manufacturer's minimum operating temperature, but the value may be set higher. For a duel-fuel heat pump, use the BackupHeatingSwitchoverTemperature element.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="CoolingSensibleHeatFraction" type="Fraction"/>
+					<xs:element minOccurs="0" name="CoolingSensibleHeatFraction" type="HPXMLFractionInclusive"/>
 					<xs:element minOccurs="0" name="BackupType" type="HeatPumpBackupType">
 						<xs:annotation>
 							<xs:documentation>Whether the heat pump backup is integrated into the unit (describe in BackupSystemFuel, BackupAnnualHeatingEfficiency, BackupHeatingCapacity), or a
@@ -3623,29 +3623,29 @@
 					</xs:element>
 					<xs:element name="BackupSystemFuel" type="FuelType" minOccurs="0"/>
 					<xs:element name="BackupAnnualHeatingEfficiency" minOccurs="0" type="HeatingEfficiencyType" maxOccurs="unbounded"/>
-					<xs:element minOccurs="0" name="BackupHeatingInputRating" type="Capacity">
+					<xs:element minOccurs="0" name="BackupHeatingInputRating" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>[Btuh] Input heating capacity</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="BackupHeatingCapacity" type="Capacity">
+					<xs:element minOccurs="0" name="BackupHeatingCapacity" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>[Btuh] Output heating capacity</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="BackupHeatingSwitchoverTemperature" type="Temperature">
+					<xs:element minOccurs="0" name="BackupHeatingSwitchoverTemperature" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>[deg F] Temperature at which the backup heating is activated and the compressor is disabled in, e.g., a dual-fuel heat pump.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="BackupHeatingLockoutTemperature" type="Temperature">
+					<xs:element minOccurs="0" name="BackupHeatingLockoutTemperature" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>[deg F] Temperature above which the backup heating is disabled, often to prevent backup heating usage during recovery from a thermostat heating setback. For a duel-fuel heat pump, use the BackupHeatingSwitchoverTemperature element.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="FractionHeatLoadServed" type="Fraction" minOccurs="0"/>
-					<xs:element name="FractionCoolLoadServed" type="Fraction" minOccurs="0"/>
-					<xs:element minOccurs="0" name="FloorAreaServed" type="SurfaceArea">
+					<xs:element name="FractionHeatLoadServed" type="HPXMLFractionInclusive" minOccurs="0"/>
+					<xs:element name="FractionCoolLoadServed" type="HPXMLFractionInclusive" minOccurs="0"/>
+					<xs:element minOccurs="0" name="FloorAreaServed" type="HPXMLDoubleGreaterThanZero">
 						<xs:annotation>
 							<xs:documentation>[sq.ft.]</xs:documentation>
 						</xs:annotation>
@@ -3678,20 +3678,20 @@
 				<xs:sequence>
 					<xs:element name="CoolingSystemType" type="CoolingSystemType" minOccurs="0"/>
 					<xs:element minOccurs="0" name="CoolingSystemFuel" type="FuelType"/>
-					<xs:element minOccurs="0" name="CoolingCapacity" type="Capacity">
+					<xs:element minOccurs="0" name="CoolingCapacity" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>[Btuh] Output cooling capacity</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element minOccurs="0" name="CompressorType" type="CompressorType"/>
-					<xs:element name="FractionCoolLoadServed" type="Fraction" minOccurs="0"/>
-					<xs:element minOccurs="0" name="FloorAreaServed" type="SurfaceArea">
+					<xs:element name="FractionCoolLoadServed" type="HPXMLFractionInclusive" minOccurs="0"/>
+					<xs:element minOccurs="0" name="FloorAreaServed" type="HPXMLDoubleGreaterThanZero">
 						<xs:annotation>
 							<xs:documentation>[sq.ft.]</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element minOccurs="0" name="SensibleHeatFraction" type="Fraction"/>
+					<xs:element minOccurs="0" name="SensibleHeatFraction" type="HPXMLFractionInclusive"/>
 					<xs:element minOccurs="0" name="CoolingDetailedPerformanceData">
 						<xs:complexType>
 							<xs:sequence>
@@ -3717,7 +3717,7 @@
 			<xs:element minOccurs="0" name="BoreholesOrTrenches">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero"/>
+						<xs:element minOccurs="0" name="Count" type="HPXMLIntegerGreaterThanZero"/>
 						<xs:element minOccurs="0" name="Length" type="HPXMLDouble">
 							<xs:annotation>
 								<xs:documentation>[ft] Length of each borehole (vertical) or trench (horizontal)</xs:documentation>
@@ -3784,7 +3784,7 @@
 	<xs:complexType name="CoolingEfficiencyType">
 		<xs:sequence>
 			<xs:element name="Units" type="CoolingEfficiencyUnits"/>
-			<xs:element name="Value" type="Efficiency"/>
+			<xs:element name="Value" type="HPXMLDoubleGreaterThanZero"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
@@ -3795,14 +3795,14 @@
 					<xs:documentation>For AFUE and Percent enter values as a fractional number between 0 and 1, i.e. 80% = 0.8</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Value" type="Efficiency"/>
+			<xs:element name="Value" type="HPXMLDoubleGreaterThanZero"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
 	<xs:complexType name="BatteryCapacityType">
 		<xs:sequence>
 			<xs:element name="Units" type="BatteryCapacityUnits"> </xs:element>
-			<xs:element name="Value" type="BatteryCapacity">
+			<xs:element name="Value" type="HPXMLDecimalGreaterThanZero">
 				<xs:annotation>
 					<xs:documentation>Ah is computed by multiplying the discharge current (Amps) by the discharge time (hours). kWh is computed by multiplying the power output (kW) by the discharge time (hours).</xs:documentation>
 				</xs:annotation>
@@ -3823,26 +3823,26 @@
 	</xs:complexType>
 	<xs:complexType name="HydronicDistributionInfo">
 		<xs:sequence>
-			<xs:element name="FractionHydronicPipeInsulated" type="Fraction" minOccurs="0"/>
-			<xs:element minOccurs="0" name="PipeRValue" type="RValue"/>
-			<xs:element minOccurs="0" name="PipeInsulationThickness" type="LengthMeasurement">
+			<xs:element name="FractionHydronicPipeInsulated" type="HPXMLFractionInclusive" minOccurs="0"/>
+			<xs:element minOccurs="0" name="PipeRValue" type="HPXMLDoubleGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="PipeInsulationThickness" type="HPXMLDoubleGreaterThanOrEqualToZero">
 				<xs:annotation>
 					<xs:documentation>[in]</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="PipeLength" type="LengthMeasurement">
+			<xs:element minOccurs="0" name="PipeLength" type="HPXMLDoubleGreaterThanOrEqualToZero">
 				<xs:annotation>
 					<xs:documentation>[ft]</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element minOccurs="0" name="PipeDiameter" type="PipeDiameterType"/>
 			<xs:element name="HydronicDistributionType" type="HydronicDistributionType" minOccurs="0"/>
-			<xs:element minOccurs="0" name="SupplyTemperature" type="Temperature">
+			<xs:element minOccurs="0" name="SupplyTemperature" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[degF]</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="ReturnTemperature" type="Temperature">
+			<xs:element minOccurs="0" name="ReturnTemperature" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[degF]</xs:documentation>
 				</xs:annotation>
@@ -3878,12 +3878,12 @@
 						<xs:element name="DuctType" type="DuctType" minOccurs="0"/>
 						<xs:element name="DuctMaterial" type="DuctMaterial" minOccurs="0"/>
 						<xs:element minOccurs="0" name="DuctInsulationMaterial" type="InsulationMaterial"/>
-						<xs:element name="DuctInsulationRValue" type="RValue" minOccurs="0">
+						<xs:element name="DuctInsulationRValue" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0">
 							<xs:annotation>
 								<xs:documentation>This should exclude the exterior air film -- e.g., use zero for uninsulated ducts. For ducts buried in insulation, this should only represent any surrounding insulation duct wrap and not the entire attic insulation R-value.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DuctInsulationThickness" type="LengthMeasurement">
+						<xs:element minOccurs="0" name="DuctInsulationThickness" type="HPXMLDoubleGreaterThanOrEqualToZero">
 							<xs:annotation>
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
@@ -3894,19 +3894,19 @@
 								<xs:documentation>Describes ducts buried in, e.g., attic loose-fill insulation. Partially buried ducts have insulation that does not cover the top of the ducts. Fully buried ducts have insulation that just covers the top of the ducts. Deeply buried ducts have insulation that continues above the top of the ducts. See https://basc.pnnl.gov/resource-guides/ducts-buried-attic-insulation for more information.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DuctEffectiveRValue" type="RValue">
+						<xs:element minOccurs="0" name="DuctEffectiveRValue" type="HPXMLDoubleGreaterThanOrEqualToZero">
 							<xs:annotation>
 								<xs:documentation>The overall effective R-value. Includes the exterior air film as well as other effects such as adjustments for insulation wrapped around round ducts, or ducts buried in attic insulation.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element name="DuctLocation" type="DuctLocation" minOccurs="0"/>
-						<xs:element minOccurs="0" name="FractionDuctArea" type="Fraction">
+						<xs:element minOccurs="0" name="FractionDuctArea" type="HPXMLFractionInclusive">
 							<xs:annotation>
 								<xs:documentation>If a DuctType of supply or return is specified above, this is the fraction of the supply or return duct area. If DuctType is omitted above, this is
 									the fraction of the total duct area. </xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DuctSurfaceArea" type="SurfaceArea">
+						<xs:element minOccurs="0" name="DuctSurfaceArea" type="HPXMLDoubleGreaterThanZero">
 							<xs:annotation>
 								<xs:documentation>[sq.ft.]</xs:documentation>
 							</xs:annotation>
@@ -3916,7 +3916,7 @@
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="NumberofReturnRegisters" type="IntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="NumberofReturnRegisters" type="HPXMLIntegerGreaterThanOrEqualToZero"/>
 			<xs:element minOccurs="0" name="TotalExternalStaticPressureMeasurement">
 				<xs:complexType>
 					<xs:sequence>
@@ -3952,9 +3952,9 @@
 	<xs:complexType name="IncentiveDetailsType">
 		<xs:sequence>
 			<xs:element name="IncentiveType" type="SystemIdentifiersInfoType"/>
-			<xs:element name="FundingSourceCode" type="FundingSourceCode" minOccurs="0"/>
-			<xs:element name="FundingSourceName" type="FundingSourceName" minOccurs="0"/>
-			<xs:element name="IncentiveAmount" type="IncentiveAmount" minOccurs="0"/>
+			<xs:element name="FundingSourceCode" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="FundingSourceName" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="IncentiveAmount" type="HPXMLDecimal" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -3987,17 +3987,17 @@
 									<xs:element minOccurs="0" name="PublicTransportation">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="DistanceFromSubway" type="LengthMeasurement">
+												<xs:element minOccurs="0" name="DistanceFromSubway" type="HPXMLDoubleGreaterThanOrEqualToZero">
 													<xs:annotation>
 														<xs:documentation>[ft]</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="DistanceFromBus" type="LengthMeasurement">
+												<xs:element minOccurs="0" name="DistanceFromBus" type="HPXMLDoubleGreaterThanOrEqualToZero">
 													<xs:annotation>
 														<xs:documentation>[ft]</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="DistanceFromTrain" type="LengthMeasurement">
+												<xs:element minOccurs="0" name="DistanceFromTrain" type="HPXMLDoubleGreaterThanOrEqualToZero">
 													<xs:annotation>
 														<xs:documentation>[ft]</xs:documentation>
 													</xs:annotation>
@@ -4006,7 +4006,7 @@
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="WalkingScore" type="IntegerGreaterThanOrEqualToZero"/>
+									<xs:element minOccurs="0" name="WalkingScore" type="HPXMLIntegerGreaterThanOrEqualToZero"/>
 									<xs:element minOccurs="0" name="WalkingScoreSource" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="FuelTypesAvailable">
 										<xs:annotation>
@@ -4042,27 +4042,27 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:element minOccurs="0" name="HouseholdType" type="HouseholdType"/>
-									<xs:element minOccurs="0" name="YearOccupied" type="Year">
+									<xs:element minOccurs="0" name="YearOccupied" type="HPXMLInteger">
 										<xs:annotation>
 											<xs:documentation>The year the current occupants moved into the building</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="ResidentPopulationType" type="ResidentPopulationType"/>
 									<xs:element minOccurs="0" name="Occupancy" type="Occupancy"/>
-									<xs:element name="NumberofResidents" type="PeopleCount" minOccurs="0"/>
-									<xs:element minOccurs="0" name="NumberofAdults" type="PeopleCount">
+									<xs:element name="NumberofResidents" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0"/>
+									<xs:element minOccurs="0" name="NumberofAdults" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>18 or older</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofChildren" type="IntegerGreaterThanOrEqualToZero">
+									<xs:element minOccurs="0" name="NumberofChildren" type="HPXMLIntegerGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>less than 18 years old</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="PubliclySubsidized" type="HPXMLBoolean"/>
 									<xs:element minOccurs="0" name="LowIncome" type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="OccupantIncomeRange" type="FractionGreaterThanOne">
+									<xs:element minOccurs="0" name="OccupantIncomeRange" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>Percentage as a fraction (50% = 0.5)</xs:documentation>
 										</xs:annotation>
@@ -4081,9 +4081,9 @@
 						<xs:element minOccurs="0" name="BuildingConstruction">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element name="YearBuilt" type="Year" minOccurs="0"/>
+									<xs:element name="YearBuilt" type="HPXMLInteger" minOccurs="0"/>
 									<xs:element minOccurs="0" name="YearBuiltKnownOrEstimated" type="KnownOrEstimated"/>
-									<xs:element minOccurs="0" name="YearofLastRemodel" type="Year"/>
+									<xs:element minOccurs="0" name="YearofLastRemodel" type="HPXMLInteger"/>
 									<xs:element name="ResidentialFacilityType" type="ResidentialFacilityType" minOccurs="0"/>
 									<xs:element minOccurs="0" name="PassiveSolar" type="HPXMLBoolean">
 										<xs:annotation>
@@ -4092,61 +4092,61 @@
 												http://www.eere.energy.gov/basics/buildings/passive_solar_design.html)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="BuildingHeight" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="BuildingHeight" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[ft] height of building</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofUnits" type="IntegerGreaterThanZero">
+									<xs:element minOccurs="0" name="NumberofUnits" type="HPXMLIntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Number of dwelling units represented by the HPXML Building element. Used as a multiplier.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofUnitsInBuilding" type="IntegerGreaterThanZero">
+									<xs:element minOccurs="0" name="NumberofUnitsInBuilding" type="HPXMLIntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Total number of dwelling units in the physical building.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofFloors" type="NumberOfFloorsType">
+									<xs:element minOccurs="0" name="NumberofFloors" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>Total number of floors including a basement, whether conditioned or unconditioned</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofConditionedFloors" type="NumberOfFloorsType">
+									<xs:element minOccurs="0" name="NumberofConditionedFloors" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>Number of floors that are heated/cooled including a basement</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofConditionedFloorsAboveGrade" type="NumberOfFloorsType">
+									<xs:element minOccurs="0" name="NumberofConditionedFloorsAboveGrade" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>Number of floors above grade that are heated/cooled</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="AverageCeilingHeight" type="LengthMeasurement" minOccurs="0">
+									<xs:element name="AverageCeilingHeight" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[ft] Average distance from the floor to the ceiling</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FloorToFloorHeight" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="FloorToFloorHeight" type="HPXMLDoubleGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>[ft] distance between floors</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofRooms" type="IntegerGreaterThanZero"/>
-									<xs:element name="NumberofBedrooms" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
-									<xs:element name="NumberofBathrooms" type="IntegerGreaterThanZero" minOccurs="0"/>
-									<xs:element minOccurs="0" name="NumberofCompleteBathrooms" type="IntegerGreaterThanZero">
+									<xs:element minOccurs="0" name="NumberofRooms" type="HPXMLIntegerGreaterThanZero"/>
+									<xs:element name="NumberofBedrooms" type="HPXMLIntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+									<xs:element name="NumberofBathrooms" type="HPXMLIntegerGreaterThanZero" minOccurs="0"/>
+									<xs:element minOccurs="0" name="NumberofCompleteBathrooms" type="HPXMLIntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Number of bathrooms with a tub or shower</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="BuildingFootprintArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="BuildingFootprintArea" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="FootprintShape" type="FootprintShape"/>
-									<xs:element minOccurs="0" name="GrossFloorArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="GrossFloorArea" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Gross floor area (based on ASHRAE definition) is the sum of the floor areas of the spaces within the building, including
 												basements, mezzanine and intermediate‐floored tiers, and penthouses with headroom height of 7.5 ft (2.2 meters) or greater. Measurements must be taken
@@ -4156,7 +4156,7 @@
 												vehicles.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NetFloorArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="NetFloorArea" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] The floor area of an occupiable space defined by the inside surfaces of its walls but excluding shafts, column enclosures, and
 												other permanently enclosed, inaccessible, and unoccupiable areas. Obstructions in the space such as furnishings, display or storage racks, and other
@@ -4164,33 +4164,33 @@
 												area.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ConditionedFloorArea" type="SurfaceArea" minOccurs="0">
+									<xs:element name="ConditionedFloorArea" type="HPXMLDoubleGreaterThanZero" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] All finished space that is within the (insulated) conditioned space boundary (that is, within the insulated envelope), regardless
 												of HVAC configuration.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FinishedFloorArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="FinishedFloorArea" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Floor area of home that is finished and assumed to be occupied.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="NumberofStoriesAboveGrade" type="IntegerGreaterThanZero" minOccurs="0"/>
-									<xs:element minOccurs="0" name="CooledFloorArea" type="SurfaceArea">
+									<xs:element name="NumberofStoriesAboveGrade" type="HPXMLIntegerGreaterThanZero" minOccurs="0"/>
+									<xs:element minOccurs="0" name="CooledFloorArea" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] The total area of all enclosed spaces measured to the internal face of the external walls. Included are areas of sloping surfaces
 												such as staircases, galleries, raked auditoria, and tiered terraces where the area taken is from the area on the plan. Excluded are areas that are not
 												enclosed such as open floors, covered ways and balconies.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HeatedFloorArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="HeatedFloorArea" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] The total area of all enclosed spaces measured to the internal face of the external walls. Included are areas of sloping surfaces
 												such as staircases, galleries, raked auditoria, and tiered terraces where the area taken is from the area on the plan. Excluded are areas that are not
 												enclosed such as open floors, covered ways and balconies.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="UnconditionedFloorArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="UnconditionedFloorArea" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] An enclosed space within a building that does not meet the requirements of a conditioned space. Spaces that have no control over
 												thermal conditions but intentionally or unintentionally receive thermal energy from adjacent spaces are considered unconditioned spaces (such as an
@@ -4198,7 +4198,7 @@
 												unconditioned spaces (such as a parking garage with no thermal comfort criteria).</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="BuildingVolume" type="Volume">
+									<xs:element minOccurs="0" name="BuildingVolume" type="HPXMLDoubleGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>[cu.ft.] A volume of a building surrounded by solid surfaces such as walls, roofs, floors, fenestration, and doors where the total opening
 												area to the outside can be reduced to less than 1% of the Gross Interior Floor Area of the space. Spaces that are temporarily enclosed such as patios
@@ -4206,7 +4206,7 @@
 												building.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ConditionedBuildingVolume" type="Volume" minOccurs="0">
+									<xs:element name="ConditionedBuildingVolume" type="HPXMLDoubleGreaterThanZero" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[cu.ft.] Volume inside the building envelope of the conditioned spaces. This metric can be calculated as the volume of the building if
 												every space is conditioned or on a floor-by-floor basis. For spaces with vertical walls and horizontal ceilings and floors, this is calculated as the
@@ -4226,10 +4226,10 @@
 											<xs:documentation>Primary attic type of building</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="AverageAtticRValue" type="RValue" minOccurs="0"/>
-									<xs:element name="AverageWallRValue" type="RValue" minOccurs="0"/>
-									<xs:element name="AverageFloorRValue" type="RValue" minOccurs="0"/>
-									<xs:element name="AverageDuctRValue" type="RValue" minOccurs="0"/>
+									<xs:element name="AverageAtticRValue" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0"/>
+									<xs:element name="AverageWallRValue" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0"/>
+									<xs:element name="AverageFloorRValue" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0"/>
+									<xs:element name="AverageDuctRValue" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0"/>
 									<xs:element minOccurs="0" name="GaragePresent" type="HPXMLBoolean"/>
 									<xs:element minOccurs="0" name="GarageLocation" type="GarageLocation"/>
 									<xs:element minOccurs="0" name="SpaceAboveGarage" type="SpaceAboveGarage"/>
@@ -4260,7 +4260,7 @@
 						<xs:element name="TermiteZone" type="TermiteZone" minOccurs="0"/>
 						<xs:element name="HurricaneZone" type="HPXMLBoolean" minOccurs="0"/>
 						<xs:element name="FloodZone" type="HPXMLBoolean" minOccurs="0"/>
-						<xs:element name="EarthquakeZone" type="EarthquakeZone" minOccurs="0"/>
+						<xs:element name="EarthquakeZone" type="HPXMLBoolean" minOccurs="0"/>
 						<xs:element maxOccurs="unbounded" minOccurs="0" name="WeatherStation" type="WeatherStation">
 							<xs:annotation>
 								<xs:documentation>Weather location used in model simulation and/or utility bill regression analysis</xs:documentation>
@@ -4343,7 +4343,7 @@
 												both.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Year" type="Year">
+									<xs:element minOccurs="0" name="Year" type="HPXMLInteger">
 										<xs:annotation>
 											<xs:documentation>The year the certification or verification was awarded.</xs:documentation>
 										</xs:annotation>
@@ -4372,34 +4372,34 @@
 	<xs:complexType name="ProjectDetailsType">
 		<xs:sequence>
 			<xs:element maxOccurs="unbounded" minOccurs="0" ref="ExternalResource"/>
-			<xs:element name="ProgramName" type="ProgramName" minOccurs="0"/>
+			<xs:element name="ProgramName" type="HPXMLString" minOccurs="0"/>
 			<xs:element maxOccurs="1" minOccurs="0" ref="ContractorSystemIdentifiers"/>
-			<xs:element minOccurs="0" name="ProgramSponsor" type="ProgramSponsor"/>
-			<xs:element name="ProjectType" type="ProjectType" minOccurs="0"/>
-			<xs:element name="Title" type="Title" minOccurs="0"/>
+			<xs:element minOccurs="0" name="ProgramSponsor" type="HPXMLString"/>
+			<xs:element name="ProjectType" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="Title" type="HPXMLString" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="ProjectStatus"/>
-			<xs:element name="Notes" type="Notes" minOccurs="0"/>
-			<xs:element name="StartDate" type="StartDate" minOccurs="0">
+			<xs:element name="Notes" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="StartDate" type="HPXMLDate" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Start date of project</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="CompleteDateEstimated" type="CompleteDateEstimated" minOccurs="0">
+			<xs:element name="CompleteDateEstimated" type="HPXMLDate" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Estimated completion date of project</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="CompleteDateActual" type="CompleteDateActual" minOccurs="0">
+			<xs:element name="CompleteDateActual" type="HPXMLDate" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Actual completion date of project</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="Hours" type="Hours">
+			<xs:element minOccurs="0" name="Hours" type="HPXMLInteger">
 				<xs:annotation>
 					<xs:documentation>Amount of time spent by contractor on this stage of the project</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="FeeCost" type="Cost">
+			<xs:element minOccurs="0" name="FeeCost" type="HPXMLDecimal">
 				<xs:annotation>
 					<xs:documentation>Cost of any fees associated with the audit or other project activities</xs:documentation>
 				</xs:annotation>
@@ -4433,8 +4433,8 @@
 	</xs:complexType>
 	<xs:complexType name="TotalCostType">
 		<xs:sequence>
-			<xs:element name="TotalCostHealthSafetyMeasures" type="TotalCostHealthSafetyMeasures" minOccurs="1"/>
-			<xs:element name="TotalCostQualEnergyMeasures" type="TotalCostQualEnergyMeasures" minOccurs="1"/>
+			<xs:element name="TotalCostHealthSafetyMeasures" type="HPXMLDouble" minOccurs="1"/>
+			<xs:element name="TotalCostQualEnergyMeasures" type="HPXMLDouble" minOccurs="1"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
@@ -4452,21 +4452,21 @@
 				</xs:complexType>
 			</xs:element>
 			<xs:element maxOccurs="unbounded" minOccurs="0" ref="ExternalResource"/>
-			<xs:element name="MeasureCode" type="MeasureCode" minOccurs="0"/>
-			<xs:element name="MeasureDescription" type="MeasureDescription" minOccurs="0"/>
+			<xs:element name="MeasureCode" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="MeasureDescription" type="HPXMLString" minOccurs="0"/>
 			<xs:element minOccurs="0" name="Quantity">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element name="Units" type="HPXMLString"/>
-						<xs:element name="Value" type="Quantity"/>
+						<xs:element name="Value" type="HPXMLDecimal"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Location" type="UnitLocation" minOccurs="0"/>
-			<xs:element name="EstimatedLife" type="EstimatedLife" minOccurs="0"/>
-			<xs:element name="InstallationDate" type="InstallationDate" minOccurs="0"/>
-			<xs:element name="Cost" type="Cost" minOccurs="0"/>
+			<xs:element name="EstimatedLife" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="InstallationDate" type="HPXMLDate" minOccurs="0"/>
+			<xs:element name="Cost" type="HPXMLDecimal" minOccurs="0"/>
 			<xs:element name="UnitPricingIndicator" type="HPXMLBoolean" minOccurs="0"/>
 			<xs:element minOccurs="0" name="Incentives">
 				<xs:complexType>
@@ -4482,15 +4482,15 @@
 						<xs:element maxOccurs="unbounded" name="ResourcesSaved">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element name="ResourceTypeCode" type="ResourceTypeCode"/>
-									<xs:element name="LoadProfile" type="LoadProfile" minOccurs="0">
+									<xs:element name="ResourceTypeCode" type="HPXMLString"/>
+									<xs:element name="LoadProfile" type="HPXMLString" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>A load profile is created using measurements of a customer's electricity use at regular intervals, typically one hour or less, and
 												provides an accurate representation of a customer's usage pattern over time.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="Quantity" type="Quantity"/>
-									<xs:element name="AnnualAmount" type="AnnualAmount" minOccurs="0"/>
+									<xs:element name="Quantity" type="HPXMLDecimal"/>
+									<xs:element name="AnnualAmount" type="HPXMLString" minOccurs="0"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -4502,8 +4502,8 @@
 			</xs:element>
 			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType" maxOccurs="2"/>
 			<xs:element maxOccurs="2" minOccurs="0" name="WaterSavingsInfo" type="WaterSavingsType"/>
-			<xs:element minOccurs="0" name="CustomerNotes" type="Notes"/>
-			<xs:element minOccurs="0" name="WorkscopeNotes" type="Notes"/>
+			<xs:element minOccurs="0" name="CustomerNotes" type="HPXMLString"/>
+			<xs:element minOccurs="0" name="WorkscopeNotes" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="Status" type="ImprovementStatusType"/>
 			<xs:element minOccurs="0" name="NotInstalledReasonCode" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="InstallingContractor" type="RemoteReference"/>
@@ -4515,7 +4515,7 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element name="QAStatus" type="TestResultType"/>
-						<xs:element name="QAComments" type="Notes"/>
+						<xs:element name="QAComments" type="HPXMLString"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -4597,13 +4597,13 @@
 								<xs:documentation>For Percent enter values as a fractional number, i.e. 30% = 0.3</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="Value" type="MeasuredDuctLeakage" minOccurs="0"/>
+						<xs:element name="Value" type="HPXMLDouble" minOccurs="0"/>
 						<xs:element minOccurs="0" name="TotalOrToOutside" type="DuctLeakageTotalOrToOutside"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="EffectiveLeakageArea" type="SurfaceArea">
+			<xs:element minOccurs="0" name="EffectiveLeakageArea" type="HPXMLDoubleGreaterThanZero">
 				<xs:annotation>
 					<xs:documentation>The Leakage Area is defined in TECBLAST as the size of a sharp edged orifice which would leak at the same flow rate as the measured leakage, if the orifice were
 						subjected to the Test Pressure. Leakage Area [sq in] = Duct System Leakage Rate [CFM] / (1.06 * (Test Pressure [Pa]) ^ 0.5)</xs:documentation>
@@ -4865,12 +4865,12 @@
 					<xs:documentation>Type of stud, joist, etc. (2x4, 2x6, etc)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="Spacing" type="LengthMeasurement">
+			<xs:element minOccurs="0" name="Spacing" type="HPXMLDoubleGreaterThanOrEqualToZero">
 				<xs:annotation>
 					<xs:documentation>[in] Spacing on center</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="FramingFactor" type="Fraction"/>
+			<xs:element minOccurs="0" name="FramingFactor" type="HPXMLFractionInclusive"/>
 			<xs:element minOccurs="0" name="Material" type="StudMaterial"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
@@ -4879,9 +4879,9 @@
 	<xs:complexType name="TelephoneInfoType">
 		<xs:sequence>
 			<xs:element name="TelephoneType" type="TelephoneTypeCode" minOccurs="0"/>
-			<xs:element name="TelephoneNumber" type="TelephoneNumber"/>
+			<xs:element name="TelephoneNumber" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="PreferredContactMethod" type="HPXMLBoolean"/>
-			<xs:element name="TelephoneExtension" type="TelephoneExtension" minOccurs="0"/>
+			<xs:element name="TelephoneExtension" type="HPXMLString" minOccurs="0"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -4889,7 +4889,7 @@
 	<xs:complexType name="EmailInfoType">
 		<xs:sequence>
 			<xs:element name="EmailType" type="EmailTypeCode" minOccurs="0"/>
-			<xs:element name="EmailAddress" type="EmailAddress"/>
+			<xs:element name="EmailAddress" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="PreferredContactMethod" type="HPXMLBoolean"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
@@ -4920,12 +4920,12 @@
 	<xs:group name="WindowInfo">
 		<xs:sequence>
 			<xs:group ref="SystemInfo"/>
-			<xs:element name="Area" type="SurfaceArea" minOccurs="0">
+			<xs:element name="Area" type="HPXMLDoubleGreaterThanZero" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[sq.ft.] Total window surface area for this group of windows</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero">
+			<xs:element minOccurs="0" name="Count" type="HPXMLIntegerGreaterThanZero">
 				<xs:annotation>
 					<xs:documentation>Number of windows in the group</xs:documentation>
 				</xs:annotation>
@@ -4941,16 +4941,16 @@
 			<xs:element minOccurs="0" name="GlassType" type="GlassType"/>
 			<xs:element minOccurs="0" name="GasFill" type="GasFill"/>
 			<xs:element name="Condition" type="WindowCondition" minOccurs="0"/>
-			<xs:element name="UFactor" type="UFactor" minOccurs="0"/>
-			<xs:element name="SHGC" type="SHGC" minOccurs="0"/>
-			<xs:element minOccurs="0" name="VisibleTransmittance" type="Fraction"/>
+			<xs:element name="UFactor" type="HPXMLDoubleGreaterThanZero" minOccurs="0"/>
+			<xs:element name="SHGC" type="HPXMLFractionExclusive" minOccurs="0"/>
+			<xs:element minOccurs="0" name="VisibleTransmittance" type="HPXMLFractionInclusive"/>
 			<xs:element name="NFRCCertified" type="HPXMLBoolean" minOccurs="0"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="WindowThirdPartyCertification"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="WindowFilm">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
-						<xs:element minOccurs="0" name="ShadingCoefficient" type="Fraction">
+						<xs:element minOccurs="0" name="ShadingCoefficient" type="HPXMLFractionInclusive">
 							<xs:annotation>
 								<xs:documentation>Shading coefficients are defined as a multiplier on transmittance: 1 is transparent, 0 is opaque. </xs:documentation>
 							</xs:annotation>
@@ -4965,13 +4965,13 @@
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element minOccurs="0" name="Type" type="ExteriorShading"/>
-						<xs:element minOccurs="0" name="SummerShadingCoefficient" type="Fraction">
+						<xs:element minOccurs="0" name="SummerShadingCoefficient" type="HPXMLFractionInclusive">
 							<xs:annotation>
 								<xs:documentation>The shading coefficient to apply during the summer months. Shading coefficients are defined as a multiplier on transmittance: 1 is transparent, 0 is
 									opaque. </xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="WinterShadingCoefficient" type="Fraction">
+						<xs:element minOccurs="0" name="WinterShadingCoefficient" type="HPXMLFractionInclusive">
 							<xs:annotation>
 								<xs:documentation>The shading coefficient to apply during the winter months. Shading coefficients are defined as a multiplier on transmittance: 1 is transparent, 0 is
 									opaque. </xs:documentation>
@@ -4990,13 +4990,13 @@
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element minOccurs="0" name="Type" type="InteriorShading"/>
-						<xs:element minOccurs="0" name="SummerShadingCoefficient" type="Fraction">
+						<xs:element minOccurs="0" name="SummerShadingCoefficient" type="HPXMLFractionInclusive">
 							<xs:annotation>
 								<xs:documentation>The shading coefficient to apply during the summer months. Shading coefficients are defined as a multiplier on transmittance: 1 is transparent, 0 is
 									opaque. </xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="WinterShadingCoefficient" type="Fraction">
+						<xs:element minOccurs="0" name="WinterShadingCoefficient" type="HPXMLFractionInclusive">
 							<xs:annotation>
 								<xs:documentation>The shading coefficient to apply during the winter months. Shading coefficients are defined as a multiplier on transmittance: 1 is transparent, 0 is
 									opaque. </xs:documentation>
@@ -5029,7 +5029,7 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
-						<xs:element minOccurs="0" name="RValue" type="RValue"/>
+						<xs:element minOccurs="0" name="RValue" type="HPXMLDoubleGreaterThanOrEqualToZero"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -5038,17 +5038,17 @@
 			<xs:element minOccurs="0" name="Overhangs">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="Depth" type="LengthMeasurement">
+						<xs:element name="Depth" type="HPXMLDoubleGreaterThanOrEqualToZero">
 							<xs:annotation>
 								<xs:documentation>[ft] Depth of overhang</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DistanceToTopOfWindow" type="LengthMeasurement">
+						<xs:element minOccurs="0" name="DistanceToTopOfWindow" type="HPXMLDoubleGreaterThanOrEqualToZero">
 							<xs:annotation>
 								<xs:documentation>[ft] Vertical distance from overhang to top of window</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DistanceToBottomOfWindow" type="LengthMeasurement">
+						<xs:element minOccurs="0" name="DistanceToBottomOfWindow" type="HPXMLDoubleGreaterThanOrEqualToZero">
 							<xs:annotation>
 								<xs:documentation>[ft] Vertical distance from overhang to bottom of window</xs:documentation>
 							</xs:annotation>
@@ -5145,7 +5145,7 @@
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
-						<xs:element name="JobRole" type="JobRole" minOccurs="0"/>
+						<xs:element name="JobRole" type="HPXMLString" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="ID" type="xs:int" use="required"/>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -5179,7 +5179,7 @@
 			<xs:element minOccurs="0" name="Date" type="HPXMLDate"/>
 			<xs:element minOccurs="0" name="BusinessConductingTest" type="RemoteReference"/>
 			<xs:element minOccurs="0" name="IndividualConductingTest" type="RemoteReference"/>
-			<xs:element minOccurs="0" name="OutsideTemperature" type="Temperature">
+			<xs:element minOccurs="0" name="OutsideTemperature" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[deg F]</xs:documentation>
 				</xs:annotation>
@@ -5192,12 +5192,12 @@
 					<xs:documentation>This element is intended to describe the type of infiltration measured, e.g., for an individual single-family attached or multifamily dwelling unit. Either whole building or single unit infiltration can be measured. For single unit infiltration, leakage can occur through exterior surfaces, interior surfaces, or both. For example, guarded tests measure unit exterior leakage, unguarded or compartmentalization tests measure unit total leakage, and combining both tests can measure unit interior leakage.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="HousePressure" type="HousePressure" minOccurs="0">
+			<xs:element name="HousePressure" type="HPXMLDoubleGreaterThanZero" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[Pa] with respect to outside</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="FanPressure" type="FanPressure" minOccurs="0">
+			<xs:element name="FanPressure" type="HPXMLDouble" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[Pa]</xs:documentation>
 				</xs:annotation>
@@ -5208,7 +5208,7 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element name="UnitofMeasure" type="BuildingAirLeakageUnit" minOccurs="0"/>
-						<xs:element name="AirLeakage" type="BuildingAirLeakage" minOccurs="0"/>
+						<xs:element name="AirLeakage" type="HPXMLDoubleGreaterThanZero" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -5507,32 +5507,32 @@
 			<xs:element minOccurs="0" ref="ConnectedDevice"/>
 			<xs:element minOccurs="0" ref="AttachedToZone"/>
 			<xs:element name="ControlType" type="ThermostatType" minOccurs="0"/>
-			<xs:element name="SetpointTempHeatingSeason" type="Temperature" minOccurs="0">
+			<xs:element name="SetpointTempHeatingSeason" type="HPXMLDouble" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[deg F]</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="SetbackTempHeatingSeason" type="Temperature" minOccurs="0">
+			<xs:element name="SetbackTempHeatingSeason" type="HPXMLDouble" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[deg F]</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="TotalSetbackHoursperWeekHeating" type="Hours" minOccurs="0">
+			<xs:element name="TotalSetbackHoursperWeekHeating" type="HPXMLInteger" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[hours]</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="SetupTempCoolingSeason" type="Temperature" minOccurs="0">
+			<xs:element name="SetupTempCoolingSeason" type="HPXMLDouble" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[deg F]</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="SetpointTempCoolingSeason" type="Temperature" minOccurs="0">
+			<xs:element name="SetpointTempCoolingSeason" type="HPXMLDouble" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[deg F]</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="TotalSetupHoursperWeekCooling" type="Hours" minOccurs="0">
+			<xs:element name="TotalSetupHoursperWeekCooling" type="HPXMLInteger" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[hours]</xs:documentation>
 				</xs:annotation>
@@ -5540,12 +5540,12 @@
 			<xs:element minOccurs="0" name="HotWaterResetControl" type="HotWaterResetControl"/>
 			<xs:element minOccurs="0" name="HeatLowered" type="HVACControlTypeAdjustments"/>
 			<xs:element minOccurs="0" name="ACAdjusted" type="HVACControlTypeAdjustments"/>
-			<xs:element minOccurs="0" name="FractionThermostaticRadiatorValves" type="Fraction">
+			<xs:element minOccurs="0" name="FractionThermostaticRadiatorValves" type="HPXMLFractionInclusive">
 				<xs:annotation>
 					<xs:documentation>Fraction of rooms controlled by thermostatic radiator valves</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="FractionElectronicZoneValves" type="Fraction">
+			<xs:element minOccurs="0" name="FractionElectronicZoneValves" type="HPXMLFractionInclusive">
 				<xs:annotation>
 					<xs:documentation>Percent of rooms controlled by electronic zone valves with thermostats</xs:documentation>
 				</xs:annotation>
@@ -5599,8 +5599,8 @@
 					<xs:documentation>Year and month of the last tune and repair for this HVAC equipment.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="NumberofCoilsReplaced" type="IntegerGreaterThanOrEqualToZero"/>
-			<xs:element minOccurs="0" name="NumberofAirHandlersReplaced" type="IntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="NumberofCoilsReplaced" type="HPXMLIntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="NumberofAirHandlersReplaced" type="HPXMLIntegerGreaterThanOrEqualToZero"/>
 			<xs:element minOccurs="0" name="AirFilter">
 				<xs:complexType>
 					<xs:sequence>
@@ -5653,10 +5653,10 @@
 	<xs:complexType name="WaterHeaterImprovementInfo">
 		<xs:sequence>
 			<xs:element name="JacketInstalledIndicator" type="HPXMLBoolean" minOccurs="0"/>
-			<xs:element name="DispositionofExistingSystem" type="DispositionofExistingSystem" minOccurs="0"/>
+			<xs:element name="DispositionofExistingSystem" type="HPXMLString" minOccurs="0"/>
 			<xs:element name="RepairsDescription" type="HPXMLString" minOccurs="0" maxOccurs="unbounded"/>
-			<xs:element name="PipeInsulated" type="PipeInsulated" minOccurs="0"/>
-			<xs:element name="LengthofPipeInsulated" type="LengthMeasurement" minOccurs="0">
+			<xs:element name="PipeInsulated" type="HPXMLString" minOccurs="0"/>
+			<xs:element name="LengthofPipeInsulated" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[ft]</xs:documentation>
 				</xs:annotation>
@@ -5855,7 +5855,7 @@
 			<xs:group ref="SystemInfo"/>
 			<xs:element name="Name" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="City" nillable="true" type="HPXMLString"/>
-			<xs:element minOccurs="0" name="State" type="StateCode"/>
+			<xs:element minOccurs="0" name="State" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="WBAN" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="WMO" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="Type" type="WeatherStationType"/>
@@ -5866,14 +5866,14 @@
 	</xs:complexType>
 	<xs:complexType name="PipeInsulationType">
 		<xs:sequence>
-			<xs:element name="PipeRValue" type="RValue" minOccurs="0"/>
-			<xs:element minOccurs="0" name="PipeLengthInsulated" type="LengthMeasurement">
+			<xs:element name="PipeRValue" type="HPXMLDoubleGreaterThanOrEqualToZero" minOccurs="0"/>
+			<xs:element minOccurs="0" name="PipeLengthInsulated" type="HPXMLDoubleGreaterThanOrEqualToZero">
 				<xs:annotation>
 					<xs:documentation>[ft]</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element minOccurs="0" name="PipeDiameterInsulated" type="PipeDiameterType"/>
-			<xs:element name="FractionPipeInsulation" type="Fraction" minOccurs="0">
+			<xs:element name="FractionPipeInsulation" type="HPXMLFractionInclusive" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Fraction of total pipe insulated</xs:documentation>
 				</xs:annotation>
@@ -5960,7 +5960,7 @@
 	<xs:complexType name="VentilationType">
 		<xs:sequence>
 			<xs:element name="UnitofMeasure" type="VentilationUnit" minOccurs="0"/>
-			<xs:element name="Value" type="BuildingAirLeakage" minOccurs="0"/>
+			<xs:element name="Value" type="HPXMLDoubleGreaterThanZero" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
@@ -5970,7 +5970,7 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element name="Dimension" type="DiameterDimension"/>
-						<xs:element name="Value" type="LengthMeasurement">
+						<xs:element name="Value" type="HPXMLDoubleGreaterThanOrEqualToZero">
 							<xs:annotation>
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
@@ -6020,27 +6020,27 @@
 	<xs:complexType name="CoolingPerformanceDataPoint">
 		<xs:sequence>
 			<xs:element maxOccurs="unbounded" minOccurs="0" ref="ExternalResource"/>
-			<xs:element name="OutdoorTemperature" type="Temperature" minOccurs="0">
+			<xs:element name="OutdoorTemperature" type="HPXMLDouble" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[F] drybulb</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="IndoorTemperature" type="Temperature">
+			<xs:element minOccurs="0" name="IndoorTemperature" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[F] drybulb</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="IndoorWetbulbTemperature" type="Temperature">
+			<xs:element minOccurs="0" name="IndoorWetbulbTemperature" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[F] wetbulb</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="Capacity" type="Capacity">
+			<xs:element minOccurs="0" name="Capacity" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[Btuh] output capacity</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="CapacityFractionOfNominal" type="FractionGreaterThanOne">
+			<xs:element minOccurs="0" name="CapacityFractionOfNominal" type="HPXMLDoubleGreaterThanOrEqualToZero">
 				<xs:annotation>
 					<xs:documentation>Fraction of the nominal output capacity</xs:documentation>
 				</xs:annotation>
@@ -6058,22 +6058,22 @@
 	<xs:complexType name="HeatingPerformanceDataPoint">
 		<xs:sequence>
 			<xs:element maxOccurs="unbounded" minOccurs="0" ref="ExternalResource"/>
-			<xs:element name="OutdoorTemperature" type="Temperature" minOccurs="0">
+			<xs:element name="OutdoorTemperature" type="HPXMLDouble" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>[F] drybulb</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="IndoorTemperature" type="Temperature">
+			<xs:element minOccurs="0" name="IndoorTemperature" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[F] drybulb</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="Capacity" type="Capacity">
+			<xs:element minOccurs="0" name="Capacity" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[Btuh] output capacity</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="CapacityFractionOfNominal" type="FractionGreaterThanOne">
+			<xs:element minOccurs="0" name="CapacityFractionOfNominal" type="HPXMLDoubleGreaterThanOrEqualToZero">
 				<xs:annotation>
 					<xs:documentation>Fraction of the nominal output capacity</xs:documentation>
 				</xs:annotation>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -100,7 +100,7 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="HPXMLFractionExcludingZero_simple">
+	<xs:simpleType name="HPXMLFractionGreaterThanZero_simple">
 		<xs:annotation>
 			<xs:documentation>A fraction that has to be between 0 exclusive and 1 inclusive</xs:documentation>
 		</xs:annotation>
@@ -109,9 +109,9 @@
 			<xs:maxInclusive value="1"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:complexType name="HPXMLFractionExcludingZero">
+	<xs:complexType name="HPXMLFractionGreaterThanZero">
 		<xs:simpleContent>
-			<xs:extension base="HPXMLFractionExcludingZero_simple">
+			<xs:extension base="HPXMLFractionGreaterThanZero_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -41,6 +41,30 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+	<xs:simpleType name="HPXMLDoubleGreaterThanZero_simple">
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="HPXMLDoubleGreaterThanZero">
+		<xs:simpleContent>
+			<xs:extension base="HPXMLDoubleGreaterThanZero_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="HPXMLDoubleGreaterThanOrEqualToZero_simple">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="HPXMLDoubleGreaterThanOrEqualToZero">
+		<xs:simpleContent>
+			<xs:extension base="HPXMLDoubleGreaterThanOrEqualToZero_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:complexType name="HPXMLDecimal">
 		<xs:simpleContent>
 			<xs:extension base="xs:decimal">
@@ -48,9 +72,93 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+	<xs:simpleType name="HPXMLDecimalGreaterThanZero_simple">
+		<xs:restriction base="xs:decimal">
+			<xs:minInclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="HPXMLDecimalGreaterThanZero">
+		<xs:simpleContent>
+			<xs:extension base="HPXMLDecimalGreaterThanZero_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="HPXMLFractionInclusive_simple">
+		<xs:annotation>
+			<xs:documentation>A fraction that has to be between 0 and 1 inclusive</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+			<xs:maxInclusive value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="HPXMLFractionInclusive">
+		<xs:simpleContent>
+			<xs:extension base="HPXMLFractionInclusive_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="HPXMLFractionExcludingZero_simple">
+		<xs:annotation>
+			<xs:documentation>A fraction that has to be between 0 exclusive and 1 inclusive</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+			<xs:maxInclusive value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="HPXMLFractionExcludingZero">
+		<xs:simpleContent>
+			<xs:extension base="HPXMLFractionExcludingZero_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="HPXMLFractionExclusive_simple">
+		<xs:annotation>
+			<xs:documentation>A fraction that has to be between 0 and 1 exclusive</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0"/>
+			<xs:maxExclusive value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="HPXMLFractionExclusive">
+		<xs:simpleContent>
+			<xs:extension base="HPXMLFractionExclusive_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:complexType name="HPXMLInteger">
 		<xs:simpleContent>
 			<xs:extension base="xs:integer">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="HPXMLIntegerGreaterThanZero_simple">
+		<xs:restriction base="xs:integer">
+			<xs:minExclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="HPXMLIntegerGreaterThanZero">
+		<xs:simpleContent>
+			<xs:extension base="HPXMLIntegerGreaterThanZero_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="HPXMLIntegerGreaterThanOrEqualToZero_simple">
+		<xs:restriction base="xs:integer">
+			<xs:minInclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="HPXMLIntegerGreaterThanOrEqualToZero">
+		<xs:simpleContent>
+			<xs:extension base="HPXMLIntegerGreaterThanOrEqualToZero_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -75,16 +183,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="StateCode_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="StateCode">
-		<xs:simpleContent>
-			<xs:extension base="StateCode_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="ZipCode_simple">
 		<xs:restriction base="xs:string">
 			<xs:pattern value="[0-9]{5}(-[0-9]{4})?"/>
@@ -97,37 +195,7 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="USPSBarCode_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="USPSBarCode">
-		<xs:simpleContent>
-			<xs:extension base="USPSBarCode_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<!--Name Information Below-->
-	<xs:simpleType name="PrefixName_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="PrefixName">
-		<xs:simpleContent>
-			<xs:extension base="PrefixName_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="SuffixName_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="SuffixName">
-		<xs:simpleContent>
-			<xs:extension base="SuffixName_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="IndividualType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="owner-occupant"/>
@@ -174,26 +242,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="TelephoneNumber_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="TelephoneNumber">
-		<xs:simpleContent>
-			<xs:extension base="TelephoneNumber_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="TelephoneExtension_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="TelephoneExtension">
-		<xs:simpleContent>
-			<xs:extension base="TelephoneExtension_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<!--Email Information Below-->
 	<xs:simpleType name="EmailTypeCode_simple">
 		<xs:restriction base="xs:string">
@@ -209,90 +257,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="EmailAddress_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="EmailAddress">
-		<xs:simpleContent>
-			<xs:extension base="EmailAddress_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<!--System Identifiers Below-->
-	<xs:simpleType name="SendingSystemIdentifierType_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="SendingSystemIdentifierType">
-		<xs:simpleContent>
-			<xs:extension base="SendingSystemIdentifierType_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="SendingSystemIdentifierValue_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="SendingSystemIdentifierValue">
-		<xs:simpleContent>
-			<xs:extension base="SendingSystemIdentifierValue_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="ReceivingSystemIdentifierType_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="ReceivingSystemIdentifierType">
-		<xs:simpleContent>
-			<xs:extension base="ReceivingSystemIdentifierType_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="ReceivingSystemIdentifierValue_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="ReceivingSystemIdentifierValue">
-		<xs:simpleContent>
-			<xs:extension base="ReceivingSystemIdentifierValue_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<!--XMLTransaction Header Information Below-->
-	<xs:simpleType name="XMLType_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="XMLType">
-		<xs:simpleContent>
-			<xs:extension base="XMLType_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="XMLGeneratedBy_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="XMLGeneratedBy">
-		<xs:simpleContent>
-			<xs:extension base="XMLGeneratedBy_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="CreatedDateAndTime_simple">
-		<xs:restriction base="xs:dateTime"/>
-	</xs:simpleType>
-	<xs:complexType name="CreatedDateAndTime">
-		<xs:simpleContent>
-			<xs:extension base="CreatedDateAndTime_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<!--Utility Information Below-->
-	<!--Misc Data Fields Below-->
 	<!--Air Infiltration Below-->
 	<xs:simpleType name="BuildingLeakiness_simple">
 		<xs:restriction base="xs:string">
@@ -319,18 +283,6 @@
 	<xs:complexType name="WindConditions">
 		<xs:simpleContent>
 			<xs:extension base="WindConditions_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="BuildingAirLeakage_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="BuildingAirLeakage">
-		<xs:simpleContent>
-			<xs:extension base="BuildingAirLeakage_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -365,16 +317,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="FanPressure_simple">
-		<xs:restriction base="xs:double"/>
-	</xs:simpleType>
-	<xs:complexType name="FanPressure">
-		<xs:simpleContent>
-			<xs:extension base="FanPressure_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="FanRingUsed_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="open"/>
@@ -398,18 +340,6 @@
 	<xs:complexType name="TypeofBlowerDoorTest">
 		<xs:simpleContent>
 			<xs:extension base="TypeofBlowerDoorTest_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="HousePressure_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="HousePressure">
-		<xs:simpleContent>
-			<xs:extension base="HousePressure_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -494,16 +424,6 @@
 	<xs:complexType name="ClimateZoneIECC">
 		<xs:simpleContent>
 			<xs:extension base="ClimateZoneIECC_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="EarthquakeZone_simple">
-		<xs:restriction base="xs:boolean"/>
-	</xs:simpleType>
-	<xs:complexType name="EarthquakeZone">
-		<xs:simpleContent>
-			<xs:extension base="EarthquakeZone_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -615,42 +535,6 @@
 	<xs:complexType name="OrientationType">
 		<xs:simpleContent>
 			<xs:extension base="OrientationType_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="NumberOfFloorsType_simple">
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="NumberOfFloorsType">
-		<xs:simpleContent>
-			<xs:extension base="NumberOfFloorsType_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="IntegerGreaterThanZero_simple">
-		<xs:restriction base="xs:integer">
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="IntegerGreaterThanZero">
-		<xs:simpleContent>
-			<xs:extension base="IntegerGreaterThanZero_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="IntegerGreaterThanOrEqualToZero_simple">
-		<xs:restriction base="xs:integer">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="IntegerGreaterThanOrEqualToZero">
-		<xs:simpleContent>
-			<xs:extension base="IntegerGreaterThanOrEqualToZero_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -810,16 +694,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="Year_simple">
-		<xs:restriction base="xs:integer"/>
-	</xs:simpleType>
-	<xs:complexType name="Year">
-		<xs:simpleContent>
-			<xs:extension base="Year_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<!-- Make sure to update FuelType with changes to this list as well. -->
 	<xs:simpleType name="ConsumptionType_simple">
 		<xs:restriction base="xs:string">
@@ -953,16 +827,6 @@
 	<xs:complexType name="PeakSeason">
 		<xs:simpleContent>
 			<xs:extension base="PeakSeason_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="COReading_simple">
-		<xs:restriction base="xs:double"/>
-	</xs:simpleType>
-	<xs:complexType name="COReading">
-		<xs:simpleContent>
-			<xs:extension base="COReading_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -1242,31 +1106,7 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="RValue_simple">
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="RValue">
-		<xs:simpleContent>
-			<xs:extension base="RValue_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<!--Insulation Below-->
-	<xs:simpleType name="AssemblyRValue_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="AssemblyRValue">
-		<xs:simpleContent>
-			<xs:extension base="AssemblyRValue_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="DoorThirdPartyCertifications_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Energy Star"/>
@@ -1643,19 +1483,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="SHGC_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-			<xs:maxExclusive value="1"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="SHGC">
-		<xs:simpleContent>
-			<xs:extension base="SHGC_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="InteriorShading_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="light blinds"/>
@@ -1694,18 +1521,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="UFactor_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="UFactor">
-		<xs:simpleContent>
-			<xs:extension base="UFactor_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<!--Combustion Appliance Tests Below-->
 	<xs:simpleType name="FlueCondition_simple">
 		<xs:restriction base="xs:string">
@@ -1721,16 +1536,6 @@
 		</xs:simpleContent>
 	</xs:complexType>
 	<!--Combustion Appliance Zone Test Below-->
-	<xs:simpleType name="CAZDepressurizationLimit_simple">
-		<xs:restriction base="xs:double"/>
-	</xs:simpleType>
-	<xs:complexType name="CAZDepressurizationLimit">
-		<xs:simpleContent>
-			<xs:extension base="CAZDepressurizationLimit_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="OpenClosed_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="open"/>
@@ -1753,16 +1558,6 @@
 	<xs:complexType name="DepressurizationFindingPoorCase">
 		<xs:simpleContent>
 			<xs:extension base="DepressurizationFindingPoorCase_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="NetPressureChange_simple">
-		<xs:restriction base="xs:double"/>
-	</xs:simpleType>
-	<xs:complexType name="NetPressureChange">
-		<xs:simpleContent>
-			<xs:extension base="NetPressureChange_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -1842,18 +1637,6 @@
 	<xs:complexType name="DistrictSteamType">
 		<xs:simpleContent>
 			<xs:extension base="DistrictSteamType_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Efficiency_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="Efficiency">
-		<xs:simpleContent>
-			<xs:extension base="Efficiency_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -2064,16 +1847,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="MeasuredDuctLeakage_simple">
-		<xs:restriction base="xs:double"/>
-	</xs:simpleType>
-	<xs:complexType name="MeasuredDuctLeakage">
-		<xs:simpleContent>
-			<xs:extension base="MeasuredDuctLeakage_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<!--HVAC System Below-->
 	<xs:simpleType name="AirHandlerStaticPressureMeasurementLocation_simple">
 		<xs:restriction base="xs:string">
@@ -2102,16 +1875,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="Capacity_simple">
-		<xs:restriction base="xs:double"/>
-	</xs:simpleType>
-	<xs:complexType name="Capacity">
-		<xs:simpleContent>
-			<xs:extension base="Capacity_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="HVACMaintenanceSchedule_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="none"/>
@@ -2130,36 +1893,6 @@
 	<xs:complexType name="HVACMaintenanceSchedule">
 		<xs:simpleContent>
 			<xs:extension base="HVACMaintenanceSchedule_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="DispositionofExistingSystem_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="DispositionofExistingSystem">
-		<xs:simpleContent>
-			<xs:extension base="DispositionofExistingSystem_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Manufacturer_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="Manufacturer">
-		<xs:simpleContent>
-			<xs:extension base="Manufacturer_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Model_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="Model">
-		<xs:simpleContent>
-			<xs:extension base="Model_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -2199,16 +1932,6 @@
 		</xs:simpleContent>
 	</xs:complexType>
 	<!--Thermostats Below-->
-	<xs:simpleType name="Temperature_simple">
-		<xs:restriction base="xs:double"/>
-	</xs:simpleType>
-	<xs:complexType name="Temperature">
-		<xs:simpleContent>
-			<xs:extension base="Temperature_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="ThermostatType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="programmable thermostat"/>
@@ -2239,16 +1962,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="Hours_simple">
-		<xs:restriction base="xs:integer"/>
-	</xs:simpleType>
-	<xs:complexType name="Hours">
-		<xs:simpleContent>
-			<xs:extension base="Hours_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<!--Water Heating System Below-->
 	<xs:simpleType name="EnergyFactor_simple">
 		<xs:restriction base="xs:double">
@@ -2263,16 +1976,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="PipeInsulated_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="PipeInsulated">
-		<xs:simpleContent>
-			<xs:extension base="PipeInsulated_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="RecoveryEfficiency_simple">
 		<xs:restriction base="xs:double">
 			<xs:minExclusive value="0"/>
@@ -2282,41 +1985,6 @@
 	<xs:complexType name="RecoveryEfficiency">
 		<xs:simpleContent>
 			<xs:extension base="RecoveryEfficiency_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Volume_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="Volume">
-		<xs:simpleContent>
-			<xs:extension base="Volume_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="ThermalEfficiency_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-			<xs:maxInclusive value="1"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="ThermalEfficiency">
-		<xs:simpleContent>
-			<xs:extension base="ThermalEfficiency_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="ProjectType_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="ProjectType">
-		<xs:simpleContent>
-			<xs:extension base="ProjectType_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -2354,74 +2022,6 @@
 	<xs:complexType name="DishwasherType">
 		<xs:simpleContent>
 			<xs:extension base="DishwasherType_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="RatedAnnualkWh_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="RatedAnnualkWh">
-		<xs:simpleContent>
-			<xs:extension base="RatedAnnualkWh_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="RatedWaterGalPerCycle_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="RatedWaterGalPerCycle">
-		<xs:simpleContent>
-			<xs:extension base="RatedWaterGalPerCycle_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<!--Freezer Below-->
-	<!--Refrigerators Below-->
-	<!--Energy Savings Information Below-->
-	<xs:simpleType name="TotalCostHealthSafetyMeasures_simple">
-		<xs:restriction base="xs:double"/>
-	</xs:simpleType>
-	<xs:complexType name="TotalCostHealthSafetyMeasures">
-		<xs:simpleContent>
-			<xs:extension base="TotalCostHealthSafetyMeasures_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="TotalCostQualEnergyMeasures_simple">
-		<xs:restriction base="xs:double"/>
-	</xs:simpleType>
-	<xs:complexType name="TotalCostQualEnergyMeasures">
-		<xs:simpleContent>
-			<xs:extension base="TotalCostQualEnergyMeasures_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<!--Software Information Below-->
-	<xs:simpleType name="SoftwareProgramUsed_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="SoftwareProgramUsed">
-		<xs:simpleContent>
-			<xs:extension base="SoftwareProgramUsed_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="SoftwareProgramVersion_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="SoftwareProgramVersion">
-		<xs:simpleContent>
-			<xs:extension base="SoftwareProgramVersion_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -2653,18 +2253,6 @@
 	<xs:complexType name="GrossOrNet">
 		<xs:simpleContent>
 			<xs:extension base="GrossOrNet_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="SurfaceArea_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="SurfaceArea">
-		<xs:simpleContent>
-			<xs:extension base="SurfaceArea_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -3095,240 +2683,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="ResourceTypeCode_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="ResourceTypeCode">
-		<xs:simpleContent>
-			<xs:extension base="ResourceTypeCode_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Quantity_simple">
-		<xs:restriction base="xs:decimal"/>
-	</xs:simpleType>
-	<xs:complexType name="Quantity">
-		<xs:simpleContent>
-			<xs:extension base="Quantity_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="ProgramName_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="ProgramName">
-		<xs:simpleContent>
-			<xs:extension base="ProgramName_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Title_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="Title">
-		<xs:simpleContent>
-			<xs:extension base="Title_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="StartDate_simple">
-		<xs:restriction base="xs:date"/>
-	</xs:simpleType>
-	<xs:complexType name="StartDate">
-		<xs:simpleContent>
-			<xs:extension base="StartDate_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="CompleteDateEstimated_simple">
-		<xs:restriction base="xs:date"/>
-	</xs:simpleType>
-	<xs:complexType name="CompleteDateEstimated">
-		<xs:simpleContent>
-			<xs:extension base="CompleteDateEstimated_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="CompleteDateActual_simple">
-		<xs:restriction base="xs:date"/>
-	</xs:simpleType>
-	<xs:complexType name="CompleteDateActual">
-		<xs:simpleContent>
-			<xs:extension base="CompleteDateActual_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Notes_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="Notes">
-		<xs:simpleContent>
-			<xs:extension base="Notes_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="MeasureCode_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="MeasureCode">
-		<xs:simpleContent>
-			<xs:extension base="MeasureCode_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="MeasureDescription_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="MeasureDescription">
-		<xs:simpleContent>
-			<xs:extension base="MeasureDescription_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="EstimatedLife_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="EstimatedLife">
-		<xs:simpleContent>
-			<xs:extension base="EstimatedLife_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="InstallationDate_simple">
-		<xs:restriction base="xs:date"/>
-	</xs:simpleType>
-	<xs:complexType name="InstallationDate">
-		<xs:simpleContent>
-			<xs:extension base="InstallationDate_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Cost_simple">
-		<xs:restriction base="xs:decimal"/>
-	</xs:simpleType>
-	<xs:complexType name="Cost">
-		<xs:simpleContent>
-			<xs:extension base="Cost_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="FundingSourceCode_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="FundingSourceCode">
-		<xs:simpleContent>
-			<xs:extension base="FundingSourceCode_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="FundingSourceName_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="FundingSourceName">
-		<xs:simpleContent>
-			<xs:extension base="FundingSourceName_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="IncentiveAmount_simple">
-		<xs:restriction base="xs:decimal"/>
-	</xs:simpleType>
-	<xs:complexType name="IncentiveAmount">
-		<xs:simpleContent>
-			<xs:extension base="IncentiveAmount_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="LoadProfile_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="LoadProfile">
-		<xs:simpleContent>
-			<xs:extension base="LoadProfile_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="AnnualAmount_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="AnnualAmount">
-		<xs:simpleContent>
-			<xs:extension base="AnnualAmount_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="JobRole_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="JobRole">
-		<xs:simpleContent>
-			<xs:extension base="JobRole_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Fraction_simple">
-		<xs:annotation>
-			<xs:documentation>A fraction that has to be between 0 and 1 inclusive</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-			<xs:maxInclusive value="1"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="Fraction">
-		<xs:simpleContent>
-			<xs:extension base="Fraction_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="FractionExcludingZero_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-			<xs:maxInclusive value="1"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="FractionExcludingZero">
-		<xs:simpleContent>
-			<xs:extension base="FractionExcludingZero_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="FractionGreaterThanOne_simple">
-		<xs:annotation>
-			<xs:documentation>A fraction that can be greater than one (ie 110%)</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="FractionGreaterThanOne">
-		<xs:simpleContent>
-			<xs:extension base="FractionGreaterThanOne_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="ImprovementStatusType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Installed"/>
@@ -3464,18 +2818,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="LengthMeasurement_simple">
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="LengthMeasurement">
-		<xs:simpleContent>
-			<xs:extension base="LengthMeasurement_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="InsulationGrade_simple">
 		<xs:restriction base="xs:integer">
 			<xs:minInclusive value="1"/>
@@ -3501,18 +2843,6 @@
 	<xs:complexType name="FloorCovering">
 		<xs:simpleContent>
 			<xs:extension base="FloorCovering_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Pitch_simple">
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="Pitch">
-		<xs:simpleContent>
-			<xs:extension base="Pitch_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -3584,42 +2914,6 @@
 	<xs:complexType name="EVChargingConnector">
 		<xs:simpleContent>
 			<xs:extension base="EVChargingConnector_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Current_simple">
-		<xs:restriction base="xs:decimal">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="Current">
-		<xs:simpleContent>
-			<xs:extension base="Current_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Voltage_simple">
-		<xs:restriction base="xs:decimal">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="Voltage">
-		<xs:simpleContent>
-			<xs:extension base="Voltage_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Power_simple">
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="Power">
-		<xs:simpleContent>
-			<xs:extension base="Power_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -3799,16 +3093,6 @@
 	<xs:complexType name="eGridRegions">
 		<xs:simpleContent>
 			<xs:extension base="eGridRegions_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="ProgramSponsor_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="ProgramSponsor">
-		<xs:simpleContent>
-			<xs:extension base="ProgramSponsor_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -4003,30 +3287,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="Speed_simple">
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="Speed">
-		<xs:simpleContent>
-			<xs:extension base="Speed_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="FlowRate_simple">
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="FlowRate">
-		<xs:simpleContent>
-			<xs:extension base="FlowRate_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="PoolCleanerType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="robotic"/>
@@ -4175,18 +3435,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="PeopleCount_simple">
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="PeopleCount">
-		<xs:simpleContent>
-			<xs:extension base="PeopleCount_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="WindThirdPartyCertification_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="AWEA 9.1-2009"/>
@@ -4238,32 +3486,6 @@
 	<xs:complexType name="MERV">
 		<xs:simpleContent>
 			<xs:extension base="MERV_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="SolarAbsorptance_simple">
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-			<xs:maxInclusive value="1"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="SolarAbsorptance">
-		<xs:simpleContent>
-			<xs:extension base="SolarAbsorptance_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="Emittance_simple">
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-			<xs:maxInclusive value="1"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="Emittance">
-		<xs:simpleContent>
-			<xs:extension base="Emittance_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -4351,18 +3573,6 @@
 	<xs:complexType name="BatteryType">
 		<xs:simpleContent>
 			<xs:extension base="BatteryType_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="BatteryCapacity_simple">
-		<xs:restriction base="xs:decimal">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="BatteryCapacity">
-		<xs:simpleContent>
-			<xs:extension base="BatteryCapacity_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -4487,44 +3697,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="CollectorRatedThermalLosses_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="CollectorRatedThermalLosses">
-		<xs:simpleContent>
-			<xs:extension base="CollectorRatedThermalLosses_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="SolarFraction_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-			<xs:maxInclusive value="1"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="SolarFraction">
-		<xs:simpleContent>
-			<xs:extension base="SolarFraction_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="CollectorRatedOpticalEfficiency_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-			<xs:maxExclusive value="1"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="CollectorRatedOpticalEfficiency">
-		<xs:simpleContent>
-			<xs:extension base="CollectorRatedOpticalEfficiency_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="PVModuleType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="standard"/>
@@ -4607,18 +3779,6 @@
 	<xs:complexType name="ExternalResourceType">
 		<xs:simpleContent>
 			<xs:extension base="ExternalResourceType_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="SolarThermalSystemEnergyFactor_simple">
-		<xs:restriction base="xs:double">
-			<xs:minExclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="SolarThermalSystemEnergyFactor">
-		<xs:simpleContent>
-			<xs:extension base="SolarThermalSystemEnergyFactor_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>


### PR DESCRIPTION
Closes #339. Removes 88 redundant datatypes in favor of more generic datatypes (e.g., `HPXMLDoubleGreaterThanZero`). Non-breaking change; everything should behave the same as before.