### PR TITLE
Allow radiant barriers for (attic) walls/floors

### DIFF
--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -1418,9 +1418,9 @@
 												<xs:element name="AirDistribution" type="AirDistributionInfo"/>
 												<xs:element name="HydronicDistribution" type="HydronicDistributionInfo"/>
 												<xs:element name="Other" type="HPXMLString">
-												<xs:annotation>
-												<xs:documentation>describe</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>describe</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 											</xs:choice>
 											<xs:attribute name="dataSource" type="DataSource"/>
@@ -1484,60 +1484,60 @@
 												<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
 												<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 												<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero">
-												<xs:annotation>
-												<xs:documentation>Number of similar ventilation fans (e.g., bath fans).</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>Number of similar ventilation fans (e.g., bath fans).</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="FanType" type="VentilationFanType"/>
 												<xs:element minOccurs="0" name="CFISControls">
-												<xs:annotation>
-												<xs:documentation>Relevant when FanType="central fan integrated supply".</xs:documentation>
-												</xs:annotation>
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element minOccurs="0" name="HasOutdoorAirControl" type="HPXMLBoolean">
-												<xs:annotation>
-												<xs:documentation>Has controls to block the flow of outside air when the CFIS system is not ventilating. For example, an electronically-controlled mechanical damper, or an in-line fan that substantially blocks the flow when not running.</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" name="AdditionalRuntimeOperatingMode" type="AdditionalRuntimeOperatingMode">
-												<xs:annotation>
-												<xs:documentation>Describes if/how the CFIS system provides additional ventilation beyond when the HVAC system is running to meet a given ventilation target.</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element name="SupplementalFan" type="LocalReference" minOccurs="0" maxOccurs="1">
-												<xs:annotation>
-												<xs:documentation>When AdditionalRuntimeOperatingMode="supplemental fan", specifies the VentilationFan that serves as that supplemental fan.</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												</xs:complexType>
+													<xs:annotation>
+														<xs:documentation>Relevant when FanType="central fan integrated supply".</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element minOccurs="0" name="HasOutdoorAirControl" type="HPXMLBoolean">
+																<xs:annotation>
+																	<xs:documentation>Has controls to block the flow of outside air when the CFIS system is not ventilating. For example, an electronically-controlled mechanical damper, or an in-line fan that substantially blocks the flow when not running.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" name="AdditionalRuntimeOperatingMode" type="AdditionalRuntimeOperatingMode">
+																<xs:annotation>
+																	<xs:documentation>Describes if/how the CFIS system provides additional ventilation beyond when the HVAC system is running to meet a given ventilation target.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="SupplementalFan" type="LocalReference" minOccurs="0" maxOccurs="1">
+																<xs:annotation>
+																	<xs:documentation>When AdditionalRuntimeOperatingMode="supplemental fan", specifies the VentilationFan that serves as that supplemental fan.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+													</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="RatedFlowRate" type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>[CFM] as rated by manufacturer</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>[CFM] as rated by manufacturer</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="CalculatedFlowRate" type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>[CFM] as calculated using duct size, prescriptive approach</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>[CFM] as calculated using duct size, prescriptive approach</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="TestedFlowRate" type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>[CFM] as tested by assessor/auditor/inspector</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>[CFM] as tested by assessor/auditor/inspector</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="HoursInOperation" type="HoursPerDay">
-												<xs:annotation>
-												<xs:documentation>24 = continuous, less than 24 = intermittent</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>24 = continuous, less than 24 = intermittent</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="DeliveredVentilation" type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>[CFM]</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>[CFM]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="FanControlProperlyLabeled" type="BooleanWithNA"/>
 												<xs:element minOccurs="0" name="ProperlyVented" type="BooleanWithNA"/>
@@ -1547,65 +1547,65 @@
 												<xs:element minOccurs="0" name="UsedForSeasonalCoolingLoadReduction" type="HPXMLBoolean"/>
 												<xs:element minOccurs="0" name="UsedForGarageVentilation" type="HPXMLBoolean"/>
 												<xs:element minOccurs="0" name="IsSharedSystem" type="HPXMLBoolean">
-												<xs:annotation>
-												<xs:documentation>Does the system serve multiple building/dwelling units?</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>Does the system serve multiple building/dwelling units?</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="NumberofUnitsServed" type="HPXMLInteger"/>
 												<xs:element minOccurs="0" name="RatedNoise" type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>[sones] from manufacturer's info</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>[sones] from manufacturer's info</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="TestedNoise" type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>[sones] as tested in field</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>[sones] as tested in field</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="TotalRecoveryEfficiency" type="FractionExcludingZero">
-												<xs:annotation>
-												<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by electric
+													<xs:annotation>
+														<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by electric
 															consumption, case heat loss or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential
 															total energy that could be recovered plus the exhaust fan energy. Values for some products can be found at the Home Ventilating Institute
 															(hvi.org).</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="SensibleRecoveryEfficiency" type="FractionExcludingZero">
-												<xs:annotation>
-												<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by electric consumption, case heat loss or heat gain,
+													<xs:annotation>
+														<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by electric consumption, case heat loss or heat gain,
 															air leakage, airflow mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test),
 															as a percent of the potential sensible energy that could be recovered plus the exhaust fan energy. Values for some products can be found at
 															the Home Ventilating Institute (hvi.org).</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="AdjustedTotalRecoveryEfficiency" type="FractionExcludingZero">
-												<xs:annotation>
-												<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by case heat loss
+													<xs:annotation>
+														<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by case heat loss
 															or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential total energy that could be
 															recovered. This value is used to predict and compare Cooling Season Performance for the HRV/ERV unit. This value should be used for energy
 															modeling when wattage for air movement is separately accounted for in the energy model. Values for some products can be found at the Home
 															Ventilating Institute (hvi.org).</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="AdjustedSensibleRecoveryEfficiency" type="FractionExcludingZero">
-												<xs:annotation>
-												<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by case heat loss or heat gain, air leakage, airflow
+													<xs:annotation>
+														<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by case heat loss or heat gain, air leakage, airflow
 															mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test), as a percent of the
 															potential sensible energy that could be recovered. This value should be used for energy modeling when wattage for air movement is separately
 															accounted for in the energy model. Values for some products can be found at the Home Ventilating Institute (hvi.org).</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="FanPower" type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>[W]</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>[W]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="VentilationFanThirdPartyCertification"/>
 												<xs:element name="AttachedToHVACDistributionSystem" type="LocalReference" minOccurs="0" maxOccurs="1">
-												<xs:annotation>
-												<xs:documentation>For central fan integrated supply mechanical ventilation, specifies the HVAC distribution system it is attached
+													<xs:annotation>
+														<xs:documentation>For central fan integrated supply mechanical ventilation, specifies the HVAC distribution system it is attached
 															to.</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -1714,14 +1714,14 @@
 										<xs:complexType>
 											<xs:sequence>
 												<xs:element minOccurs="0" name="SupplyAirSource" type="AdjacentTo">
-												<xs:annotation>
-												<xs:documentation>Where the air is supplied from; not the location where the supply ducts are running through.</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>Where the air is supplied from; not the location where the supply ducts are running through.</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="ExhaustAirTermination" type="AdjacentTo">
-												<xs:annotation>
-												<xs:documentation>Where the air is exhausted to; not the location where the exhaust ducts are running through.</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>Where the air is exhausted to; not the location where the exhaust ducts are running through.</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element ref="extension" minOccurs="0"/>
 											</xs:sequence>
@@ -1755,38 +1755,38 @@
 										<xs:complexType>
 											<xs:sequence>
 												<xs:element minOccurs="0" name="Jacket">
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element minOccurs="0" name="InsulationMaterial" type="InsulationMaterial"/>
-												<xs:element name="JacketRValue" type="RValue" minOccurs="0"/>
-												<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>[in]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												<xs:attribute name="dataSource" type="DataSource"/>
-												</xs:complexType>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element minOccurs="0" name="InsulationMaterial" type="InsulationMaterial"/>
+															<xs:element name="JacketRValue" type="RValue" minOccurs="0"/>
+															<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+																<xs:annotation>
+																	<xs:documentation>[in]</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+														<xs:attribute name="dataSource" type="DataSource"/>
+													</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="TankWall">
-												<xs:annotation>
-												<xs:documentation>Refers to the insulation in the tank wall itself. This information is sometimes available on the water heater's name plate or
+													<xs:annotation>
+														<xs:documentation>Refers to the insulation in the tank wall itself. This information is sometimes available on the water heater's name plate or
 															the units specification sheet, or can be estimated by removing the water heater's access plate.</xs:documentation>
-												</xs:annotation>
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element minOccurs="0" name="InsulationMaterial" type="InsulationMaterial"/>
-												<xs:element name="TankWallRValue" type="RValue" minOccurs="0"/>
-												<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>[in]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												<xs:attribute name="dataSource" type="DataSource"/>
-												</xs:complexType>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element minOccurs="0" name="InsulationMaterial" type="InsulationMaterial"/>
+															<xs:element name="TankWallRValue" type="RValue" minOccurs="0"/>
+															<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+																<xs:annotation>
+																	<xs:documentation>[in]</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+														<xs:attribute name="dataSource" type="DataSource"/>
+													</xs:complexType>
 												</xs:element>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
@@ -1864,46 +1864,46 @@
 										<xs:complexType>
 											<xs:choice>
 												<xs:element name="Standard">
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element minOccurs="0" name="PipingLength" type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>Measured length of hot water piping from the hot water heater to the farthest hot water fixture, measured
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element minOccurs="0" name="PipingLength" type="LengthMeasurement">
+																<xs:annotation>
+																	<xs:documentation>Measured length of hot water piping from the hot water heater to the farthest hot water fixture, measured
 																		longitudinally from plans, assuming the hot water piping does not run diagonally, plus 10 feet of piping for each floor level,
 																		plus 5 feet of piping for unconditioned basements. [ft]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												<xs:attribute name="dataSource" type="DataSource"/>
-												</xs:complexType>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+														<xs:attribute name="dataSource" type="DataSource"/>
+													</xs:complexType>
 												</xs:element>
 												<xs:element name="Recirculation">
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element minOccurs="0" name="ControlType" type="RecirculationControlType"/>
-												<xs:element minOccurs="0" name="RecirculationPipingLoopLength" type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>Hot water recirculation loop piping length including both supply and return sides of the loop, measured
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element minOccurs="0" name="ControlType" type="RecirculationControlType"/>
+															<xs:element minOccurs="0" name="RecirculationPipingLoopLength" type="LengthMeasurement">
+																<xs:annotation>
+																	<xs:documentation>Hot water recirculation loop piping length including both supply and return sides of the loop, measured
 																		longitudinally from plans, assuming the hot water piping does not run diagonally. [ft]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" name="BranchPipingLength" type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>Length of the branch hot water piping from the recirculation loop to the farthest hot water fixture from the
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" name="BranchPipingLength" type="LengthMeasurement">
+																<xs:annotation>
+																	<xs:documentation>Length of the branch hot water piping from the recirculation loop to the farthest hot water fixture from the
 																		recirculation loop, measured longitudinally from plans, assuming the branch hot water piping does not run diagonally, plus 20
 																		feet of piping for each floor level greater than one plus 10 feet of piping for unconditioned basements. [ft]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" name="PumpPower" type="Power">
-												<xs:annotation>
-												<xs:documentation>[W]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												<xs:attribute name="dataSource" type="DataSource"/>
-												</xs:complexType>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" name="PumpPower" type="Power">
+																<xs:annotation>
+																	<xs:documentation>[W]</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+														<xs:attribute name="dataSource" type="DataSource"/>
+													</xs:complexType>
 												</xs:element>
 											</xs:choice>
 											<xs:attribute name="dataSource" type="DataSource"/>
@@ -1916,9 +1916,9 @@
 												<xs:element minOccurs="0" name="FacilitiesConnected" type="DrainWaterHeatRecoveryFacilitiesConnected"/>
 												<xs:element minOccurs="0" name="EqualFlow" type="HPXMLBoolean"/>
 												<xs:element minOccurs="0" name="Efficiency" type="FractionExcludingZero">
-												<xs:annotation>
-												<xs:documentation>Efficiency percent expressed as a fraction from 0-1.</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>Efficiency percent expressed as a fraction from 0-1.</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -2588,89 +2588,89 @@
 												<xs:element minOccurs="0" ref="ConnectedDevice"/>
 												<xs:element minOccurs="0" name="Type" type="PoolPumpType"/>
 												<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString">
-												<xs:annotation>
-												<xs:documentation>Manufacturer of pool pump.</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>Manufacturer of pool pump.</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString">
-												<xs:annotation>
-												<xs:documentation>Serial number of pool pump.</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>Serial number of pool pump.</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="ModelNumber" type="HPXMLString">
-												<xs:annotation>
-												<xs:documentation>Model number of pool pump.</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>Model number of pool pump.</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="ThirdPartyCertification" type="PoolPump3rdPartyCertification" maxOccurs="unbounded">
-												<xs:annotation>
-												<xs:documentation>Independent organization has verified that product or appliance meets or exceeds the standard in question (ENERGY STAR, CEE,
+													<xs:annotation>
+														<xs:documentation>Independent organization has verified that product or appliance meets or exceeds the standard in question (ENERGY STAR, CEE,
 															or other)</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="EnergyFactor" type="Efficiency">
-												<xs:annotation>
-												<xs:documentation>[gal/Wh] The measure of overall pool filter pump efficiency in units of gallons per watt-hour, as determined using the
+													<xs:annotation>
+														<xs:documentation>[gal/Wh] The measure of overall pool filter pump efficiency in units of gallons per watt-hour, as determined using the
 															applicable test method in Section 4.1.2. Energy factor is analogous to other energy factors such as miles per gallon. Energy factor (EF) is
 															calculated as: EF (gal/Wh) = flow rate (gpm) * 60 &#247; power (watts) (ANSI/APSP/ICC-15 2011).</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="SpeedSetting" type="PoolPumpSpeedSetting">
-												<xs:annotation>
-												<xs:documentation>The speed setting at which the Energy Factor was measured (ENERGY STAR, 2013).</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>The speed setting at which the Energy Factor was measured (ENERGY STAR, 2013).</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="RatedHorsepower" type="Power">
-												<xs:annotation>
-												<xs:documentation>The motor power output designed by the manufacturer for a rated RPM, voltage and frequency. May be less than total horsepower
+													<xs:annotation>
+														<xs:documentation>The motor power output designed by the manufacturer for a rated RPM, voltage and frequency. May be less than total horsepower
 															where the service factor is greater than 1.0, or equal to total horsepower where the service factor = 1.0 (ANSI/APSP/ICC-15
 															2011).</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="TotalHorsepower" type="Power">
-												<xs:annotation>
-												<xs:documentation>The total horsepower, or product of the rated horsepower and the service factor of a motor used on a pool pump (also known as
+													<xs:annotation>
+														<xs:documentation>The total horsepower, or product of the rated horsepower and the service factor of a motor used on a pool pump (also known as
 															SFHP) based on the maximum continuous duty motor power output rating allowable for the nameplate ambient rating and motor insulation class
 															(e.g., total horsepower = rated horsepower * service factor) (ANSI/APSP/ICC-15 2011).</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="ServiceFactor" type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>A multiplier applied to the rated horsepower of a pump motor to indicate the percent above nameplate horsepower at which the
+													<xs:annotation>
+														<xs:documentation>A multiplier applied to the rated horsepower of a pump motor to indicate the percent above nameplate horsepower at which the
 															motor can operate continuously without exceeding its allowable insulation class temperature limit, provided that other design parameters,
 															such rated voltage, frequency and ambient temperature, are within limits. A 1.5 hp pump with a 1.65 service factor produces 2.475 hp (total
 															horsepower) at the maximum service factor point (ANSI/APSP/ICC-15 2011).</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element maxOccurs="unbounded" minOccurs="0" name="PumpSpeed">
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element minOccurs="0" name="Power" type="Power">
-												<xs:annotation>
-												<xs:documentation>[W]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" name="MotorNominalSpeed" type="Speed">
-												<xs:annotation>
-												<xs:documentation>[Rev/min] The number of revolutions of the motor shaft in a given unit of time, expressed as revolutions per
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element minOccurs="0" name="Power" type="Power">
+																<xs:annotation>
+																	<xs:documentation>[W]</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" name="MotorNominalSpeed" type="Speed">
+																<xs:annotation>
+																	<xs:documentation>[Rev/min] The number of revolutions of the motor shaft in a given unit of time, expressed as revolutions per
 																		minute (RPM) (ENERGY STAR, 2013).</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" name="FlowRate" type="FlowRate">
-												<xs:annotation>
-												<xs:documentation>[gal/min] The volume of water flowing through the filtration system in a given time, usually measured in gallons
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" name="FlowRate" type="FlowRate">
+																<xs:annotation>
+																	<xs:documentation>[gal/min] The volume of water flowing through the filtration system in a given time, usually measured in gallons
 																		per minute (gpm) (ANSI/APSP/ICC-15 2011).</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" name="HoursPerDay" type="HoursPerDay">
-												<xs:annotation>
-												<xs:documentation>[hours] Number of hours per day a pool pump operates at a particular speed setting.</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												<xs:attribute name="dataSource" type="DataSource"/>
-												</xs:complexType>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" name="HoursPerDay" type="HoursPerDay">
+																<xs:annotation>
+																	<xs:documentation>[hours] Number of hours per day a pool pump operates at a particular speed setting.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+														<xs:attribute name="dataSource" type="DataSource"/>
+													</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -2876,81 +2876,81 @@
 										<xs:complexType>
 											<xs:sequence minOccurs="0">
 												<xs:element name="CAZAppliance" type="RemoteReference">
-												<xs:annotation>
-												<xs:documentation>The ID of the system tested</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>The ID of the system tested</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="CombustionVentingSystem" type="RemoteReference"/>
 												<xs:element name="FlueVisualCondition" type="FlueCondition" minOccurs="0"/>
 												<xs:element minOccurs="0" name="FlueConditionNotes" type="HPXMLString"/>
 												<xs:element name="OutsideTemperatureFlueDraftTest" type="Temperature" minOccurs="0">
-												<xs:annotation>
-												<xs:documentation>[deg F]</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>[deg F]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="FlueDraftTest">
-												<xs:annotation>
-												<xs:documentation>[Pa]</xs:documentation>
-												</xs:annotation>
-												<xs:complexType>
-												<xs:complexContent>
-												<xs:extension base="CAZApplianceReading">
-												<xs:sequence>
-												<xs:element ref="extension" minOccurs="0"/>
-												</xs:sequence>
-												</xs:extension>
-												</xs:complexContent>
-												</xs:complexType>
+													<xs:annotation>
+														<xs:documentation>[Pa]</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:complexContent>
+															<xs:extension base="CAZApplianceReading">
+																<xs:sequence>
+																	<xs:element ref="extension" minOccurs="0"/>
+																</xs:sequence>
+															</xs:extension>
+														</xs:complexContent>
+													</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="SpillageTest">
-												<xs:annotation>
-												<xs:documentation>[seconds]</xs:documentation>
-												</xs:annotation>
-												<xs:complexType>
-												<xs:complexContent>
-												<xs:extension base="CAZApplianceReading">
-												<xs:sequence>
-												<xs:element ref="extension" minOccurs="0"/>
-												</xs:sequence>
-												</xs:extension>
-												</xs:complexContent>
-												</xs:complexType>
+													<xs:annotation>
+														<xs:documentation>[seconds]</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:complexContent>
+															<xs:extension base="CAZApplianceReading">
+																<xs:sequence>
+																	<xs:element ref="extension" minOccurs="0"/>
+																</xs:sequence>
+															</xs:extension>
+														</xs:complexContent>
+													</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="CarbonMonoxideTest">
-												<xs:annotation>
-												<xs:documentation>[ppm]</xs:documentation>
-												</xs:annotation>
-												<xs:complexType>
-												<xs:complexContent>
-												<xs:extension base="CAZApplianceReading">
-												<xs:sequence>
-												<xs:element minOccurs="0" name="AmbientCOActionDuringCAZTesting" type="HPXMLString">
-												<xs:annotation>
-												<xs:documentation>BPI Gold Sheet is one example that shows action levels based upon decision logic</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												</xs:extension>
-												</xs:complexContent>
-												</xs:complexType>
+													<xs:annotation>
+														<xs:documentation>[ppm]</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:complexContent>
+															<xs:extension base="CAZApplianceReading">
+																<xs:sequence>
+																	<xs:element minOccurs="0" name="AmbientCOActionDuringCAZTesting" type="HPXMLString">
+																		<xs:annotation>
+																			<xs:documentation>BPI Gold Sheet is one example that shows action levels based upon decision logic</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element minOccurs="0" ref="extension"/>
+																</xs:sequence>
+															</xs:extension>
+														</xs:complexContent>
+													</xs:complexType>
 												</xs:element>
 												<xs:element name="StackTemperature" type="Temperature" minOccurs="0">
-												<xs:annotation>
-												<xs:documentation>[deg F] after 10 minutes run time</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>[deg F] after 10 minutes run time</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element name="FuelLeaks" minOccurs="0" maxOccurs="unbounded">
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element name="FuelType" type="FuelType"/>
-												<xs:element name="LeaksIdentified" type="HPXMLBoolean"/>
-												<xs:element name="LeaksAddressed" type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="Notes" type="HPXMLString"/>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												<xs:attribute name="dataSource" type="DataSource"/>
-												</xs:complexType>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="FuelType" type="FuelType"/>
+															<xs:element name="LeaksIdentified" type="HPXMLBoolean"/>
+															<xs:element name="LeaksAddressed" type="HPXMLBoolean"/>
+															<xs:element minOccurs="0" name="Notes" type="HPXMLString"/>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+														<xs:attribute name="dataSource" type="DataSource"/>
+													</xs:complexType>
 												</xs:element>
 												<xs:element ref="extension" minOccurs="0"/>
 											</xs:sequence>
@@ -4008,19 +4008,19 @@
 										<xs:complexType>
 											<xs:sequence>
 												<xs:element minOccurs="0" name="DistanceFromSubway" type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>[ft]</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>[ft]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="DistanceFromBus" type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>[ft]</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>[ft]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="DistanceFromTrain" type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>[ft]</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>[ft]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
@@ -4045,9 +4045,9 @@
 												<xs:element minOccurs="0" name="SoilType" type="SoilType"/>
 												<xs:element minOccurs="0" name="MoistureType" type="MoisureType"/>
 												<xs:element minOccurs="0" name="Conductivity" type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>[Btu/hr-ft-F]</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>[Btu/hr-ft-F]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -7702,9 +7702,6 @@
 	<xs:simpleType name="RadiantBarrierLocation_wall_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="RadiantBarrierLocation_floor_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
 	<xs:complexType name="RadiantBarrierLocation_roof">
 		<xs:simpleContent>
 			<xs:extension base="RadiantBarrierLocation_roof_simple">
@@ -7712,22 +7709,8 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:complexType name="RadiantBarrierLocation_wall">
-		<xs:simpleContent>
-			<xs:extension base="RadiantBarrierLocation_wall_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<!--Ventilation Below-->
 	<!--Window Group Below-->
-	<xs:complexType name="RadiantBarrierLocation_floor">
-		<xs:simpleContent>
-			<xs:extension base="RadiantBarrierLocation_floor_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="HVACThirdPartyCertification_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Energy Star"/>
@@ -11165,5 +11148,21 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-
+	<xs:complexType name="RadiantBarrierLocation_wall">
+		<xs:simpleContent>
+			<xs:extension base="RadiantBarrierLocation_wall_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="RadiantBarrierLocation_floor_simple">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:complexType name="RadiantBarrierLocation_floor">
+		<xs:simpleContent>
+			<xs:extension base="RadiantBarrierLocation_floor_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 </xs:schema>

--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -986,7 +986,7 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element name="RadiantBarrier" type="HPXMLBoolean" minOccurs="0"/>
-									<xs:element name="RadiantBarrierLocation" type="RadiantBarrierLocation_roof" minOccurs="0"/>
+									<xs:element name="RadiantBarrierLocation" type="RadiantBarrierLocation" minOccurs="0"/>
 									<xs:element name="RadiantBarrierGrade" type="InsulationGrade" minOccurs="0"/>
 									<xs:element minOccurs="0" name="Insulation" type="InsulationInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
@@ -1081,10 +1081,9 @@
 									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
 									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
 									<xs:element minOccurs="0" name="InteriorFinish" type="InteriorFinishInfo"/>
-									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"/>
 									<xs:element name="RadiantBarrier" type="HPXMLBoolean" minOccurs="0"/>
-									<xs:element name="RadiantBarrierLocation" type="RadiantBarrierLocation_wall" minOccurs="0"/>
 									<xs:element name="RadiantBarrierGrade" type="InsulationGrade" minOccurs="0"/>
+									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
@@ -1190,10 +1189,9 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="InteriorFinish" type="InteriorFinishInfo"/>
-									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"/>
 									<xs:element name="RadiantBarrier" type="HPXMLBoolean" minOccurs="0"/>
-									<xs:element name="RadiantBarrierLocation" type="RadiantBarrierLocation_floor" minOccurs="0"/>
 									<xs:element name="RadiantBarrierGrade" type="InsulationGrade" minOccurs="0"/>
+									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -7692,24 +7690,20 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="RadiantBarrierLocation_roof_simple">
+	<xs:simpleType name="RadiantBarrierLocation_simple">
 		<xs:annotation>
 			<xs:documentation>Enumerations from http://www.fsec.ucf.edu/en/publications/pdf/FSEC-DN-7-84.pdf</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="top side of truss under sheathing"/>
 			<xs:enumeration value="below bottom chord of truss"/>
-			<xs:enumeration value="attic floor"/>
 			<xs:enumeration value="underside of rafters"/>
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="RadiantBarrierLocation_wall_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="RadiantBarrierLocation_roof">
+	<xs:complexType name="RadiantBarrierLocation">
 		<xs:simpleContent>
-			<xs:extension base="RadiantBarrierLocation_roof_simple">
+			<xs:extension base="RadiantBarrierLocation_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -11125,23 +11119,6 @@
 	<xs:complexType name="MoisureType">
 		<xs:simpleContent>
 			<xs:extension base="MoistureType_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:complexType name="RadiantBarrierLocation_wall">
-		<xs:simpleContent>
-			<xs:extension base="RadiantBarrierLocation_wall_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="RadiantBarrierLocation_floor_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="RadiantBarrierLocation_floor">
-		<xs:simpleContent>
-			<xs:extension base="RadiantBarrierLocation_floor_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>

--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -986,7 +986,7 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element name="RadiantBarrier" type="HPXMLBoolean" minOccurs="0"/>
-									<xs:element name="RadiantBarrierLocation" type="RadiantBarrierLocation" minOccurs="0"/>
+									<xs:element name="RadiantBarrierLocation" type="RadiantBarrierLocation_roof" minOccurs="0"/>
 									<xs:element name="RadiantBarrierGrade" type="InsulationGrade" minOccurs="0"/>
 									<xs:element minOccurs="0" name="Insulation" type="InsulationInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
@@ -1082,6 +1082,9 @@
 									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
 									<xs:element minOccurs="0" name="InteriorFinish" type="InteriorFinishInfo"/>
 									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"/>
+									<xs:element name="RadiantBarrier" type="HPXMLBoolean" minOccurs="0"/>
+									<xs:element name="RadiantBarrierLocation" type="RadiantBarrierLocation_wall" minOccurs="0"/>
+									<xs:element name="RadiantBarrierGrade" type="InsulationGrade" minOccurs="0"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
@@ -1188,6 +1191,9 @@
 									</xs:element>
 									<xs:element minOccurs="0" name="InteriorFinish" type="InteriorFinishInfo"/>
 									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"/>
+									<xs:element name="RadiantBarrier" type="HPXMLBoolean" minOccurs="0"/>
+									<xs:element name="RadiantBarrierLocation" type="RadiantBarrierLocation_floor" minOccurs="0"/>
+									<xs:element name="RadiantBarrierGrade" type="InsulationGrade" minOccurs="0"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1412,9 +1418,9 @@
 												<xs:element name="AirDistribution" type="AirDistributionInfo"/>
 												<xs:element name="HydronicDistribution" type="HydronicDistributionInfo"/>
 												<xs:element name="Other" type="HPXMLString">
-													<xs:annotation>
-														<xs:documentation>describe</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>describe</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 											</xs:choice>
 											<xs:attribute name="dataSource" type="DataSource"/>
@@ -1478,60 +1484,60 @@
 												<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
 												<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 												<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero">
-													<xs:annotation>
-														<xs:documentation>Number of similar ventilation fans (e.g., bath fans).</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>Number of similar ventilation fans (e.g., bath fans).</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="FanType" type="VentilationFanType"/>
 												<xs:element minOccurs="0" name="CFISControls">
-													<xs:annotation>
-														<xs:documentation>Relevant when FanType="central fan integrated supply".</xs:documentation>
-													</xs:annotation>
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element minOccurs="0" name="HasOutdoorAirControl" type="HPXMLBoolean">
-																<xs:annotation>
-																	<xs:documentation>Has controls to block the flow of outside air when the CFIS system is not ventilating. For example, an electronically-controlled mechanical damper, or an in-line fan that substantially blocks the flow when not running.</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" name="AdditionalRuntimeOperatingMode" type="AdditionalRuntimeOperatingMode">
-																<xs:annotation>
-																	<xs:documentation>Describes if/how the CFIS system provides additional ventilation beyond when the HVAC system is running to meet a given ventilation target.</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element name="SupplementalFan" type="LocalReference" minOccurs="0" maxOccurs="1">
-																<xs:annotation>
-																	<xs:documentation>When AdditionalRuntimeOperatingMode="supplemental fan", specifies the VentilationFan that serves as that supplemental fan.</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" ref="extension"/>
-														</xs:sequence>
-													</xs:complexType>
+												<xs:annotation>
+												<xs:documentation>Relevant when FanType="central fan integrated supply".</xs:documentation>
+												</xs:annotation>
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element minOccurs="0" name="HasOutdoorAirControl" type="HPXMLBoolean">
+												<xs:annotation>
+												<xs:documentation>Has controls to block the flow of outside air when the CFIS system is not ventilating. For example, an electronically-controlled mechanical damper, or an in-line fan that substantially blocks the flow when not running.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="AdditionalRuntimeOperatingMode" type="AdditionalRuntimeOperatingMode">
+												<xs:annotation>
+												<xs:documentation>Describes if/how the CFIS system provides additional ventilation beyond when the HVAC system is running to meet a given ventilation target.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element name="SupplementalFan" type="LocalReference" minOccurs="0" maxOccurs="1">
+												<xs:annotation>
+												<xs:documentation>When AdditionalRuntimeOperatingMode="supplemental fan", specifies the VentilationFan that serves as that supplemental fan.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="RatedFlowRate" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>[CFM] as rated by manufacturer</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>[CFM] as rated by manufacturer</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="CalculatedFlowRate" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>[CFM] as calculated using duct size, prescriptive approach</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>[CFM] as calculated using duct size, prescriptive approach</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="TestedFlowRate" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>[CFM] as tested by assessor/auditor/inspector</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>[CFM] as tested by assessor/auditor/inspector</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="HoursInOperation" type="HoursPerDay">
-													<xs:annotation>
-														<xs:documentation>24 = continuous, less than 24 = intermittent</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>24 = continuous, less than 24 = intermittent</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="DeliveredVentilation" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>[CFM]</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>[CFM]</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="FanControlProperlyLabeled" type="BooleanWithNA"/>
 												<xs:element minOccurs="0" name="ProperlyVented" type="BooleanWithNA"/>
@@ -1541,65 +1547,65 @@
 												<xs:element minOccurs="0" name="UsedForSeasonalCoolingLoadReduction" type="HPXMLBoolean"/>
 												<xs:element minOccurs="0" name="UsedForGarageVentilation" type="HPXMLBoolean"/>
 												<xs:element minOccurs="0" name="IsSharedSystem" type="HPXMLBoolean">
-													<xs:annotation>
-														<xs:documentation>Does the system serve multiple building/dwelling units?</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>Does the system serve multiple building/dwelling units?</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="NumberofUnitsServed" type="HPXMLInteger"/>
 												<xs:element minOccurs="0" name="RatedNoise" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>[sones] from manufacturer's info</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>[sones] from manufacturer's info</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="TestedNoise" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>[sones] as tested in field</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>[sones] as tested in field</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="TotalRecoveryEfficiency" type="FractionExcludingZero">
-													<xs:annotation>
-														<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by electric
+												<xs:annotation>
+												<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by electric
 															consumption, case heat loss or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential
 															total energy that could be recovered plus the exhaust fan energy. Values for some products can be found at the Home Ventilating Institute
 															(hvi.org).</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="SensibleRecoveryEfficiency" type="FractionExcludingZero">
-													<xs:annotation>
-														<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by electric consumption, case heat loss or heat gain,
+												<xs:annotation>
+												<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by electric consumption, case heat loss or heat gain,
 															air leakage, airflow mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test),
 															as a percent of the potential sensible energy that could be recovered plus the exhaust fan energy. Values for some products can be found at
 															the Home Ventilating Institute (hvi.org).</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="AdjustedTotalRecoveryEfficiency" type="FractionExcludingZero">
-													<xs:annotation>
-														<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by case heat loss
+												<xs:annotation>
+												<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by case heat loss
 															or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential total energy that could be
 															recovered. This value is used to predict and compare Cooling Season Performance for the HRV/ERV unit. This value should be used for energy
 															modeling when wattage for air movement is separately accounted for in the energy model. Values for some products can be found at the Home
 															Ventilating Institute (hvi.org).</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="AdjustedSensibleRecoveryEfficiency" type="FractionExcludingZero">
-													<xs:annotation>
-														<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by case heat loss or heat gain, air leakage, airflow
+												<xs:annotation>
+												<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by case heat loss or heat gain, air leakage, airflow
 															mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test), as a percent of the
 															potential sensible energy that could be recovered. This value should be used for energy modeling when wattage for air movement is separately
 															accounted for in the energy model. Values for some products can be found at the Home Ventilating Institute (hvi.org).</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="FanPower" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>[W]</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>[W]</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="VentilationFanThirdPartyCertification"/>
 												<xs:element name="AttachedToHVACDistributionSystem" type="LocalReference" minOccurs="0" maxOccurs="1">
-													<xs:annotation>
-														<xs:documentation>For central fan integrated supply mechanical ventilation, specifies the HVAC distribution system it is attached
+												<xs:annotation>
+												<xs:documentation>For central fan integrated supply mechanical ventilation, specifies the HVAC distribution system it is attached
 															to.</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -1708,14 +1714,14 @@
 										<xs:complexType>
 											<xs:sequence>
 												<xs:element minOccurs="0" name="SupplyAirSource" type="AdjacentTo">
-													<xs:annotation>
-														<xs:documentation>Where the air is supplied from; not the location where the supply ducts are running through.</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>Where the air is supplied from; not the location where the supply ducts are running through.</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="ExhaustAirTermination" type="AdjacentTo">
-													<xs:annotation>
-														<xs:documentation>Where the air is exhausted to; not the location where the exhaust ducts are running through.</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>Where the air is exhausted to; not the location where the exhaust ducts are running through.</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element ref="extension" minOccurs="0"/>
 											</xs:sequence>
@@ -1749,38 +1755,38 @@
 										<xs:complexType>
 											<xs:sequence>
 												<xs:element minOccurs="0" name="Jacket">
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element minOccurs="0" name="InsulationMaterial" type="InsulationMaterial"/>
-															<xs:element name="JacketRValue" type="RValue" minOccurs="0"/>
-															<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
-																<xs:annotation>
-																	<xs:documentation>[in]</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" ref="extension"/>
-														</xs:sequence>
-														<xs:attribute name="dataSource" type="DataSource"/>
-													</xs:complexType>
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element minOccurs="0" name="InsulationMaterial" type="InsulationMaterial"/>
+												<xs:element name="JacketRValue" type="RValue" minOccurs="0"/>
+												<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[in]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												<xs:attribute name="dataSource" type="DataSource"/>
+												</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="TankWall">
-													<xs:annotation>
-														<xs:documentation>Refers to the insulation in the tank wall itself. This information is sometimes available on the water heater's name plate or
+												<xs:annotation>
+												<xs:documentation>Refers to the insulation in the tank wall itself. This information is sometimes available on the water heater's name plate or
 															the units specification sheet, or can be estimated by removing the water heater's access plate.</xs:documentation>
-													</xs:annotation>
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element minOccurs="0" name="InsulationMaterial" type="InsulationMaterial"/>
-															<xs:element name="TankWallRValue" type="RValue" minOccurs="0"/>
-															<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
-																<xs:annotation>
-																	<xs:documentation>[in]</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" ref="extension"/>
-														</xs:sequence>
-														<xs:attribute name="dataSource" type="DataSource"/>
-													</xs:complexType>
+												</xs:annotation>
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element minOccurs="0" name="InsulationMaterial" type="InsulationMaterial"/>
+												<xs:element name="TankWallRValue" type="RValue" minOccurs="0"/>
+												<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[in]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												<xs:attribute name="dataSource" type="DataSource"/>
+												</xs:complexType>
 												</xs:element>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
@@ -1858,46 +1864,46 @@
 										<xs:complexType>
 											<xs:choice>
 												<xs:element name="Standard">
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element minOccurs="0" name="PipingLength" type="LengthMeasurement">
-																<xs:annotation>
-																	<xs:documentation>Measured length of hot water piping from the hot water heater to the farthest hot water fixture, measured
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element minOccurs="0" name="PipingLength" type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>Measured length of hot water piping from the hot water heater to the farthest hot water fixture, measured
 																		longitudinally from plans, assuming the hot water piping does not run diagonally, plus 10 feet of piping for each floor level,
 																		plus 5 feet of piping for unconditioned basements. [ft]</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" ref="extension"/>
-														</xs:sequence>
-														<xs:attribute name="dataSource" type="DataSource"/>
-													</xs:complexType>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												<xs:attribute name="dataSource" type="DataSource"/>
+												</xs:complexType>
 												</xs:element>
 												<xs:element name="Recirculation">
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element minOccurs="0" name="ControlType" type="RecirculationControlType"/>
-															<xs:element minOccurs="0" name="RecirculationPipingLoopLength" type="LengthMeasurement">
-																<xs:annotation>
-																	<xs:documentation>Hot water recirculation loop piping length including both supply and return sides of the loop, measured
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element minOccurs="0" name="ControlType" type="RecirculationControlType"/>
+												<xs:element minOccurs="0" name="RecirculationPipingLoopLength" type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>Hot water recirculation loop piping length including both supply and return sides of the loop, measured
 																		longitudinally from plans, assuming the hot water piping does not run diagonally. [ft]</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" name="BranchPipingLength" type="LengthMeasurement">
-																<xs:annotation>
-																	<xs:documentation>Length of the branch hot water piping from the recirculation loop to the farthest hot water fixture from the
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="BranchPipingLength" type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>Length of the branch hot water piping from the recirculation loop to the farthest hot water fixture from the
 																		recirculation loop, measured longitudinally from plans, assuming the branch hot water piping does not run diagonally, plus 20
 																		feet of piping for each floor level greater than one plus 10 feet of piping for unconditioned basements. [ft]</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" name="PumpPower" type="Power">
-																<xs:annotation>
-																	<xs:documentation>[W]</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" ref="extension"/>
-														</xs:sequence>
-														<xs:attribute name="dataSource" type="DataSource"/>
-													</xs:complexType>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="PumpPower" type="Power">
+												<xs:annotation>
+												<xs:documentation>[W]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												<xs:attribute name="dataSource" type="DataSource"/>
+												</xs:complexType>
 												</xs:element>
 											</xs:choice>
 											<xs:attribute name="dataSource" type="DataSource"/>
@@ -1910,9 +1916,9 @@
 												<xs:element minOccurs="0" name="FacilitiesConnected" type="DrainWaterHeatRecoveryFacilitiesConnected"/>
 												<xs:element minOccurs="0" name="EqualFlow" type="HPXMLBoolean"/>
 												<xs:element minOccurs="0" name="Efficiency" type="FractionExcludingZero">
-													<xs:annotation>
-														<xs:documentation>Efficiency percent expressed as a fraction from 0-1.</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>Efficiency percent expressed as a fraction from 0-1.</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -2582,89 +2588,89 @@
 												<xs:element minOccurs="0" ref="ConnectedDevice"/>
 												<xs:element minOccurs="0" name="Type" type="PoolPumpType"/>
 												<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString">
-													<xs:annotation>
-														<xs:documentation>Manufacturer of pool pump.</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>Manufacturer of pool pump.</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString">
-													<xs:annotation>
-														<xs:documentation>Serial number of pool pump.</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>Serial number of pool pump.</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="ModelNumber" type="HPXMLString">
-													<xs:annotation>
-														<xs:documentation>Model number of pool pump.</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>Model number of pool pump.</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="ThirdPartyCertification" type="PoolPump3rdPartyCertification" maxOccurs="unbounded">
-													<xs:annotation>
-														<xs:documentation>Independent organization has verified that product or appliance meets or exceeds the standard in question (ENERGY STAR, CEE,
+												<xs:annotation>
+												<xs:documentation>Independent organization has verified that product or appliance meets or exceeds the standard in question (ENERGY STAR, CEE,
 															or other)</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="EnergyFactor" type="Efficiency">
-													<xs:annotation>
-														<xs:documentation>[gal/Wh] The measure of overall pool filter pump efficiency in units of gallons per watt-hour, as determined using the
+												<xs:annotation>
+												<xs:documentation>[gal/Wh] The measure of overall pool filter pump efficiency in units of gallons per watt-hour, as determined using the
 															applicable test method in Section 4.1.2. Energy factor is analogous to other energy factors such as miles per gallon. Energy factor (EF) is
 															calculated as: EF (gal/Wh) = flow rate (gpm) * 60 &#247; power (watts) (ANSI/APSP/ICC-15 2011).</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="SpeedSetting" type="PoolPumpSpeedSetting">
-													<xs:annotation>
-														<xs:documentation>The speed setting at which the Energy Factor was measured (ENERGY STAR, 2013).</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>The speed setting at which the Energy Factor was measured (ENERGY STAR, 2013).</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="RatedHorsepower" type="Power">
-													<xs:annotation>
-														<xs:documentation>The motor power output designed by the manufacturer for a rated RPM, voltage and frequency. May be less than total horsepower
+												<xs:annotation>
+												<xs:documentation>The motor power output designed by the manufacturer for a rated RPM, voltage and frequency. May be less than total horsepower
 															where the service factor is greater than 1.0, or equal to total horsepower where the service factor = 1.0 (ANSI/APSP/ICC-15
 															2011).</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="TotalHorsepower" type="Power">
-													<xs:annotation>
-														<xs:documentation>The total horsepower, or product of the rated horsepower and the service factor of a motor used on a pool pump (also known as
+												<xs:annotation>
+												<xs:documentation>The total horsepower, or product of the rated horsepower and the service factor of a motor used on a pool pump (also known as
 															SFHP) based on the maximum continuous duty motor power output rating allowable for the nameplate ambient rating and motor insulation class
 															(e.g., total horsepower = rated horsepower * service factor) (ANSI/APSP/ICC-15 2011).</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="ServiceFactor" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>A multiplier applied to the rated horsepower of a pump motor to indicate the percent above nameplate horsepower at which the
+												<xs:annotation>
+												<xs:documentation>A multiplier applied to the rated horsepower of a pump motor to indicate the percent above nameplate horsepower at which the
 															motor can operate continuously without exceeding its allowable insulation class temperature limit, provided that other design parameters,
 															such rated voltage, frequency and ambient temperature, are within limits. A 1.5 hp pump with a 1.65 service factor produces 2.475 hp (total
 															horsepower) at the maximum service factor point (ANSI/APSP/ICC-15 2011).</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element maxOccurs="unbounded" minOccurs="0" name="PumpSpeed">
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element minOccurs="0" name="Power" type="Power">
-																<xs:annotation>
-																	<xs:documentation>[W]</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" name="MotorNominalSpeed" type="Speed">
-																<xs:annotation>
-																	<xs:documentation>[Rev/min] The number of revolutions of the motor shaft in a given unit of time, expressed as revolutions per
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element minOccurs="0" name="Power" type="Power">
+												<xs:annotation>
+												<xs:documentation>[W]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="MotorNominalSpeed" type="Speed">
+												<xs:annotation>
+												<xs:documentation>[Rev/min] The number of revolutions of the motor shaft in a given unit of time, expressed as revolutions per
 																		minute (RPM) (ENERGY STAR, 2013).</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" name="FlowRate" type="FlowRate">
-																<xs:annotation>
-																	<xs:documentation>[gal/min] The volume of water flowing through the filtration system in a given time, usually measured in gallons
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="FlowRate" type="FlowRate">
+												<xs:annotation>
+												<xs:documentation>[gal/min] The volume of water flowing through the filtration system in a given time, usually measured in gallons
 																		per minute (gpm) (ANSI/APSP/ICC-15 2011).</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" name="HoursPerDay" type="HoursPerDay">
-																<xs:annotation>
-																	<xs:documentation>[hours] Number of hours per day a pool pump operates at a particular speed setting.</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" ref="extension"/>
-														</xs:sequence>
-														<xs:attribute name="dataSource" type="DataSource"/>
-													</xs:complexType>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="HoursPerDay" type="HoursPerDay">
+												<xs:annotation>
+												<xs:documentation>[hours] Number of hours per day a pool pump operates at a particular speed setting.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												<xs:attribute name="dataSource" type="DataSource"/>
+												</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -2870,81 +2876,81 @@
 										<xs:complexType>
 											<xs:sequence minOccurs="0">
 												<xs:element name="CAZAppliance" type="RemoteReference">
-													<xs:annotation>
-														<xs:documentation>The ID of the system tested</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>The ID of the system tested</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="CombustionVentingSystem" type="RemoteReference"/>
 												<xs:element name="FlueVisualCondition" type="FlueCondition" minOccurs="0"/>
 												<xs:element minOccurs="0" name="FlueConditionNotes" type="HPXMLString"/>
 												<xs:element name="OutsideTemperatureFlueDraftTest" type="Temperature" minOccurs="0">
-													<xs:annotation>
-														<xs:documentation>[deg F]</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>[deg F]</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="FlueDraftTest">
-													<xs:annotation>
-														<xs:documentation>[Pa]</xs:documentation>
-													</xs:annotation>
-													<xs:complexType>
-														<xs:complexContent>
-															<xs:extension base="CAZApplianceReading">
-																<xs:sequence>
-																	<xs:element ref="extension" minOccurs="0"/>
-																</xs:sequence>
-															</xs:extension>
-														</xs:complexContent>
-													</xs:complexType>
+												<xs:annotation>
+												<xs:documentation>[Pa]</xs:documentation>
+												</xs:annotation>
+												<xs:complexType>
+												<xs:complexContent>
+												<xs:extension base="CAZApplianceReading">
+												<xs:sequence>
+												<xs:element ref="extension" minOccurs="0"/>
+												</xs:sequence>
+												</xs:extension>
+												</xs:complexContent>
+												</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="SpillageTest">
-													<xs:annotation>
-														<xs:documentation>[seconds]</xs:documentation>
-													</xs:annotation>
-													<xs:complexType>
-														<xs:complexContent>
-															<xs:extension base="CAZApplianceReading">
-																<xs:sequence>
-																	<xs:element ref="extension" minOccurs="0"/>
-																</xs:sequence>
-															</xs:extension>
-														</xs:complexContent>
-													</xs:complexType>
+												<xs:annotation>
+												<xs:documentation>[seconds]</xs:documentation>
+												</xs:annotation>
+												<xs:complexType>
+												<xs:complexContent>
+												<xs:extension base="CAZApplianceReading">
+												<xs:sequence>
+												<xs:element ref="extension" minOccurs="0"/>
+												</xs:sequence>
+												</xs:extension>
+												</xs:complexContent>
+												</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="CarbonMonoxideTest">
-													<xs:annotation>
-														<xs:documentation>[ppm]</xs:documentation>
-													</xs:annotation>
-													<xs:complexType>
-														<xs:complexContent>
-															<xs:extension base="CAZApplianceReading">
-																<xs:sequence>
-																	<xs:element minOccurs="0" name="AmbientCOActionDuringCAZTesting" type="HPXMLString">
-																		<xs:annotation>
-																			<xs:documentation>BPI Gold Sheet is one example that shows action levels based upon decision logic</xs:documentation>
-																		</xs:annotation>
-																	</xs:element>
-																	<xs:element minOccurs="0" ref="extension"/>
-																</xs:sequence>
-															</xs:extension>
-														</xs:complexContent>
-													</xs:complexType>
+												<xs:annotation>
+												<xs:documentation>[ppm]</xs:documentation>
+												</xs:annotation>
+												<xs:complexType>
+												<xs:complexContent>
+												<xs:extension base="CAZApplianceReading">
+												<xs:sequence>
+												<xs:element minOccurs="0" name="AmbientCOActionDuringCAZTesting" type="HPXMLString">
+												<xs:annotation>
+												<xs:documentation>BPI Gold Sheet is one example that shows action levels based upon decision logic</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												</xs:extension>
+												</xs:complexContent>
+												</xs:complexType>
 												</xs:element>
 												<xs:element name="StackTemperature" type="Temperature" minOccurs="0">
-													<xs:annotation>
-														<xs:documentation>[deg F] after 10 minutes run time</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>[deg F] after 10 minutes run time</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element name="FuelLeaks" minOccurs="0" maxOccurs="unbounded">
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element name="FuelType" type="FuelType"/>
-															<xs:element name="LeaksIdentified" type="HPXMLBoolean"/>
-															<xs:element name="LeaksAddressed" type="HPXMLBoolean"/>
-															<xs:element minOccurs="0" name="Notes" type="HPXMLString"/>
-															<xs:element minOccurs="0" ref="extension"/>
-														</xs:sequence>
-														<xs:attribute name="dataSource" type="DataSource"/>
-													</xs:complexType>
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element name="FuelType" type="FuelType"/>
+												<xs:element name="LeaksIdentified" type="HPXMLBoolean"/>
+												<xs:element name="LeaksAddressed" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="Notes" type="HPXMLString"/>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												<xs:attribute name="dataSource" type="DataSource"/>
+												</xs:complexType>
 												</xs:element>
 												<xs:element ref="extension" minOccurs="0"/>
 											</xs:sequence>
@@ -4002,19 +4008,19 @@
 										<xs:complexType>
 											<xs:sequence>
 												<xs:element minOccurs="0" name="DistanceFromSubway" type="LengthMeasurement">
-													<xs:annotation>
-														<xs:documentation>[ft]</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>[ft]</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="DistanceFromBus" type="LengthMeasurement">
-													<xs:annotation>
-														<xs:documentation>[ft]</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>[ft]</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="DistanceFromTrain" type="LengthMeasurement">
-													<xs:annotation>
-														<xs:documentation>[ft]</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>[ft]</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
@@ -4039,9 +4045,9 @@
 												<xs:element minOccurs="0" name="SoilType" type="SoilType"/>
 												<xs:element minOccurs="0" name="MoistureType" type="MoisureType"/>
 												<xs:element minOccurs="0" name="Conductivity" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>[Btu/hr-ft-F]</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>[Btu/hr-ft-F]</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -7681,7 +7687,7 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="RadiantBarrierLocation_simple">
+	<xs:simpleType name="RadiantBarrierLocation_roof_simple">
 		<xs:annotation>
 			<xs:documentation>Enumerations from http://www.fsec.ucf.edu/en/publications/pdf/FSEC-DN-7-84.pdf</xs:documentation>
 		</xs:annotation>
@@ -7693,15 +7699,35 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:complexType name="RadiantBarrierLocation">
+	<xs:simpleType name="RadiantBarrierLocation_wall_simple">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="RadiantBarrierLocation_floor_simple">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:complexType name="RadiantBarrierLocation_roof">
 		<xs:simpleContent>
-			<xs:extension base="RadiantBarrierLocation_simple">
+			<xs:extension base="RadiantBarrierLocation_roof_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="RadiantBarrierLocation_wall">
+		<xs:simpleContent>
+			<xs:extension base="RadiantBarrierLocation_wall_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
 	<!--Ventilation Below-->
 	<!--Window Group Below-->
+	<xs:complexType name="RadiantBarrierLocation_floor">
+		<xs:simpleContent>
+			<xs:extension base="RadiantBarrierLocation_floor_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="HVACThirdPartyCertification_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Energy Star"/>
@@ -11139,4 +11165,5 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+
 </xs:schema>

--- a/schemas/HPXML.xsd
+++ b/schemas/HPXML.xsd
@@ -1,24 +1,18 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10"
-    targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.1">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.1">
     <xs:include schemaLocation="HPXMLBaseElements.xsd"/>
     <xs:element name="HPXML">
         <xs:complexType>
             <xs:sequence>
                 <xs:element ref="XMLTransactionHeaderInformation"/>
                 <xs:element ref="SoftwareInfo"/>
-                <xs:element maxOccurs="unbounded" minOccurs="0" name="Contractor" nillable="true"
-                    type="Contractor"/>
-                <xs:element maxOccurs="unbounded" minOccurs="0" name="Customer" nillable="true"
-                    type="Customer"/>
-                <xs:element maxOccurs="unbounded" minOccurs="0" name="Building" nillable="true"
-                    type="Building"/>
-                <xs:element maxOccurs="unbounded" minOccurs="0" name="Project" nillable="true"
-                    type="Project"/>
-                <xs:element maxOccurs="unbounded" minOccurs="0" name="Utility" nillable="true"
-                    type="Utility"/>
-                <xs:element maxOccurs="unbounded" minOccurs="0" name="Consumption" nillable="true"
-                    type="Consumption"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="Contractor" nillable="true" type="Contractor"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="Customer" nillable="true" type="Customer"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="Building" nillable="true" type="Building"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="Project" nillable="true" type="Project"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="Utility" nillable="true" type="Utility"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="Consumption" nillable="true" type="Consumption"/>
             </xs:sequence>
             <xs:attribute name="schemaVersion" type="schemaVersionType" use="required"/>
             <xs:attribute name="dataSource" type="DataSource"/>

--- a/schemas/HPXML.xsd
+++ b/schemas/HPXML.xsd
@@ -1,18 +1,24 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.1">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10"
+    targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.1">
     <xs:include schemaLocation="HPXMLBaseElements.xsd"/>
     <xs:element name="HPXML">
         <xs:complexType>
             <xs:sequence>
                 <xs:element ref="XMLTransactionHeaderInformation"/>
                 <xs:element ref="SoftwareInfo"/>
-                <xs:element maxOccurs="unbounded" minOccurs="0" name="Contractor" nillable="true" type="Contractor"/>
-                <xs:element maxOccurs="unbounded" minOccurs="0" name="Customer" nillable="true" type="Customer"/>
-                <xs:element maxOccurs="unbounded" minOccurs="0" name="Building" nillable="true" type="Building"/>
-                <xs:element maxOccurs="unbounded" minOccurs="0" name="Project" nillable="true" type="Project"/>
-                <xs:element maxOccurs="unbounded" minOccurs="0" name="Utility" nillable="true" type="Utility"/>
-                <xs:element maxOccurs="unbounded" minOccurs="0" name="Consumption" nillable="true" type="Consumption"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="Contractor" nillable="true"
+                    type="Contractor"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="Customer" nillable="true"
+                    type="Customer"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="Building" nillable="true"
+                    type="Building"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="Project" nillable="true"
+                    type="Project"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="Utility" nillable="true"
+                    type="Utility"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="Consumption" nillable="true"
+                    type="Consumption"/>
             </xs:sequence>
             <xs:attribute name="schemaVersion" type="schemaVersionType" use="required"/>
             <xs:attribute name="dataSource" type="DataSource"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10"
-	targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.1">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.1">
 	<xs:include schemaLocation="HPXMLDataTypes.xsd"/>
 	<xs:element name="XMLTransactionHeaderInformation">
 		<xs:annotation>
@@ -65,14 +64,10 @@
 				systems, and have it identified in the two systems. Also, there is an id attribute to define a local id to be used internally. </xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType"
-				minOccurs="0"/>
-			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue"
-				minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType"
-				minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue"
-				minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType" minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue" minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType" minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="id" type="xs:ID" use="required">
 			<xs:annotation>
@@ -96,14 +91,10 @@
 				elements in other xml transactions.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType"
-				minOccurs="0"/>
-			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue"
-				minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType"
-				minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue"
-				minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType" minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue" minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType" minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="idref" type="xs:IDREF">
 			<xs:annotation>
@@ -162,8 +153,7 @@
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="IndividualType" type="IndividualType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="Telephone"
-				type="TelephoneInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="Telephone" type="TelephoneInfoType"/>
 			<xs:element minOccurs="0" maxOccurs="unbounded" name="Email" type="EmailInfoType"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
@@ -180,11 +170,9 @@
 				<xs:element minOccurs="0" name="MeterNumber" type="HPXMLString"/>
 				<xs:element name="UtilityAccountNumber" type="HPXMLString" minOccurs="0"/>
 				<xs:element minOccurs="0" name="Permission" type="HPXMLBoolean"/>
-				<xs:element name="UtilityServiceTypeProvided" type="ConsumptionType" minOccurs="0"
-					maxOccurs="unbounded"/>
+				<xs:element name="UtilityServiceTypeProvided" type="ConsumptionType" minOccurs="0" maxOccurs="unbounded"/>
 				<xs:element minOccurs="0" name="BusinessInfo" type="BusinessInfoType"/>
-				<xs:element maxOccurs="unbounded" minOccurs="0" name="BusinessContactInfo"
-					type="BusinessContactInfoType"/>
+				<xs:element maxOccurs="unbounded" minOccurs="0" name="BusinessContactInfo" type="BusinessContactInfoType"/>
 				<xs:element ref="extension" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attribute name="dataSource" type="DataSource"/>
@@ -240,8 +228,7 @@
 		<xs:complexContent>
 			<xs:extension base="InsulationInfoBase">
 				<xs:sequence>
-					<xs:element maxOccurs="unbounded" minOccurs="0" name="Layer"
-						type="InsulationLayerInfo"> </xs:element>
+					<xs:element maxOccurs="unbounded" minOccurs="0" name="Layer" type="InsulationLayerInfo"> </xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -251,8 +238,7 @@
 		<xs:complexContent>
 			<xs:extension base="InsulationInfoBase">
 				<xs:sequence>
-					<xs:element maxOccurs="unbounded" minOccurs="0" name="Layer"
-						type="FoundationWallInsulationLayerInfo"> </xs:element>
+					<xs:element maxOccurs="unbounded" minOccurs="0" name="Layer" type="FoundationWallInsulationLayerInfo"> </xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -262,8 +248,7 @@
 		<xs:complexContent>
 			<xs:extension base="InsulationInfoBase">
 				<xs:sequence>
-					<xs:element maxOccurs="unbounded" minOccurs="0" name="Layer"
-						type="SlabPerimeterInsulationLayerInfo"> </xs:element>
+					<xs:element maxOccurs="unbounded" minOccurs="0" name="Layer" type="SlabPerimeterInsulationLayerInfo"> </xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -273,8 +258,7 @@
 		<xs:complexContent>
 			<xs:extension base="InsulationInfoBase">
 				<xs:sequence>
-					<xs:element maxOccurs="unbounded" minOccurs="0" name="Layer"
-						type="UnderSlabInsulationLayerInfo"> </xs:element>
+					<xs:element maxOccurs="unbounded" minOccurs="0" name="Layer" type="UnderSlabInsulationLayerInfo"> </xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -306,14 +290,12 @@
 		<xs:complexContent>
 			<xs:extension base="InsulationLayerInfoBase">
 				<xs:sequence>
-					<xs:element name="DistanceToTopOfInsulation" type="LengthMeasurement"
-						minOccurs="0">
+					<xs:element name="DistanceToTopOfInsulation" type="LengthMeasurement" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>[ft] Vertical distance from top of foundation wall to top of insulation.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="DistanceToBottomOfInsulation" type="LengthMeasurement"
-						minOccurs="0">
+					<xs:element name="DistanceToBottomOfInsulation" type="LengthMeasurement" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>[ft] Vertical distance from top of foundation wall to bottom of insulation.</xs:documentation>
 						</xs:annotation>
@@ -383,8 +365,7 @@
 			<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 			<xs:element name="ModelYear" type="Year" minOccurs="0"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification"
-				type="ApplianceThirdPartyCertifications"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="ApplianceThirdPartyCertifications"/>
 			<xs:element minOccurs="0" name="IsSharedAppliance" type="HPXMLBoolean">
 				<xs:annotation>
 					<xs:documentation>Does the appliance serve multiple building/dwelling units?</xs:documentation>
@@ -418,8 +399,7 @@
 								drying cycle energy as well as energy consumed during Stand-by and Off modes.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element maxOccurs="unbounded" minOccurs="0" name="ControlType"
-						type="ClothesDryerControlType"/>
+					<xs:element maxOccurs="unbounded" minOccurs="0" name="ControlType" type="ClothesDryerControlType"/>
 					<xs:element minOccurs="0" name="Vented" type="HPXMLBoolean"/>
 					<xs:element minOccurs="0" name="VentedFlowRate" type="FlowRate"/>
 					<xs:element ref="extension" minOccurs="0"/>
@@ -443,8 +423,7 @@
 								Factor.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="IntegratedModifiedEnergyFactor" type="HPXMLDouble"
-						minOccurs="0">
+					<xs:element name="IntegratedModifiedEnergyFactor" type="HPXMLDouble" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>The energy performance metric for ENERGY STAR certified residential clothes washers as of March 7, 2015.</xs:documentation>
 						</xs:annotation>
@@ -512,14 +491,11 @@
 					<xs:element minOccurs="0" name="Location" type="RefrigeratorLocation"/>
 					<xs:element minOccurs="0" name="Fuel" type="FuelType"/>
 					<xs:element name="HeatDryDefaultOff" type="HPXMLBoolean" minOccurs="0"/>
-					<xs:element name="AuxillaryWaterHeaterDefaultOff" type="HPXMLBoolean"
-						minOccurs="0"/>
+					<xs:element name="AuxillaryWaterHeaterDefaultOff" type="HPXMLBoolean" minOccurs="0"/>
 					<xs:element minOccurs="0" name="RatedAnnualkWh" type="RatedAnnualkWh"/>
 					<xs:element minOccurs="0" name="EnergyFactor" type="EnergyFactor"/>
-					<xs:element minOccurs="0" name="RatedWaterGalPerCycle"
-						type="RatedWaterGalPerCycle"/>
-					<xs:element minOccurs="0" name="PlaceSettingCapacity"
-						type="IntegerGreaterThanZero"/>
+					<xs:element minOccurs="0" name="RatedWaterGalPerCycle" type="RatedWaterGalPerCycle"/>
+					<xs:element minOccurs="0" name="PlaceSettingCapacity" type="IntegerGreaterThanZero"/>
 					<xs:element minOccurs="0" name="Usage" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>loads/week of actual usage by the occupants; use LabelUsage instead for the loads/week on the EnergyGuide label</xs:documentation>
@@ -649,8 +625,7 @@
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
-					<xs:element minOccurs="0" name="FractionDehumidificationLoadServed"
-						type="Fraction"/>
+					<xs:element minOccurs="0" name="FractionDehumidificationLoadServed" type="Fraction"/>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -684,8 +659,7 @@
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element name="SoftwareProgramUsed" type="SoftwareProgramUsed" minOccurs="0"/>
-				<xs:element name="SoftwareProgramVersion" type="SoftwareProgramVersion"
-					minOccurs="0"/>
+				<xs:element name="SoftwareProgramVersion" type="SoftwareProgramVersion" minOccurs="0"/>
 				<xs:element ref="extension" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attribute name="dataSource" type="DataSource"/>
@@ -704,12 +678,9 @@
 			<xs:element name="Auditor">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="Qualification" type="AuditorQualification"
-							maxOccurs="unbounded"/>
-						<xs:element minOccurs="0" name="StateWhereQualificationHeld"
-							type="StateCode"/>
-						<xs:element minOccurs="0" name="YearsExperience"
-							type="IntegerGreaterThanOrEqualToZero"/>
+						<xs:element minOccurs="0" name="Qualification" type="AuditorQualification" maxOccurs="unbounded"/>
+						<xs:element minOccurs="0" name="StateWhereQualificationHeld" type="StateCode"/>
+						<xs:element minOccurs="0" name="YearsExperience" type="IntegerGreaterThanOrEqualToZero"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -718,10 +689,8 @@
 			<xs:element name="Implementer">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" minOccurs="0" name="Qualification"
-							type="ImplementerQualification"/>
-						<xs:element minOccurs="0" name="StateWhereQualificationHeld"
-							type="StateCode"/>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="Qualification" type="ImplementerQualification"/>
+						<xs:element minOccurs="0" name="StateWhereQualificationHeld" type="StateCode"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -743,8 +712,7 @@
 		<xs:sequence>
 			<xs:group maxOccurs="unbounded" ref="SystemInfo"/>
 			<xs:element name="BusinessInfo" type="BusinessInfoType"/>
-			<xs:element name="SubContractor" type="ContractorType" minOccurs="0"
-				maxOccurs="unbounded"/>
+			<xs:element name="SubContractor" type="ContractorType" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -758,8 +726,7 @@
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element name="SpaceName" type="HPXMLString" minOccurs="0"/>
-						<xs:element minOccurs="0" name="NumberOfBedrooms"
-							type="IntegerGreaterThanOrEqualToZero"/>
+						<xs:element minOccurs="0" name="NumberOfBedrooms" type="IntegerGreaterThanOrEqualToZero"/>
 						<xs:element minOccurs="0" name="FloorArea" type="SurfaceArea">
 							<xs:annotation>
 								<xs:documentation>[sq.ft.]</xs:documentation>
@@ -805,8 +772,7 @@
 			<xs:element name="AirInfiltration" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="AirInfiltrationMeasurement"
-							type="AirInfiltrationMeasurementType" maxOccurs="unbounded"/>
+						<xs:element minOccurs="0" name="AirInfiltrationMeasurement" type="AirInfiltrationMeasurementType" maxOccurs="unbounded"/>
 						<xs:element minOccurs="0" name="AirSealing" maxOccurs="unbounded">
 							<xs:complexType>
 								<xs:sequence>
@@ -815,14 +781,9 @@
 									<xs:element minOccurs="0" name="ComponentsAirSealed">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element maxOccurs="unbounded" minOccurs="0"
-												name="Attic" type="AtticComponentsAirSealed"/>
-												<xs:element maxOccurs="unbounded" minOccurs="0"
-												name="BasementCrawlspace"
-												type="BasementCrawlspaceComponentsAirSealed"/>
-												<xs:element maxOccurs="unbounded" minOccurs="0"
-												name="LivingSpace"
-												type="LivingSpaceComponentsAirSealed"/>
+												<xs:element maxOccurs="unbounded" minOccurs="0" name="Attic" type="AtticComponentsAirSealed"/>
+												<xs:element maxOccurs="unbounded" minOccurs="0" name="BasementCrawlspace" type="BasementCrawlspaceComponentsAirSealed"/>
+												<xs:element maxOccurs="unbounded" minOccurs="0" name="LivingSpace" type="LivingSpaceComponentsAirSealed"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -860,25 +821,19 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="1" name="AtticType" type="AtticType"/>
-									<xs:element minOccurs="0" name="VentilationRate"
-										type="VentilationType"/>
-									<xs:element minOccurs="0" name="WithinInfiltrationVolume"
-										type="HPXMLBoolean">
+									<xs:element minOccurs="0" name="VentilationRate" type="VentilationType"/>
+									<xs:element minOccurs="0" name="WithinInfiltrationVolume" type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Specifies whether the attic is within the infiltration volume impacted by an air leakage test.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AttachedToRoof"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToWall"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFloor"
-										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToRoof" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFloor" type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo"
-												type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -904,31 +859,22 @@
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
 									<xs:element name="FoundationType" type="FoundationType"/>
-									<xs:element minOccurs="0" name="VentilationRate"
-										type="VentilationType"/>
-									<xs:element minOccurs="0" name="ThermalBoundary"
-										type="FoundationThermalBoundary"/>
-									<xs:element minOccurs="0" name="WithinInfiltrationVolume"
-										type="HPXMLBoolean">
+									<xs:element minOccurs="0" name="VentilationRate" type="VentilationType"/>
+									<xs:element minOccurs="0" name="ThermalBoundary" type="FoundationThermalBoundary"/>
+									<xs:element minOccurs="0" name="WithinInfiltrationVolume" type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Specifies whether the foundation is within the infiltration volume impacted by an air leakage test.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AttachedToRimJoist"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToWall"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFoundationWall"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFloor"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToSlab"
-										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToRimJoist" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFoundationWall" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFloor" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToSlab" type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo"
-												type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -960,32 +906,23 @@
 									<xs:element minOccurs="1" name="GarageType">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="AttachedtoHouse"
-												type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="Vented"
-												type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="Conditioned"
-												type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="AttachedtoHouse" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="Vented" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="AttachedToRoof"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToWall"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFoundationWall"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFloor"
-										type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToSlab"
-										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToRoof" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFoundationWall" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFloor" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToSlab" type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo"
-												type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -1010,28 +947,23 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo"
-										type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Surface area of the roof itself</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation"
-										type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
 									<xs:element name="Azimuth" type="AzimuthType" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="RoofType" type="RoofType"/>
-									<xs:element minOccurs="0" name="RoofColor"
-										type="WallAndRoofColor"/>
-									<xs:element minOccurs="0" name="SolarAbsorptance"
-										type="SolarAbsorptance"/>
+									<xs:element minOccurs="0" name="RoofColor" type="WallAndRoofColor"/>
+									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
 									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
-									<xs:element minOccurs="0" name="InteriorFinish"
-										type="InteriorFinishInfo"/>
+									<xs:element minOccurs="0" name="InteriorFinish" type="InteriorFinishInfo"/>
 									<xs:element minOccurs="0" name="Rafters" type="StudProperties"/>
 									<xs:element minOccurs="0" name="DeckType" type="DeckType"/>
 									<xs:element minOccurs="0" name="Pitch" type="Pitch">
@@ -1039,14 +971,10 @@
 											<xs:documentation>Pitch of roof ?/12</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="RadiantBarrier" type="HPXMLBoolean"
-										minOccurs="0"/>
-									<xs:element name="RadiantBarrierLocation"
-										type="RadiantBarrierLocation_roof" minOccurs="0"/>
-									<xs:element name="RadiantBarrierGrade" type="InsulationGrade"
-										minOccurs="0"/>
-									<xs:element minOccurs="0" name="Insulation"
-										type="InsulationInfo"/>
+									<xs:element name="RadiantBarrier" type="HPXMLBoolean" minOccurs="0"/>
+									<xs:element name="RadiantBarrierLocation" type="RadiantBarrierLocation_roof" minOccurs="0"/>
+									<xs:element name="RadiantBarrierGrade" type="InsulationGrade" minOccurs="0"/>
+									<xs:element minOccurs="0" name="Insulation" type="InsulationInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1064,42 +992,34 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element minOccurs="0" name="ExteriorAdjacentTo"
-										type="AdjacentTo"/>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo"
-										type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="ExteriorAdjacentTo" type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation"
-										type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
 									<xs:element name="Azimuth" type="AzimuthType" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Perimeter"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Perimeter" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="Siding" type="Siding"/>
 									<xs:element minOccurs="0" name="Color" type="WallAndRoofColor"/>
-									<xs:element minOccurs="0" name="SolarAbsorptance"
-										type="SolarAbsorptance"/>
+									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
 									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
-									<xs:element minOccurs="0" name="Insulation"
-										type="InsulationInfo"/>
-									<xs:element minOccurs="0" name="FloorJoists"
-										type="StudProperties"/>
+									<xs:element minOccurs="0" name="Insulation" type="InsulationInfo"/>
+									<xs:element minOccurs="0" name="FloorJoists" type="StudProperties"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo"
-												type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -1121,15 +1041,11 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo"
-										minOccurs="0"/>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo"
-										type="AdjacentTo"/>
-									<xs:element minOccurs="0" name="AtticWallType"
-										type="AtticWallType"/>
+									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo" minOccurs="0"/>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="AtticWallType" type="AtticWallType"/>
 									<xs:element name="WallType" type="WallType" minOccurs="0"/>
-									<xs:element minOccurs="0" name="Thickness"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[in] Thickness of the entire wall assembly, including any siding, sheathing, continuous insulation, and interior finish.</xs:documentation>
 										</xs:annotation>
@@ -1139,8 +1055,7 @@
 											<xs:documentation>[sq.ft.] Gross wall area</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation"
-										type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
 									<xs:element name="Azimuth" type="AzimuthType" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
@@ -1149,24 +1064,17 @@
 									<xs:element minOccurs="0" name="Studs" type="StudProperties"/>
 									<xs:element minOccurs="0" name="Siding" type="Siding"/>
 									<xs:element minOccurs="0" name="Color" type="WallAndRoofColor"/>
-									<xs:element minOccurs="0" name="SolarAbsorptance"
-										type="SolarAbsorptance"/>
+									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
 									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
-									<xs:element minOccurs="0" name="InteriorFinish"
-										type="InteriorFinishInfo"/>
-									<xs:element minOccurs="0" maxOccurs="1" name="Insulation"
-										type="InsulationInfo"/>
-									<xs:element name="RadiantBarrier" type="HPXMLBoolean"
-										minOccurs="0"/>
-									<xs:element name="RadiantBarrierLocation"
-										type="RadiantBarrierLocation_wall" minOccurs="0"/>
-									<xs:element name="RadiantBarrierGrade" type="InsulationGrade"
-										minOccurs="0"/>
+									<xs:element minOccurs="0" name="InteriorFinish" type="InteriorFinishInfo"/>
+									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"/>
+									<xs:element name="RadiantBarrier" type="HPXMLBoolean" minOccurs="0"/>
+									<xs:element name="RadiantBarrierLocation" type="RadiantBarrierLocation_wall" minOccurs="0"/>
+									<xs:element name="RadiantBarrierGrade" type="InsulationGrade" minOccurs="0"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo"
-												type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -1188,10 +1096,8 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo"
-										minOccurs="0"/>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo"
-										type="AdjacentTo"/>
+									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo" minOccurs="0"/>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="Type" type="FoundationWallType"/>
 									<xs:element minOccurs="0" name="Length" type="LengthMeasurement">
 										<xs:annotation>
@@ -1208,37 +1114,30 @@
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation"
-										type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
 									<xs:element name="Azimuth" type="AzimuthType" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Thickness"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[in] Thickness of the foundation wall structural element (e.g., concrete), excluding any interior framing and continuous insulation.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="DepthBelowGrade"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="DepthBelowGrade" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Depth below grade of foundation wall</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AdjacentToFoundation"
-										type="LocalReference">
+									<xs:element minOccurs="0" name="AdjacentToFoundation" type="LocalReference">
 										<xs:annotation>
 											<xs:documentation>If this foundation wall is adjacent to another foundation, use this reference to indicate which one.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="InteriorStuds"
-										type="StudProperties"/>
-									<xs:element minOccurs="0" name="InteriorFinish"
-										type="InteriorFinishInfo"/>
-									<xs:element maxOccurs="1" minOccurs="0" name="Insulation"
-										type="FoundationWallInsulationInfo"/>
+									<xs:element minOccurs="0" name="InteriorStuds" type="StudProperties"/>
+									<xs:element minOccurs="0" name="InteriorFinish" type="InteriorFinishInfo"/>
+									<xs:element maxOccurs="1" minOccurs="0" name="Insulation" type="FoundationWallInsulationInfo"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1260,38 +1159,27 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo"
-										minOccurs="0"/>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo"
-										type="AdjacentTo"/>
-									<xs:element minOccurs="0" name="FloorOrCeiling"
-										type="FloorOrCeiling">
+									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo" minOccurs="0"/>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="FloorOrCeiling" type="FloorOrCeiling">
 										<xs:annotation>
 											<xs:documentation>From the perspective of the living/conditioned space.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="FloorType" type="FloorType"/>
-									<xs:element minOccurs="0" name="FloorJoists"
-										type="StudProperties"/>
-									<xs:element minOccurs="0" name="FloorTrusses"
-										type="StudProperties"/>
-									<xs:element minOccurs="0" name="FloorCovering"
-										type="FloorCovering"/>
+									<xs:element minOccurs="0" name="FloorJoists" type="StudProperties"/>
+									<xs:element minOccurs="0" name="FloorTrusses" type="StudProperties"/>
+									<xs:element minOccurs="0" name="FloorCovering" type="FloorCovering"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="InteriorFinish"
-										type="InteriorFinishInfo"/>
-									<xs:element minOccurs="0" maxOccurs="1" name="Insulation"
-										type="InsulationInfo"/>
-									<xs:element name="RadiantBarrier" type="HPXMLBoolean"
-										minOccurs="0"/>
-									<xs:element name="RadiantBarrierLocation"
-										type="RadiantBarrierLocation_floor" minOccurs="0"/>
-									<xs:element name="RadiantBarrierGrade" type="InsulationGrade"
-										minOccurs="0"/>
+									<xs:element minOccurs="0" name="InteriorFinish" type="InteriorFinishInfo"/>
+									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"/>
+									<xs:element name="RadiantBarrier" type="HPXMLBoolean" minOccurs="0"/>
+									<xs:element name="RadiantBarrierLocation" type="RadiantBarrierLocation_floor" minOccurs="0"/>
+									<xs:element name="RadiantBarrierGrade" type="InsulationGrade" minOccurs="0"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1312,50 +1200,40 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo"
-										type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Area of the slab</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Thickness"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[in] Thickness of the foundation slab structural element (e.g., concrete), excluding any floor coverings and continuous insulation.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Perimeter"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Perimeter" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Length of slab perimeter.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="ExposedPerimeter"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="ExposedPerimeter" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Perimeter of the slab exposed to ambient conditions</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="OnGradeExposedPerimeter"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="OnGradeExposedPerimeter" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Perimeter of slab measured in feet that is on-grade (2 ft. below grade or less) and exposed to ambient conditions.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="DepthBelowGrade"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="DepthBelowGrade" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Depth from the top of the slab surface to grade</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FloorCovering"
-										type="FloorCovering"/>
-									<xs:element maxOccurs="1" minOccurs="0"
-										name="PerimeterInsulation"
-										type="SlabPerimeterInsulationInfo"/>
-									<xs:element minOccurs="0" name="UnderSlabInsulation"
-										type="UnderSlabInsulationInfo"/>
+									<xs:element minOccurs="0" name="FloorCovering" type="FloorCovering"/>
+									<xs:element maxOccurs="1" minOccurs="0" name="PerimeterInsulation" type="SlabPerimeterInsulationInfo"/>
+									<xs:element minOccurs="0" name="UnderSlabInsulation" type="UnderSlabInsulationInfo"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1377,15 +1255,12 @@
 								<xs:sequence>
 									<xs:group ref="WindowInfo"/>
 									<xs:element minOccurs="0" name="WindowType" type="WindowType"/>
-									<xs:element minOccurs="0" name="WindowtoWallRatio"
-										type="Fraction"/>
-									<xs:element minOccurs="0" name="AttachedToWall"
-										type="LocalReference"/>
+									<xs:element minOccurs="0" name="WindowtoWallRatio" type="Fraction"/>
+									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo"
-												type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -1416,10 +1291,8 @@
 											<xs:documentation>Pitch of skylight ?/12</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AttachedToRoof"
-										type="LocalReference"/>
-									<xs:element minOccurs="0" name="AttachedToFloor"
-										type="LocalReference">
+									<xs:element minOccurs="0" name="AttachedToRoof" type="LocalReference"/>
+									<xs:element minOccurs="0" name="AttachedToFloor" type="LocalReference">
 										<xs:annotation>
 											<xs:documentation>For a skylight that includes a shaft or a sun tunnel, reference the attic floor that it penetrates.</xs:documentation>
 										</xs:annotation>
@@ -1427,8 +1300,7 @@
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo"
-												type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -1449,10 +1321,8 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="AttachedToWall"
-										type="LocalReference"/>
-									<xs:element minOccurs="0" name="Count"
-										type="IntegerGreaterThanZero"/>
+									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference"/>
+									<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Total door surface area for this group of doors</xs:documentation>
@@ -1463,27 +1333,19 @@
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation"
-										type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
 									<xs:element minOccurs="0" name="DoorType" type="DoorType"/>
-									<xs:element name="DoorMaterial" type="DoorMaterial"
-										minOccurs="0"/>
-									<xs:element minOccurs="0" name="WeatherStripping"
-										type="HPXMLBoolean"/>
+									<xs:element name="DoorMaterial" type="DoorMaterial" minOccurs="0"/>
+									<xs:element minOccurs="0" name="WeatherStripping" type="HPXMLBoolean"/>
 									<xs:element name="StormDoor" type="HPXMLBoolean" minOccurs="0"/>
 									<xs:element name="RValue" type="RValue" minOccurs="0"/>
-									<xs:element minOccurs="0" name="LeakinessDescription"
-										type="BuildingLeakiness"/>
-									<xs:element minOccurs="0" name="PerformanceClass"
-										type="PerformanceClass"/>
-									<xs:element maxOccurs="unbounded" minOccurs="0"
-										name="ThirdPartyCertification"
-										type="DoorThirdPartyCertifications"/>
+									<xs:element minOccurs="0" name="LeakinessDescription" type="BuildingLeakiness"/>
+									<xs:element minOccurs="0" name="PerformanceClass" type="PerformanceClass"/>
+									<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="DoorThirdPartyCertifications"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo"
-												type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -1515,30 +1377,22 @@
 										</xs:annotation>
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0"
-												name="PrimaryHeatingSystem" type="LocalReference"/>
-												<xs:element minOccurs="0"
-												name="PrimaryCoolingSystem" type="LocalReference"
-												/>
+												<xs:element minOccurs="0" name="PrimaryHeatingSystem" type="LocalReference"/>
+												<xs:element minOccurs="0" name="PrimaryCoolingSystem" type="LocalReference"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" maxOccurs="unbounded"
-										name="HeatingSystem" type="HeatingSystemInfoType"/>
-									<xs:element minOccurs="0" maxOccurs="unbounded"
-										name="CoolingSystem" type="CoolingSystemInfoType"/>
-									<xs:element minOccurs="0" maxOccurs="unbounded" name="HeatPump"
-										type="HeatPumpInfoType"/>
-									<xs:element maxOccurs="unbounded" minOccurs="0"
-										name="GeothermalLoop" type="GeothermalLoopType"/>
+									<xs:element minOccurs="0" maxOccurs="unbounded" name="HeatingSystem" type="HeatingSystemInfoType"/>
+									<xs:element minOccurs="0" maxOccurs="unbounded" name="CoolingSystem" type="CoolingSystemInfoType"/>
+									<xs:element minOccurs="0" maxOccurs="unbounded" name="HeatPump" type="HeatPumpInfoType"/>
+									<xs:element maxOccurs="unbounded" minOccurs="0" name="GeothermalLoop" type="GeothermalLoopType"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
-						<xs:element maxOccurs="unbounded" minOccurs="0" name="HVACControl"
-							type="HVACControlType"/>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="HVACControl" type="HVACControlType"/>
 						<xs:element maxOccurs="unbounded" minOccurs="0" name="HVACDistribution">
 							<xs:complexType>
 								<xs:sequence>
@@ -1547,41 +1401,33 @@
 									<xs:element minOccurs="0" name="DistributionSystemType">
 										<xs:complexType>
 											<xs:choice>
-												<xs:element name="AirDistribution"
-												type="AirDistributionInfo"/>
-												<xs:element name="HydronicDistribution"
-												type="HydronicDistributionInfo"/>
+												<xs:element name="AirDistribution" type="AirDistributionInfo"/>
+												<xs:element name="HydronicDistribution" type="HydronicDistributionInfo"/>
 												<xs:element name="Other" type="HPXMLString">
-												<xs:annotation>
-												<xs:documentation>describe</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>describe</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 											</xs:choice>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="ConditionedFloorAreaServed"
-										type="SurfaceArea">
+									<xs:element minOccurs="0" name="ConditionedFloorAreaServed" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Conditioned floor area that this distribution system serves.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0"
-										name="AnnualHeatingDistributionSystemEfficiency"
-										type="FractionExcludingZero">
+									<xs:element minOccurs="0" name="AnnualHeatingDistributionSystemEfficiency" type="FractionExcludingZero">
 										<xs:annotation>
 											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for heating, the DSE may be approximated by equation 3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use History. Enter values as a fractional number between 0 and 1, i.e. 80% = 0.8</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0"
-										name="AnnualCoolingDistributionSystemEfficiency"
-										type="FractionExcludingZero">
+									<xs:element minOccurs="0" name="AnnualCoolingDistributionSystemEfficiency" type="FractionExcludingZero">
 										<xs:annotation>
 											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for cooling, the DSE may be approximated by equation 3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use History. Enter values as a fractional number between 0 and 1, i.e. 80% = 0.8</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HVACDistributionImprovement"
-										type="HVACDistributionImprovementInfo"/>
+									<xs:element minOccurs="0" name="HVACDistributionImprovement" type="HVACDistributionImprovementInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1590,10 +1436,8 @@
 						<xs:element minOccurs="0" name="Maintenance">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element minOccurs="0" name="Schedule"
-										type="HVACMaintenanceSchedule"/>
-									<xs:element minOccurs="0" name="ACReplacedinLastTenYears"
-										type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="Schedule" type="HVACMaintenanceSchedule"/>
+									<xs:element minOccurs="0" name="ACReplacedinLastTenYears" type="HPXMLBoolean"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1602,8 +1446,7 @@
 						<xs:element name="AnnualEnergyUse" minOccurs="0">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"
-										maxOccurs="unbounded"/>
+									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType" maxOccurs="unbounded"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
@@ -1624,171 +1467,131 @@
 											<xs:sequence>
 												<xs:group ref="SystemInfo"/>
 												<xs:element minOccurs="0" ref="ConnectedDevice"/>
-												<xs:element minOccurs="0" name="Manufacturer"
-												type="HPXMLString"/>
-												<xs:element minOccurs="0" name="SerialNumber"
-												type="HPXMLString"/>
-												<xs:element minOccurs="0" name="Count"
-												type="IntegerGreaterThanZero">
-												<xs:annotation>
-												<xs:documentation>Number of similar ventilation fans (e.g., bath fans).</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
+												<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
+												<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero">
+													<xs:annotation>
+														<xs:documentation>Number of similar ventilation fans (e.g., bath fans).</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="FanType"
-												type="VentilationFanType"/>
+												<xs:element minOccurs="0" name="FanType" type="VentilationFanType"/>
 												<xs:element minOccurs="0" name="CFISControls">
-												<xs:annotation>
-												<xs:documentation>Relevant when FanType="central fan integrated supply".</xs:documentation>
-												</xs:annotation>
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element minOccurs="0"
-												name="HasOutdoorAirControl" type="HPXMLBoolean">
-												<xs:annotation>
-												<xs:documentation>Has controls to block the flow of outside air when the CFIS system is not ventilating. For example, an electronically-controlled mechanical damper, or an in-line fan that substantially blocks the flow when not running.</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>Relevant when FanType="central fan integrated supply".</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element minOccurs="0" name="HasOutdoorAirControl" type="HPXMLBoolean">
+																<xs:annotation>
+																	<xs:documentation>Has controls to block the flow of outside air when the CFIS system is not ventilating. For example, an electronically-controlled mechanical damper, or an in-line fan that substantially blocks the flow when not running.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" name="AdditionalRuntimeOperatingMode" type="AdditionalRuntimeOperatingMode">
+																<xs:annotation>
+																	<xs:documentation>Describes if/how the CFIS system provides additional ventilation beyond when the HVAC system is running to meet a given ventilation target.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="SupplementalFan" type="LocalReference" minOccurs="0" maxOccurs="1">
+																<xs:annotation>
+																	<xs:documentation>When AdditionalRuntimeOperatingMode="supplemental fan", specifies the VentilationFan that serves as that supplemental fan.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+													</xs:complexType>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="AdditionalRuntimeOperatingMode"
-												type="AdditionalRuntimeOperatingMode">
-												<xs:annotation>
-												<xs:documentation>Describes if/how the CFIS system provides additional ventilation beyond when the HVAC system is running to meet a given ventilation target.</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="RatedFlowRate" type="HPXMLDouble">
+													<xs:annotation>
+														<xs:documentation>[CFM] as rated by manufacturer</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element name="SupplementalFan"
-												type="LocalReference" minOccurs="0" maxOccurs="1">
-												<xs:annotation>
-												<xs:documentation>When AdditionalRuntimeOperatingMode="supplemental fan", specifies the VentilationFan that serves as that supplemental fan.</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="CalculatedFlowRate" type="HPXMLDouble">
+													<xs:annotation>
+														<xs:documentation>[CFM] as calculated using duct size, prescriptive approach</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												</xs:complexType>
+												<xs:element minOccurs="0" name="TestedFlowRate" type="HPXMLDouble">
+													<xs:annotation>
+														<xs:documentation>[CFM] as tested by assessor/auditor/inspector</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="RatedFlowRate"
-												type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>[CFM] as rated by manufacturer</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="HoursInOperation" type="HoursPerDay">
+													<xs:annotation>
+														<xs:documentation>24 = continuous, less than 24 = intermittent</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="CalculatedFlowRate"
-												type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>[CFM] as calculated using duct size, prescriptive approach</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="DeliveredVentilation" type="HPXMLDouble">
+													<xs:annotation>
+														<xs:documentation>[CFM]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="TestedFlowRate"
-												type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>[CFM] as tested by assessor/auditor/inspector</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="FanControlProperlyLabeled" type="BooleanWithNA"/>
+												<xs:element minOccurs="0" name="ProperlyVented" type="BooleanWithNA"/>
+												<xs:element minOccurs="0" name="FanLocation" type="VentilationFanLocation"/>
+												<xs:element minOccurs="0" name="UsedForLocalVentilation" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="UsedForWholeBuildingVentilation" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="UsedForSeasonalCoolingLoadReduction" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="UsedForGarageVentilation" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="IsSharedSystem" type="HPXMLBoolean">
+													<xs:annotation>
+														<xs:documentation>Does the system serve multiple building/dwelling units?</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="HoursInOperation"
-												type="HoursPerDay">
-												<xs:annotation>
-												<xs:documentation>24 = continuous, less than 24 = intermittent</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="NumberofUnitsServed" type="HPXMLInteger"/>
+												<xs:element minOccurs="0" name="RatedNoise" type="HPXMLDouble">
+													<xs:annotation>
+														<xs:documentation>[sones] from manufacturer's info</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="DeliveredVentilation" type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>[CFM]</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="TestedNoise" type="HPXMLDouble">
+													<xs:annotation>
+														<xs:documentation>[sones] as tested in field</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="FanControlProperlyLabeled"
-												type="BooleanWithNA"/>
-												<xs:element minOccurs="0" name="ProperlyVented"
-												type="BooleanWithNA"/>
-												<xs:element minOccurs="0" name="FanLocation"
-												type="VentilationFanLocation"/>
-												<xs:element minOccurs="0"
-												name="UsedForLocalVentilation" type="HPXMLBoolean"/>
-												<xs:element minOccurs="0"
-												name="UsedForWholeBuildingVentilation"
-												type="HPXMLBoolean"/>
-												<xs:element minOccurs="0"
-												name="UsedForSeasonalCoolingLoadReduction"
-												type="HPXMLBoolean"/>
-												<xs:element minOccurs="0"
-												name="UsedForGarageVentilation"
-												type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="IsSharedSystem"
-												type="HPXMLBoolean">
-												<xs:annotation>
-												<xs:documentation>Does the system serve multiple building/dwelling units?</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" name="NumberofUnitsServed"
-												type="HPXMLInteger"/>
-												<xs:element minOccurs="0" name="RatedNoise"
-												type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>[sones] from manufacturer's info</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" name="TestedNoise"
-												type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>[sones] as tested in field</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0"
-												name="TotalRecoveryEfficiency"
-												type="FractionExcludingZero">
-												<xs:annotation>
-												<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by electric
+												<xs:element minOccurs="0" name="TotalRecoveryEfficiency" type="FractionExcludingZero">
+													<xs:annotation>
+														<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by electric
 															consumption, case heat loss or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential
 															total energy that could be recovered plus the exhaust fan energy. Values for some products can be found at the Home Ventilating Institute
 															(hvi.org).</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="SensibleRecoveryEfficiency"
-												type="FractionExcludingZero">
-												<xs:annotation>
-												<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by electric consumption, case heat loss or heat gain,
+												<xs:element minOccurs="0" name="SensibleRecoveryEfficiency" type="FractionExcludingZero">
+													<xs:annotation>
+														<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by electric consumption, case heat loss or heat gain,
 															air leakage, airflow mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test),
 															as a percent of the potential sensible energy that could be recovered plus the exhaust fan energy. Values for some products can be found at
 															the Home Ventilating Institute (hvi.org).</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="AdjustedTotalRecoveryEfficiency"
-												type="FractionExcludingZero">
-												<xs:annotation>
-												<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by case heat loss
+												<xs:element minOccurs="0" name="AdjustedTotalRecoveryEfficiency" type="FractionExcludingZero">
+													<xs:annotation>
+														<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by case heat loss
 															or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential total energy that could be
 															recovered. This value is used to predict and compare Cooling Season Performance for the HRV/ERV unit. This value should be used for energy
 															modeling when wattage for air movement is separately accounted for in the energy model. Values for some products can be found at the Home
 															Ventilating Institute (hvi.org).</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="AdjustedSensibleRecoveryEfficiency"
-												type="FractionExcludingZero">
-												<xs:annotation>
-												<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by case heat loss or heat gain, air leakage, airflow
+												<xs:element minOccurs="0" name="AdjustedSensibleRecoveryEfficiency" type="FractionExcludingZero">
+													<xs:annotation>
+														<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by case heat loss or heat gain, air leakage, airflow
 															mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test), as a percent of the
 															potential sensible energy that could be recovered. This value should be used for energy modeling when wattage for air movement is separately
 															accounted for in the energy model. Values for some products can be found at the Home Ventilating Institute (hvi.org).</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="FanPower"
-												type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>[W]</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="FanPower" type="HPXMLDouble">
+													<xs:annotation>
+														<xs:documentation>[W]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element maxOccurs="unbounded" minOccurs="0"
-												name="ThirdPartyCertification"
-												type="VentilationFanThirdPartyCertification"/>
-												<xs:element name="AttachedToHVACDistributionSystem"
-												type="LocalReference" minOccurs="0" maxOccurs="1">
-												<xs:annotation>
-												<xs:documentation>For central fan integrated supply mechanical ventilation, specifies the HVAC distribution system it is attached
+												<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="VentilationFanThirdPartyCertification"/>
+												<xs:element name="AttachedToHVACDistributionSystem" type="LocalReference" minOccurs="0" maxOccurs="1">
+													<xs:annotation>
+														<xs:documentation>For central fan integrated supply mechanical ventilation, specifies the HVAC distribution system it is attached
 															to.</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -1811,8 +1614,7 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="VentSystemType"
-										type="VentSystem"/>
+									<xs:element minOccurs="0" name="VentSystemType" type="VentSystem"/>
 									<xs:element minOccurs="0" ref="AttachedToZone"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
@@ -1832,68 +1634,56 @@
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
 									<xs:element minOccurs="0" ref="AttachedToZone"/>
-									<xs:element minOccurs="0" name="AttachedToCAZ"
-										type="LocalReference"/>
+									<xs:element minOccurs="0" name="AttachedToCAZ" type="LocalReference"/>
 									<xs:element name="FuelType" type="FuelType" minOccurs="0"/>
-									<xs:element name="WaterHeaterType" type="WaterHeaterType"
-										minOccurs="0"/>
+									<xs:element name="WaterHeaterType" type="WaterHeaterType" minOccurs="0"/>
 									<xs:element name="Location" type="UnitLocation" minOccurs="0"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
 									<xs:element name="ModelYear" type="Year" minOccurs="0"/>
-									<xs:element name="Manufacturer" type="Manufacturer"
-										minOccurs="0"/>
+									<xs:element name="Manufacturer" type="Manufacturer" minOccurs="0"/>
 									<xs:element name="ModelNumber" type="Model" minOccurs="0"/>
 									<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
-									<xs:element minOccurs="0" name="IsSharedSystem"
-										type="HPXMLBoolean">
+									<xs:element minOccurs="0" name="IsSharedSystem" type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Does the system serve multiple building/dwelling units or a shared laundry/equipment room?</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofUnitsServed"
-										type="HPXMLInteger"/>
-									<xs:element minOccurs="0" name="PerformanceAdjustment"
-										type="Fraction">
+									<xs:element minOccurs="0" name="NumberofUnitsServed" type="HPXMLInteger"/>
+									<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction">
 										<xs:annotation>
 											<xs:documentation>A multiplier on the performance of the system. A value of 1 implies no performance adjustment.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="ThirdPartyCertification"
-										type="DHWThirdPartyCertification" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="ThirdPartyCertification" type="DHWThirdPartyCertification" maxOccurs="unbounded"/>
 									<xs:element name="TankVolume" type="Volume" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[gal] Nominal capacity</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="MeasuredTankVolume" type="Volume"
-										minOccurs="0">
+									<xs:element name="MeasuredTankVolume" type="Volume" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[gal] Measured capacity</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FractionDHWLoadServed"
-										type="Fraction"/>
+									<xs:element minOccurs="0" name="FractionDHWLoadServed" type="Fraction"/>
 									<xs:element name="HeatingCapacity" type="Capacity" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[Btuh] For a heat pump water heater, the capacity of the heat pump.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="BackupHeatingCapacity" type="Capacity"
-										minOccurs="0">
+									<xs:element name="BackupHeatingCapacity" type="Capacity" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[Btuh] The capacity of the electric resistance heating in a heat pump water heater.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="EnergyFactor" type="EnergyFactor"
-										minOccurs="0">
+									<xs:element name="EnergyFactor" type="EnergyFactor" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>The amount of energy delivered as heated water in a day divided by the total daily energy consumption of a residential water heater, as
 												determined following standardized DOE testing procedure.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="UniformEnergyFactor" type="EnergyFactor"
-										minOccurs="0">
+									<xs:element name="UniformEnergyFactor" type="EnergyFactor" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>DOE’s new metric for communicating the energy efficiency of a residential water heater, which replaces the Energy Factor (EF) metric. More
 												efficient water heaters have a higher Uniform Energy Factor (UEF). UEF is determined by the Department of Energy’s test method outlined in 10 CFR Part
@@ -1905,22 +1695,19 @@
 											<xs:documentation>The dimensionless coefficient of performance, used to measure the efficiency of a commercial heat pump water heater.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HPWHOperatingMode"
-										type="HPWHOperatingMode"/>
+									<xs:element minOccurs="0" name="HPWHOperatingMode" type="HPWHOperatingMode"/>
 									<xs:element minOccurs="0" name="HPWHDucting">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="SupplyAirSource"
-												type="AdjacentTo">
-												<xs:annotation>
-												<xs:documentation>Where the air is supplied from; not the location where the supply ducts are running through.</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="SupplyAirSource" type="AdjacentTo">
+													<xs:annotation>
+														<xs:documentation>Where the air is supplied from; not the location where the supply ducts are running through.</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="ExhaustAirTermination" type="AdjacentTo">
-												<xs:annotation>
-												<xs:documentation>Where the air is exhausted to; not the location where the exhaust ducts are running through.</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="ExhaustAirTermination" type="AdjacentTo">
+													<xs:annotation>
+														<xs:documentation>Where the air is exhausted to; not the location where the exhaust ducts are running through.</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element ref="extension" minOccurs="0"/>
 											</xs:sequence>
@@ -1943,102 +1730,79 @@
 												nominal temperature rise of 77°F during steady state operation.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="RecoveryEfficiency" type="RecoveryEfficiency"
-										minOccurs="0">
+									<xs:element name="RecoveryEfficiency" type="RecoveryEfficiency" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>The ratio of energy delivered to heat cold water compared to the energy consumed by the water heater, as determined following standardized
 												DOE testing procedure.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ThermalEfficiency" type="ThermalEfficiency"
-										minOccurs="0"/>
+									<xs:element name="ThermalEfficiency" type="ThermalEfficiency" minOccurs="0"/>
 									<xs:element minOccurs="0" name="WaterHeaterInsulation">
 										<xs:complexType>
 											<xs:sequence>
 												<xs:element minOccurs="0" name="Jacket">
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element minOccurs="0"
-												name="InsulationMaterial"
-												type="InsulationMaterial"/>
-												<xs:element name="JacketRValue" type="RValue"
-												minOccurs="0"/>
-												<xs:element minOccurs="0" name="Thickness"
-												type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>[in]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												<xs:attribute name="dataSource" type="DataSource"
-												/>
-												</xs:complexType>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element minOccurs="0" name="InsulationMaterial" type="InsulationMaterial"/>
+															<xs:element name="JacketRValue" type="RValue" minOccurs="0"/>
+															<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+																<xs:annotation>
+																	<xs:documentation>[in]</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+														<xs:attribute name="dataSource" type="DataSource"/>
+													</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="TankWall">
-												<xs:annotation>
-												<xs:documentation>Refers to the insulation in the tank wall itself. This information is sometimes available on the water heater's name plate or
+													<xs:annotation>
+														<xs:documentation>Refers to the insulation in the tank wall itself. This information is sometimes available on the water heater's name plate or
 															the units specification sheet, or can be estimated by removing the water heater's access plate.</xs:documentation>
-												</xs:annotation>
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element minOccurs="0"
-												name="InsulationMaterial"
-												type="InsulationMaterial"/>
-												<xs:element name="TankWallRValue" type="RValue"
-												minOccurs="0"/>
-												<xs:element minOccurs="0" name="Thickness"
-												type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>[in]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												<xs:attribute name="dataSource" type="DataSource"
-												/>
-												</xs:complexType>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element minOccurs="0" name="InsulationMaterial" type="InsulationMaterial"/>
+															<xs:element name="TankWallRValue" type="RValue" minOccurs="0"/>
+															<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+																<xs:annotation>
+																	<xs:documentation>[in]</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+														<xs:attribute name="dataSource" type="DataSource"/>
+													</xs:complexType>
 												</xs:element>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="StandbyLoss"
-										type="StandbyLossType">
+									<xs:element minOccurs="0" name="StandbyLoss" type="StandbyLossType">
 										<xs:annotation>
 											<xs:documentation>The standby heat loss rate for, e.g., indirect or commercial water heaters. Published in the AHRI Consumer’s Directory of Certified Efficiency Ratings.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="MeetsACCA5QIHVACSpecification"
-										type="HPXMLBoolean" minOccurs="0"/>
-									<xs:element name="HotWaterTemperature" type="Temperature"
-										minOccurs="0">
+									<xs:element name="MeetsACCA5QIHVACSpecification" type="HPXMLBoolean" minOccurs="0"/>
+									<xs:element name="HotWaterTemperature" type="Temperature" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg F]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HasMixingValve"
-										type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="UsesDesuperheater"
-										type="HPXMLBoolean">
+									<xs:element minOccurs="0" name="HasMixingValve" type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="UsesDesuperheater" type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Indicates whether this water heater uses a desuperheater. The attached heat pump or air conditioner can be referenced in the
 												RelatedHVACSystem element.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HasSharedCombustionVentilation"
-										type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="CombustionVentilationOrphaned"
-										type="HPXMLBoolean"/>
-									<xs:element name="CombustionVentingSystem" minOccurs="0"
-										type="LocalReference"/>
-									<xs:element minOccurs="0" name="AutomaticVentDamper"
-										type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="HasSharedCombustionVentilation" type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="CombustionVentilationOrphaned" type="HPXMLBoolean"/>
+									<xs:element name="CombustionVentingSystem" minOccurs="0" type="LocalReference"/>
+									<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
 									<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
-										type="HPXMLBoolean"/>
-									<xs:element name="RelatedHVACSystem" type="LocalReference"
-										minOccurs="0">
+									<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
+									<xs:element name="RelatedHVACSystem" type="LocalReference" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>Reference a HeatingSystem, HeatPump, or CoolingSystem.</xs:documentation>
 										</xs:annotation>
@@ -2046,15 +1810,13 @@
 									<xs:element minOccurs="0" name="Installation">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="Standard"
-												type="HVACInstallationStandard"/>
+												<xs:element minOccurs="0" name="Standard" type="HVACInstallationStandard"/>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="WaterHeaterImprovement"
-										type="WaterHeaterImprovementInfo"/>
+									<xs:element minOccurs="0" name="WaterHeaterImprovement" type="WaterHeaterImprovementInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -2068,10 +1830,8 @@
 									<xs:element minOccurs="0" name="Model" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
-									<xs:element minOccurs="0" name="ControlTechnology"
-										type="DHWControllerTechnology"/>
-									<xs:element minOccurs="0" name="TemperatureControl"
-										type="DHWTemperatureControl"/>
+									<xs:element minOccurs="0" name="ControlTechnology" type="DHWControllerTechnology"/>
+									<xs:element minOccurs="0" name="TemperatureControl" type="DHWTemperatureControl"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -2081,8 +1841,7 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="AttachedToWaterHeatingSystem"
-										type="LocalReference">
+									<xs:element minOccurs="0" name="AttachedToWaterHeatingSystem" type="LocalReference">
 										<xs:annotation>
 											<xs:documentation>The water heating system that this distribution system serves.</xs:documentation>
 										</xs:annotation>
@@ -2091,73 +1850,61 @@
 										<xs:complexType>
 											<xs:choice>
 												<xs:element name="Standard">
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element minOccurs="0" name="PipingLength"
-												type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>Measured length of hot water piping from the hot water heater to the farthest hot water fixture, measured
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element minOccurs="0" name="PipingLength" type="LengthMeasurement">
+																<xs:annotation>
+																	<xs:documentation>Measured length of hot water piping from the hot water heater to the farthest hot water fixture, measured
 																		longitudinally from plans, assuming the hot water piping does not run diagonally, plus 10 feet of piping for each floor level,
 																		plus 5 feet of piping for unconditioned basements. [ft]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												<xs:attribute name="dataSource" type="DataSource"
-												/>
-												</xs:complexType>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+														<xs:attribute name="dataSource" type="DataSource"/>
+													</xs:complexType>
 												</xs:element>
 												<xs:element name="Recirculation">
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element minOccurs="0" name="ControlType"
-												type="RecirculationControlType"/>
-												<xs:element minOccurs="0"
-												name="RecirculationPipingLoopLength"
-												type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>Hot water recirculation loop piping length including both supply and return sides of the loop, measured
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element minOccurs="0" name="ControlType" type="RecirculationControlType"/>
+															<xs:element minOccurs="0" name="RecirculationPipingLoopLength" type="LengthMeasurement">
+																<xs:annotation>
+																	<xs:documentation>Hot water recirculation loop piping length including both supply and return sides of the loop, measured
 																		longitudinally from plans, assuming the hot water piping does not run diagonally. [ft]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0"
-												name="BranchPipingLength" type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>Length of the branch hot water piping from the recirculation loop to the farthest hot water fixture from the
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" name="BranchPipingLength" type="LengthMeasurement">
+																<xs:annotation>
+																	<xs:documentation>Length of the branch hot water piping from the recirculation loop to the farthest hot water fixture from the
 																		recirculation loop, measured longitudinally from plans, assuming the branch hot water piping does not run diagonally, plus 20
 																		feet of piping for each floor level greater than one plus 10 feet of piping for unconditioned basements. [ft]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" name="PumpPower"
-												type="Power">
-												<xs:annotation>
-												<xs:documentation>[W]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												<xs:attribute name="dataSource" type="DataSource"
-												/>
-												</xs:complexType>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" name="PumpPower" type="Power">
+																<xs:annotation>
+																	<xs:documentation>[W]</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+														<xs:attribute name="dataSource" type="DataSource"/>
+													</xs:complexType>
 												</xs:element>
 											</xs:choice>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="PipeInsulation"
-										type="PipeInsulationType"/>
+									<xs:element minOccurs="0" name="PipeInsulation" type="PipeInsulationType"/>
 									<xs:element minOccurs="0" name="DrainWaterHeatRecovery">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="FacilitiesConnected"
-												type="DrainWaterHeatRecoveryFacilitiesConnected"/>
-												<xs:element minOccurs="0" name="EqualFlow"
-												type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="Efficiency"
-												type="FractionExcludingZero">
-												<xs:annotation>
-												<xs:documentation>Efficiency percent expressed as a fraction from 0-1.</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="FacilitiesConnected" type="DrainWaterHeatRecoveryFacilitiesConnected"/>
+												<xs:element minOccurs="0" name="EqualFlow" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="Efficiency" type="FractionExcludingZero">
+													<xs:annotation>
+														<xs:documentation>Efficiency percent expressed as a fraction from 0-1.</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -2174,15 +1921,11 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:choice minOccurs="0">
-										<xs:element name="AttachedToWaterHeatingSystem"
-											type="LocalReference"/>
-										<xs:element name="AttachedToHotWaterDistribution"
-											type="LocalReference"/>
+										<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference"/>
+										<xs:element name="AttachedToHotWaterDistribution" type="LocalReference"/>
 									</xs:choice>
-									<xs:element minOccurs="1" name="WaterFixtureType"
-										type="WaterFixtureType"/>
-									<xs:element minOccurs="0" name="Count"
-										type="IntegerGreaterThanZero">
+									<xs:element minOccurs="1" name="WaterFixtureType" type="WaterFixtureType"/>
+									<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Number of similar water fixtures.</xs:documentation>
 										</xs:annotation>
@@ -2197,28 +1940,22 @@
 											<xs:documentation>Is the fixture considered low-flow?</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FaucetAerator"
-										type="HPXMLBoolean">
+									<xs:element minOccurs="0" name="FaucetAerator" type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Does this faucet have an aerator?</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="MinutesPerDay"
-										type="MinutesPerDay">
+									<xs:element minOccurs="0" name="MinutesPerDay" type="MinutesPerDay">
 										<xs:annotation>
 											<xs:documentation>[minutes] Number of minutes per day a water fixture operates.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0"
-										name="TemperatureInitiatedShowerFlowRestrictionValve"
-										type="HPXMLBoolean">
+									<xs:element minOccurs="0" name="TemperatureInitiatedShowerFlowRestrictionValve" type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Does the shower have a device that restricts the flow of water automatically once it has reached temperature?</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element maxOccurs="unbounded" minOccurs="0"
-										name="ThirdPartyCertification"
-										type="WaterFixtureThirdPartyCertification">
+									<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="WaterFixtureThirdPartyCertification">
 										<xs:annotation>
 											<xs:documentation>Independent organization has verified that product or appliance meets or exceeds the standard in question.</xs:documentation>
 										</xs:annotation>
@@ -2252,36 +1989,28 @@
 									<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="ModelNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" ref="AttachedToZone"/>
-									<xs:element name="SystemType" minOccurs="0"
-										type="SolarThermalSystemType"/>
-									<xs:element name="CollectorArea" type="SurfaceArea"
-										minOccurs="0">
+									<xs:element name="SystemType" minOccurs="0" type="SolarThermalSystemType"/>
+									<xs:element name="CollectorArea" type="SurfaceArea" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorLoopType"
-										type="SolarThermalCollectorLoopType"/>
-									<xs:element minOccurs="0" name="CollectorType"
-										type="SolarThermalCollectorType"/>
-									<xs:element minOccurs="0" name="CollectorOrientation"
-										type="OrientationType"/>
-									<xs:element minOccurs="0" name="CollectorAzimuth"
-										type="AzimuthType"/>
+									<xs:element minOccurs="0" name="CollectorLoopType" type="SolarThermalCollectorLoopType"/>
+									<xs:element minOccurs="0" name="CollectorType" type="SolarThermalCollectorType"/>
+									<xs:element minOccurs="0" name="CollectorOrientation" type="OrientationType"/>
+									<xs:element minOccurs="0" name="CollectorAzimuth" type="AzimuthType"/>
 									<xs:element minOccurs="0" name="CollectorTilt" type="Tilt">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorRatedOpticalEfficiency"
-										type="CollectorRatedOpticalEfficiency">
+									<xs:element minOccurs="0" name="CollectorRatedOpticalEfficiency" type="CollectorRatedOpticalEfficiency">
 										<xs:annotation>
 											<xs:documentation>[Btu/h-ft^2-F] Often referred to as Fr-tau-alpha (FRta), this describes the optical efficiency portion of the overall collector efficiency. 
 												In the OG-100 SRCC Certified Solar Thermal Collector Directory, this is the y-intercept of the efficiency curve.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorRatedThermalLosses"
-										type="CollectorRatedThermalLosses">
+									<xs:element minOccurs="0" name="CollectorRatedThermalLosses" type="CollectorRatedThermalLosses">
 										<xs:annotation>
 											<xs:documentation>Often referred to as Fr-Ul (FRUl), this describes the collector thermal losses portion of the overall collector efficiency. In the OG-100
 												SRCC Certified Solar Thermal Collector Directory, this is the slope of the efficiency curve.</xs:documentation>
@@ -2292,18 +2021,15 @@
 											<xs:documentation>[gal]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="ConnectedTo"
-										type="LocalReference"/>
-									<xs:element minOccurs="0" name="SolarFraction"
-										type="SolarFraction">
+									<xs:element minOccurs="0" name="ConnectedTo" type="LocalReference"/>
+									<xs:element minOccurs="0" name="SolarFraction" type="SolarFraction">
 										<xs:annotation>
 											<xs:documentation>The Solar Fraction is the portion of the total conventional hot water heating load (delivered energy and tank standby losses). The higher
 												the solar fraction, the greater the solar contribution to water heating, which reduces the energy required by the backup water heater. This value can be
 												found in the OG-300 SRCC Certified Solar Water Heating System Directory.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="SolarEnergyFactor"
-										type="SolarThermalSystemEnergyFactor">
+									<xs:element minOccurs="0" name="SolarEnergyFactor" type="SolarThermalSystemEnergyFactor">
 										<xs:annotation>
 											<xs:documentation>The Solar Energy Factor is defined as the energy delivered by the system divided by the electrical or gas energy put into the system. The
 												higher the number, the more energy efficient. This value can be found in the OG-300 SRCC Certified Solar Water Heating System
@@ -2327,23 +2053,17 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
-									<xs:element minOccurs="0" name="IsSharedSystem"
-										type="HPXMLBoolean">
+									<xs:element minOccurs="0" name="IsSharedSystem" type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Does the system serve multiple building/dwelling units?</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofUnitsServed"
-										type="HPXMLInteger"/>
-									<xs:element minOccurs="0" name="Location"
-										type="PVSystemLocation"/>
-									<xs:element minOccurs="0" name="Ownership"
-										type="PVSystemOwnership"/>
+									<xs:element minOccurs="0" name="NumberofUnitsServed" type="HPXMLInteger"/>
+									<xs:element minOccurs="0" name="Location" type="PVSystemLocation"/>
+									<xs:element minOccurs="0" name="Ownership" type="PVSystemOwnership"/>
 									<xs:element minOccurs="0" name="ModuleType" type="PVModuleType"/>
-									<xs:element maxOccurs="1" minOccurs="0" name="Tracking"
-										type="PVTracking"/>
-									<xs:element minOccurs="0" name="ArrayOrientation"
-										type="OrientationType"/>
+									<xs:element maxOccurs="1" minOccurs="0" name="Tracking" type="PVTracking"/>
+									<xs:element minOccurs="0" name="ArrayOrientation" type="OrientationType"/>
 									<xs:element minOccurs="0" name="ArrayAzimuth" type="AzimuthType">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
@@ -2359,40 +2079,33 @@
 											<xs:documentation>[DC Watts] Peak power as supplied by the manufacturer</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorArea"
-										type="SurfaceArea">
+									<xs:element minOccurs="0" name="CollectorArea" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberOfPanels"
-										type="IntegerGreaterThanZero"/>
-									<xs:element minOccurs="0" name="SystemLossesFraction"
-										type="Fraction">
+									<xs:element minOccurs="0" name="NumberOfPanels" type="IntegerGreaterThanZero"/>
+									<xs:element minOccurs="0" name="SystemLossesFraction" type="Fraction">
 										<xs:annotation>
 											<xs:documentation>System losses can be due to soiling, shading, snow, mismatch, wiring, electrical connections, light-induced degradation, nameplate rating
 												inaccuracies, age, and availability.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="YearModulesManufactured"
-										type="Year"/>
+									<xs:element minOccurs="0" name="YearModulesManufactured" type="Year"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
-									<xs:element minOccurs="0" name="AnnualOutput"
-										type="RatedAnnualkWh">
+									<xs:element minOccurs="0" name="AnnualOutput" type="RatedAnnualkWh">
 										<xs:annotation>
 											<xs:documentation>[kWh] Projected Annual Output for a typical meteorological year as determined by PVWatts or similar. </xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="LevelizedCostOfElectricity"
-										type="Cost">
+									<xs:element minOccurs="0" name="LevelizedCostOfElectricity" type="Cost">
 										<xs:annotation>
 											<xs:documentation>[$] The LCOE is the total cost of installing and operating a project expressed in dollars per kilowatt-hour of electricity generated by
 												the system over its life. Can be calculated with System Advisor Model, a similar software, or through a simplified calculation at
 												http://www.nrel.gov/analysis/tech_lcoe.html.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AttachedToInverter"
-										type="LocalReference"/>
+									<xs:element minOccurs="0" name="AttachedToInverter" type="LocalReference"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -2402,12 +2115,9 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="InverterType"
-										type="InverterType"/>
-									<xs:element minOccurs="0" name="InverterEfficiency"
-										type="FractionExcludingZero"/>
-									<xs:element minOccurs="0" name="YearInverterManufactured"
-										type="Year"/>
+									<xs:element minOccurs="0" name="InverterType" type="InverterType"/>
+									<xs:element minOccurs="0" name="InverterEfficiency" type="FractionExcludingZero"/>
+									<xs:element minOccurs="0" name="YearInverterManufactured" type="Year"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
@@ -2424,36 +2134,30 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="Manufacturer"
-										type="Manufacturer"/>
+									<xs:element minOccurs="0" name="Manufacturer" type="Manufacturer"/>
 									<xs:element minOccurs="0" name="ModelNumber" type="Model"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
-									<xs:element minOccurs="0" name="Count"
-										type="IntegerGreaterThanZero">
+									<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Number of similar batteries.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="Location" type="BatteryLocation"/>
-									<xs:element minOccurs="0" name="GridConnected"
-										type="HPXMLBoolean">
+									<xs:element minOccurs="0" name="GridConnected" type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Has the ability to feed electricity back on to the grid.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="BatteryType" type="BatteryType"/>
-									<xs:element minOccurs="0" name="CoolingStrategy"
-										type="BatteryCoolingStrategy"/>
-									<xs:element minOccurs="0" name="NominalCapacity"
-										type="BatteryCapacityType" maxOccurs="unbounded">
+									<xs:element minOccurs="0" name="CoolingStrategy" type="BatteryCoolingStrategy"/>
+									<xs:element minOccurs="0" name="NominalCapacity" type="BatteryCapacityType" maxOccurs="unbounded">
 										<xs:annotation>
 											<xs:documentation>The total energy available when the battery is discharged starting from 100% state of charge until it reaches the cut-off voltage.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="UsableCapacity"
-										type="BatteryCapacityType" maxOccurs="unbounded">
+									<xs:element minOccurs="0" name="UsableCapacity" type="BatteryCapacityType" maxOccurs="unbounded">
 										<xs:annotation>
 											<xs:documentation>The stored energy that can actually be used. In most cases usable capacity is less than the nominal capacity.</xs:documentation>
 										</xs:annotation>
@@ -2468,15 +2172,13 @@
 											<xs:documentation>[W] The peak power that the battery can generate for a short period of time.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NominalVoltage"
-										type="HPXMLDecimal">
+									<xs:element minOccurs="0" name="NominalVoltage" type="HPXMLDecimal">
 										<xs:annotation>
 											<xs:documentation>[V] The nominal voltage is the battery voltage when the state of charge is 0.5 (midway between being fully charged, and fully discharged)
 												with a 0.2C discharge current.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RoundTripEfficiency"
-										type="FractionExcludingZero">
+									<xs:element minOccurs="0" name="RoundTripEfficiency" type="FractionExcludingZero">
 										<xs:annotation>
 											<xs:documentation>Not all the power that is used to charge the battery is available during discharge. Round trip efficiency is the ratio of the energy put
 												in to the energy retrieved from storage.</xs:documentation>
@@ -2498,22 +2200,15 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="Count"
-										type="IntegerGreaterThanOrEqualToZero"/>
-									<xs:element minOccurs="0" name="Manufacturer"
-										type="Manufacturer"/>
-									<xs:element maxOccurs="1" minOccurs="0" name="ModelNumber"
-										type="Model"/>
+									<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanOrEqualToZero"/>
+									<xs:element minOccurs="0" name="Manufacturer" type="Manufacturer"/>
+									<xs:element maxOccurs="1" minOccurs="0" name="ModelNumber" type="Model"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
-									<xs:element minOccurs="0" name="ChargingLevel"
-										type="EVChargingLevel"/>
-									<xs:element minOccurs="0" name="ChargingConnector"
-										type="EVChargingConnector"/>
-									<xs:element maxOccurs="1" minOccurs="0" name="ModelYear"
-										type="Year"/>
-									<xs:element minOccurs="0" name="ACPowerSourceVoltage"
-										type="Voltage">
+									<xs:element minOccurs="0" name="ChargingLevel" type="EVChargingLevel"/>
+									<xs:element minOccurs="0" name="ChargingConnector" type="EVChargingConnector"/>
+									<xs:element maxOccurs="1" minOccurs="0" name="ModelYear" type="Year"/>
+									<xs:element minOccurs="0" name="ACPowerSourceVoltage" type="Voltage">
 										<xs:annotation>
 											<xs:documentation>[V] Voltage of the AC power source</xs:documentation>
 										</xs:annotation>
@@ -2551,17 +2246,14 @@
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" name="Model" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
-									<xs:element minOccurs="0" name="ThirdPartyCertification"
-										maxOccurs="unbounded" type="WindThirdPartyCertification"/>
-									<xs:element minOccurs="0" name="AWEARatedAnnualEnergy"
-										type="RatedAnnualkWh">
+									<xs:element minOccurs="0" name="ThirdPartyCertification" maxOccurs="unbounded" type="WindThirdPartyCertification"/>
+									<xs:element minOccurs="0" name="AWEARatedAnnualEnergy" type="RatedAnnualkWh">
 										<xs:annotation>
 											<xs:documentation>[kWh] the calculated total energy that would be produced during a one-year period with an average wind speed of 5 m/s (11.2
 												mph)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AWEARatedSoundLevel"
-										type="HPXMLDouble">
+									<xs:element minOccurs="0" name="AWEARatedSoundLevel" type="HPXMLDouble">
 										<xs:annotation>
 											<xs:documentation>[dBA] the sound pressure level not exceeded by the wind turbine 95% of the time at a distance of 60 meters from the rotor with an average
 												wind speed of 5 m/s (11.2 mph). </xs:documentation>
@@ -2578,20 +2270,17 @@
 											<xs:documentation>[kW] the highest point on the certified power curve.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RotorDiameter"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="RotorDiameter" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HubHeight"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="HubHeight" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="LevelizedCostOfElectricity"
-										type="Cost">
+									<xs:element minOccurs="0" name="LevelizedCostOfElectricity" type="Cost">
 										<xs:annotation>
 											<xs:documentation>[$] The LCOE is the total cost of installing and operating a project expressed in dollars per kilowatt-hour of electricity generated by
 												the system over its life. Can be calculated with System Advisor Model, a similar software, or through a simplified calculation at
@@ -2613,19 +2302,13 @@
 	</xs:complexType>
 	<xs:complexType name="Appliances">
 		<xs:sequence>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="ClothesWasher"
-				type="ClothesWasherInfoType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="ClothesDryer"
-				type="ClothesDryerInfoType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="Dishwasher"
-				type="DishwasherInfoType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="Refrigerator"
-				type="RefrigeratorInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="ClothesWasher" type="ClothesWasherInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="ClothesDryer" type="ClothesDryerInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="Dishwasher" type="DishwasherInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="Refrigerator" type="RefrigeratorInfoType"/>
 			<xs:element minOccurs="0" maxOccurs="unbounded" name="Freezer" type="FreezerInfoType"/>
-			<xs:element name="Dehumidifier" maxOccurs="unbounded" minOccurs="0"
-				type="DehumidifierInfoType"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="CookingRange"
-				type="CookingRangeInfoType"/>
+			<xs:element name="Dehumidifier" maxOccurs="unbounded" minOccurs="0" type="DehumidifierInfoType"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="CookingRange" type="CookingRangeInfoType"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="Oven" type="OvenInfoType"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
@@ -2668,15 +2351,13 @@
 								<xs:documentation>[W] per unit</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element maxOccurs="unbounded" minOccurs="0"
-							name="ThirdPartyCertification" type="LightingThirdPartyCertification"/>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="LightingThirdPartyCertification"/>
 						<xs:element name="AverageHoursPerDay" type="HoursPerDay" minOccurs="0">
 							<xs:annotation>
 								<xs:documentation>[h]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="LightingDailyHours"
-							type="LightingDailyHours">
+						<xs:element minOccurs="0" name="LightingDailyHours" type="LightingDailyHours">
 							<xs:annotation>
 								<xs:documentation>[h]</xs:documentation>
 							</xs:annotation>
@@ -2705,9 +2386,7 @@
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element minOccurs="0" ref="ConnectedDevice"/>
-						<xs:element maxOccurs="unbounded" minOccurs="0"
-							name="ThirdPartyCertification"
-							type="LightingFixtureThirdPartyCertification"/>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="LightingFixtureThirdPartyCertification"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -2718,11 +2397,9 @@
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element minOccurs="0" ref="ConnectedDevice"/>
-						<xs:element minOccurs="0" name="AttachedToLightingGroup"
-							type="LocalReference"/>
+						<xs:element minOccurs="0" name="AttachedToLightingGroup" type="LocalReference"/>
 						<xs:element name="LightingControlType" type="LightingControls" minOccurs="0"/>
-						<xs:element name="NumberofLightingControls"
-							type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+						<xs:element name="NumberofLightingControls" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
 						<xs:element name="Location" type="LightingLocation" minOccurs="0"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
@@ -2757,8 +2434,7 @@
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
-						<xs:element minOccurs="0" name="ThirdPartyCertification"
-							type="ApplianceThirdPartyCertifications" maxOccurs="unbounded"/>
+						<xs:element minOccurs="0" name="ThirdPartyCertification" type="ApplianceThirdPartyCertifications" maxOccurs="unbounded"/>
 						<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero">
 							<xs:annotation>
 								<xs:documentation>Number of similar ceiling fans.</xs:documentation>
@@ -2820,8 +2496,7 @@
 									<xs:element name="Sodium">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="Pressure"
-												type="SodiumLight_Pressure"/>
+												<xs:element minOccurs="0" name="Pressure" type="SodiumLight_Pressure"/>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
@@ -2865,8 +2540,7 @@
 								<xs:documentation>[gal] Volume of pool.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="MonthsPerYearofOperation"
-							type="MonthsPerYear">
+						<xs:element minOccurs="0" name="MonthsPerYearofOperation" type="MonthsPerYear">
 							<xs:annotation>
 								<xs:documentation>Months per year pool is in operation.</xs:documentation>
 							</xs:annotation>
@@ -2876,8 +2550,7 @@
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="SuctionPipeDiameter"
-							type="LengthMeasurement">
+						<xs:element minOccurs="0" name="SuctionPipeDiameter" type="LengthMeasurement">
 							<xs:annotation>
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
@@ -2899,109 +2572,91 @@
 											<xs:sequence>
 												<xs:group ref="SystemInfo"/>
 												<xs:element minOccurs="0" ref="ConnectedDevice"/>
-												<xs:element minOccurs="0" name="Type"
-												type="PoolPumpType"/>
-												<xs:element minOccurs="0" name="Manufacturer"
-												type="HPXMLString">
-												<xs:annotation>
-												<xs:documentation>Manufacturer of pool pump.</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="Type" type="PoolPumpType"/>
+												<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString">
+													<xs:annotation>
+														<xs:documentation>Manufacturer of pool pump.</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="SerialNumber"
-												type="HPXMLString">
-												<xs:annotation>
-												<xs:documentation>Serial number of pool pump.</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString">
+													<xs:annotation>
+														<xs:documentation>Serial number of pool pump.</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="ModelNumber"
-												type="HPXMLString">
-												<xs:annotation>
-												<xs:documentation>Model number of pool pump.</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="ModelNumber" type="HPXMLString">
+													<xs:annotation>
+														<xs:documentation>Model number of pool pump.</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="ThirdPartyCertification"
-												type="PoolPump3rdPartyCertification"
-												maxOccurs="unbounded">
-												<xs:annotation>
-												<xs:documentation>Independent organization has verified that product or appliance meets or exceeds the standard in question (ENERGY STAR, CEE,
+												<xs:element minOccurs="0" name="ThirdPartyCertification" type="PoolPump3rdPartyCertification" maxOccurs="unbounded">
+													<xs:annotation>
+														<xs:documentation>Independent organization has verified that product or appliance meets or exceeds the standard in question (ENERGY STAR, CEE,
 															or other)</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="EnergyFactor"
-												type="Efficiency">
-												<xs:annotation>
-												<xs:documentation>[gal/Wh] The measure of overall pool filter pump efficiency in units of gallons per watt-hour, as determined using the
+												<xs:element minOccurs="0" name="EnergyFactor" type="Efficiency">
+													<xs:annotation>
+														<xs:documentation>[gal/Wh] The measure of overall pool filter pump efficiency in units of gallons per watt-hour, as determined using the
 															applicable test method in Section 4.1.2. Energy factor is analogous to other energy factors such as miles per gallon. Energy factor (EF) is
 															calculated as: EF (gal/Wh) = flow rate (gpm) * 60 ÷ power (watts) (ANSI/APSP/ICC-15 2011).</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="SpeedSetting"
-												type="PoolPumpSpeedSetting">
-												<xs:annotation>
-												<xs:documentation>The speed setting at which the Energy Factor was measured (ENERGY STAR, 2013).</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="SpeedSetting" type="PoolPumpSpeedSetting">
+													<xs:annotation>
+														<xs:documentation>The speed setting at which the Energy Factor was measured (ENERGY STAR, 2013).</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="RatedHorsepower"
-												type="Power">
-												<xs:annotation>
-												<xs:documentation>The motor power output designed by the manufacturer for a rated RPM, voltage and frequency. May be less than total horsepower
+												<xs:element minOccurs="0" name="RatedHorsepower" type="Power">
+													<xs:annotation>
+														<xs:documentation>The motor power output designed by the manufacturer for a rated RPM, voltage and frequency. May be less than total horsepower
 															where the service factor is greater than 1.0, or equal to total horsepower where the service factor = 1.0 (ANSI/APSP/ICC-15
 															2011).</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="TotalHorsepower"
-												type="Power">
-												<xs:annotation>
-												<xs:documentation>The total horsepower, or product of the rated horsepower and the service factor of a motor used on a pool pump (also known as
+												<xs:element minOccurs="0" name="TotalHorsepower" type="Power">
+													<xs:annotation>
+														<xs:documentation>The total horsepower, or product of the rated horsepower and the service factor of a motor used on a pool pump (also known as
 															SFHP) based on the maximum continuous duty motor power output rating allowable for the nameplate ambient rating and motor insulation class
 															(e.g., total horsepower = rated horsepower * service factor) (ANSI/APSP/ICC-15 2011).</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="ServiceFactor"
-												type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>A multiplier applied to the rated horsepower of a pump motor to indicate the percent above nameplate horsepower at which the
+												<xs:element minOccurs="0" name="ServiceFactor" type="HPXMLDouble">
+													<xs:annotation>
+														<xs:documentation>A multiplier applied to the rated horsepower of a pump motor to indicate the percent above nameplate horsepower at which the
 															motor can operate continuously without exceeding its allowable insulation class temperature limit, provided that other design parameters,
 															such rated voltage, frequency and ambient temperature, are within limits. A 1.5 hp pump with a 1.65 service factor produces 2.475 hp (total
 															horsepower) at the maximum service factor point (ANSI/APSP/ICC-15 2011).</xs:documentation>
-												</xs:annotation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element maxOccurs="unbounded" minOccurs="0"
-												name="PumpSpeed">
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element minOccurs="0" name="Power"
-												type="Power">
-												<xs:annotation>
-												<xs:documentation>[W]</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" name="MotorNominalSpeed"
-												type="Speed">
-												<xs:annotation>
-												<xs:documentation>[Rev/min] The number of revolutions of the motor shaft in a given unit of time, expressed as revolutions per
+												<xs:element maxOccurs="unbounded" minOccurs="0" name="PumpSpeed">
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element minOccurs="0" name="Power" type="Power">
+																<xs:annotation>
+																	<xs:documentation>[W]</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" name="MotorNominalSpeed" type="Speed">
+																<xs:annotation>
+																	<xs:documentation>[Rev/min] The number of revolutions of the motor shaft in a given unit of time, expressed as revolutions per
 																		minute (RPM) (ENERGY STAR, 2013).</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" name="FlowRate"
-												type="FlowRate">
-												<xs:annotation>
-												<xs:documentation>[gal/min] The volume of water flowing through the filtration system in a given time, usually measured in gallons
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" name="FlowRate" type="FlowRate">
+																<xs:annotation>
+																	<xs:documentation>[gal/min] The volume of water flowing through the filtration system in a given time, usually measured in gallons
 																		per minute (gpm) (ANSI/APSP/ICC-15 2011).</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" name="HoursPerDay"
-												type="HoursPerDay">
-												<xs:annotation>
-												<xs:documentation>[hours] Number of hours per day a pool pump operates at a particular speed setting.</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												<xs:attribute name="dataSource" type="DataSource"
-												/>
-												</xs:complexType>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" name="HoursPerDay" type="HoursPerDay">
+																<xs:annotation>
+																	<xs:documentation>[hours] Number of hours per day a pool pump operates at a particular speed setting.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+														<xs:attribute name="dataSource" type="DataSource"/>
+													</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -3070,8 +2725,7 @@
 						<xs:element minOccurs="0" ref="AttachedToSpace"/>
 						<xs:element name="PlugLoadType" type="PlugLoadType" minOccurs="0"/>
 						<xs:element minOccurs="0" name="Location" type="PlugLoadLocation"/>
-						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero"
-							minOccurs="0"/>
+						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
 						<xs:element minOccurs="0" name="Load">
 							<xs:complexType>
 								<xs:sequence>
@@ -3093,10 +2747,8 @@
 						<xs:element minOccurs="0" ref="ConnectedDevice"/>
 						<xs:element minOccurs="0" name="ControlsPlugLoad" type="LocalReference"/>
 						<xs:element minOccurs="0" ref="AttachedToSpace"/>
-						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero"
-							minOccurs="0"/>
-						<xs:element name="PlugLoadControlType" minOccurs="0"
-							type="PlugLoadControlType"/>
+						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+						<xs:element name="PlugLoadControlType" minOccurs="0" type="PlugLoadControlType"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -3110,8 +2762,7 @@
 						<xs:element minOccurs="0" ref="AttachedToSpace"/>
 						<xs:element name="FuelLoadType" type="FuelLoadType" minOccurs="0"/>
 						<xs:element minOccurs="0" name="Location" type="FuelLoadLocation"/>
-						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero"
-							minOccurs="0"/>
+						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
 						<xs:element minOccurs="0" name="Load">
 							<xs:complexType>
 								<xs:sequence>
@@ -3145,14 +2796,10 @@
 			<xs:element name="Ventilation" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="WholeBuildingVentilationDesign"
-							type="WholeBldgVentDesignInfo"/>
-						<xs:element minOccurs="0" name="SpotVentilationDesign"
-							type="SpotVentDesignInfo"/>
-						<xs:element minOccurs="0" name="OtherVentilationIssues"
-							type="OtherVentIssues"/>
-						<xs:element minOccurs="0" name="VentilationImprovement"
-							type="VentilationImprovementInfo"/>
+						<xs:element minOccurs="0" name="WholeBuildingVentilationDesign" type="WholeBldgVentDesignInfo"/>
+						<xs:element minOccurs="0" name="SpotVentilationDesign" type="SpotVentDesignInfo"/>
+						<xs:element minOccurs="0" name="OtherVentilationIssues" type="OtherVentIssues"/>
+						<xs:element minOccurs="0" name="VentilationImprovement" type="VentilationImprovementInfo"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -3161,10 +2808,8 @@
 			<xs:element name="MoistureControl" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="MoistureControlInfo"
-							type="MoistureControlInfoType"/>
-						<xs:element minOccurs="0" name="MoistureControlImprovement"
-							type="MoistureControlImprovementInfo"/>
+						<xs:element maxOccurs="unbounded" name="MoistureControlInfo" type="MoistureControlInfoType"/>
+						<xs:element minOccurs="0" name="MoistureControlImprovement" type="MoistureControlImprovementInfo"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -3173,32 +2818,27 @@
 			<xs:element minOccurs="0" name="CombustionAppliances">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="MaxAmbientCOinLivingSpaceDuringAudit" minOccurs="0"
-							type="HPXMLDouble">
+						<xs:element name="MaxAmbientCOinLivingSpaceDuringAudit" minOccurs="0" type="HPXMLDouble">
 							<xs:annotation>
 								<xs:documentation>Monitored throughout assessment, not just appliance testing</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="CombustionApplianceZone"
-							maxOccurs="unbounded">
+						<xs:element minOccurs="0" name="CombustionApplianceZone" maxOccurs="unbounded">
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element name="CAZDepressurizationLimit"
-										type="CAZDepressurizationLimit" minOccurs="0">
+									<xs:element name="CAZDepressurizationLimit" type="CAZDepressurizationLimit" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>Pulled from industry standards by users (e.g. BPI Gold Sheet) or via software program</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="BaselineTest" type="CAZTestConfiguration"
-										minOccurs="0">
+									<xs:element name="BaselineTest" type="CAZTestConfiguration" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>Baseline pressure is read under the following conditions: no items running, all fans off, all exterior doors closed, and all interior
 												doors are opened.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="PoorCaseTest"
-										type="CAZTestConfiguration">
+									<xs:element minOccurs="0" name="PoorCaseTest" type="CAZTestConfiguration">
 										<xs:annotation>
 											<xs:documentation>The poor case CAZ depressurization test is configured by determining the largest combustion appliance zone depressurization attainable at
 												the time of testing due to the combined effects of door position, exhaust appliance operation, and air handler fan operation. A base pressure must be
@@ -3206,116 +2846,97 @@
 												depressurization attained at the time of testing and the base pressure.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="NetPressureChange" type="NetPressureChange"
-										minOccurs="0">
+									<xs:element name="NetPressureChange" type="NetPressureChange" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>With respect to the baseline pressure (e.g. no fans running, all exterior doors closed, and all interior doors opened)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="DepressurizationFindingPoorCase"
-										type="DepressurizationFindingPoorCase" minOccurs="0"/>
-									<xs:element name="AmountAmbientCOinCAZduringTesting"
-										type="HPXMLDouble" minOccurs="0">
+									<xs:element name="DepressurizationFindingPoorCase" type="DepressurizationFindingPoorCase" minOccurs="0"/>
+									<xs:element name="AmountAmbientCOinCAZduringTesting" type="HPXMLDouble" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>parts per million (ppm)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="AmbientCOinCAZExceeded35ppmduringTesting"
-										type="HPXMLBoolean" minOccurs="0"/>
-									<xs:element minOccurs="0" name="CombustionApplianceTest"
-										maxOccurs="unbounded">
+									<xs:element name="AmbientCOinCAZExceeded35ppmduringTesting" type="HPXMLBoolean" minOccurs="0"/>
+									<xs:element minOccurs="0" name="CombustionApplianceTest" maxOccurs="unbounded">
 										<xs:complexType>
 											<xs:sequence minOccurs="0">
-												<xs:element name="CAZAppliance"
-												type="RemoteReference">
-												<xs:annotation>
-												<xs:documentation>The ID of the system tested</xs:documentation>
-												</xs:annotation>
+												<xs:element name="CAZAppliance" type="RemoteReference">
+													<xs:annotation>
+														<xs:documentation>The ID of the system tested</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0"
-												name="CombustionVentingSystem"
-												type="RemoteReference"/>
-												<xs:element name="FlueVisualCondition"
-												type="FlueCondition" minOccurs="0"/>
-												<xs:element minOccurs="0" name="FlueConditionNotes"
-												type="HPXMLString"/>
-												<xs:element name="OutsideTemperatureFlueDraftTest"
-												type="Temperature" minOccurs="0">
-												<xs:annotation>
-												<xs:documentation>[deg F]</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="CombustionVentingSystem" type="RemoteReference"/>
+												<xs:element name="FlueVisualCondition" type="FlueCondition" minOccurs="0"/>
+												<xs:element minOccurs="0" name="FlueConditionNotes" type="HPXMLString"/>
+												<xs:element name="OutsideTemperatureFlueDraftTest" type="Temperature" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>[deg F]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="FlueDraftTest">
-												<xs:annotation>
-												<xs:documentation>[Pa]</xs:documentation>
-												</xs:annotation>
-												<xs:complexType>
-												<xs:complexContent>
-												<xs:extension base="CAZApplianceReading">
-												<xs:sequence>
-												<xs:element ref="extension" minOccurs="0"/>
-												</xs:sequence>
-												</xs:extension>
-												</xs:complexContent>
-												</xs:complexType>
+													<xs:annotation>
+														<xs:documentation>[Pa]</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:complexContent>
+															<xs:extension base="CAZApplianceReading">
+																<xs:sequence>
+																	<xs:element ref="extension" minOccurs="0"/>
+																</xs:sequence>
+															</xs:extension>
+														</xs:complexContent>
+													</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="SpillageTest">
-												<xs:annotation>
-												<xs:documentation>[seconds]</xs:documentation>
-												</xs:annotation>
-												<xs:complexType>
-												<xs:complexContent>
-												<xs:extension base="CAZApplianceReading">
-												<xs:sequence>
-												<xs:element ref="extension" minOccurs="0"/>
-												</xs:sequence>
-												</xs:extension>
-												</xs:complexContent>
-												</xs:complexType>
+													<xs:annotation>
+														<xs:documentation>[seconds]</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:complexContent>
+															<xs:extension base="CAZApplianceReading">
+																<xs:sequence>
+																	<xs:element ref="extension" minOccurs="0"/>
+																</xs:sequence>
+															</xs:extension>
+														</xs:complexContent>
+													</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="CarbonMonoxideTest">
-												<xs:annotation>
-												<xs:documentation>[ppm]</xs:documentation>
-												</xs:annotation>
-												<xs:complexType>
-												<xs:complexContent>
-												<xs:extension base="CAZApplianceReading">
-												<xs:sequence>
-												<xs:element minOccurs="0"
-												name="AmbientCOActionDuringCAZTesting"
-												type="HPXMLString">
-												<xs:annotation>
-												<xs:documentation>BPI Gold Sheet is one example that shows action levels based upon decision logic</xs:documentation>
-												</xs:annotation>
+													<xs:annotation>
+														<xs:documentation>[ppm]</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:complexContent>
+															<xs:extension base="CAZApplianceReading">
+																<xs:sequence>
+																	<xs:element minOccurs="0" name="AmbientCOActionDuringCAZTesting" type="HPXMLString">
+																		<xs:annotation>
+																			<xs:documentation>BPI Gold Sheet is one example that shows action levels based upon decision logic</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element minOccurs="0" ref="extension"/>
+																</xs:sequence>
+															</xs:extension>
+														</xs:complexContent>
+													</xs:complexType>
 												</xs:element>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												</xs:extension>
-												</xs:complexContent>
-												</xs:complexType>
+												<xs:element name="StackTemperature" type="Temperature" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>[deg F] after 10 minutes run time</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element name="StackTemperature"
-												type="Temperature" minOccurs="0">
-												<xs:annotation>
-												<xs:documentation>[deg F] after 10 minutes run time</xs:documentation>
-												</xs:annotation>
-												</xs:element>
-												<xs:element name="FuelLeaks" minOccurs="0"
-												maxOccurs="unbounded">
-												<xs:complexType>
-												<xs:sequence>
-												<xs:element name="FuelType" type="FuelType"/>
-												<xs:element name="LeaksIdentified"
-												type="HPXMLBoolean"/>
-												<xs:element name="LeaksAddressed"
-												type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="Notes"
-												type="HPXMLString"/>
-												<xs:element minOccurs="0" ref="extension"/>
-												</xs:sequence>
-												<xs:attribute name="dataSource" type="DataSource"
-												/>
-												</xs:complexType>
+												<xs:element name="FuelLeaks" minOccurs="0" maxOccurs="unbounded">
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="FuelType" type="FuelType"/>
+															<xs:element name="LeaksIdentified" type="HPXMLBoolean"/>
+															<xs:element name="LeaksAddressed" type="HPXMLBoolean"/>
+															<xs:element minOccurs="0" name="Notes" type="HPXMLString"/>
+															<xs:element minOccurs="0" ref="extension"/>
+														</xs:sequence>
+														<xs:attribute name="dataSource" type="DataSource"/>
+													</xs:complexType>
 												</xs:element>
 												<xs:element ref="extension" minOccurs="0"/>
 											</xs:sequence>
@@ -3337,8 +2958,7 @@
 					<xs:sequence>
 						<xs:element name="StoveID" type="SystemIdentifiersInfoType"/>
 						<xs:element minOccurs="0" name="StoveFuel" type="FuelType"/>
-						<xs:element name="HeatingStoveProperlyVented" type="HPXMLBoolean"
-							minOccurs="0"/>
+						<xs:element name="HeatingStoveProperlyVented" type="HPXMLBoolean" minOccurs="0"/>
 						<xs:element name="COReading" type="COReading" minOccurs="0"/>
 						<xs:element minOccurs="0" name="TimeofCOReading" type="HPXMLDateTime"/>
 						<xs:element name="GasLeaksIdentified" type="HPXMLBoolean" minOccurs="0"/>
@@ -3366,8 +2986,7 @@
 								<xs:documentation>Did the contracted scope of work include window replacement?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="LeadSafeCertificationNumber"
-							type="HPXMLString">
+						<xs:element minOccurs="0" name="LeadSafeCertificationNumber" type="HPXMLString">
 							<xs:annotation>
 								<xs:documentation>Certification Number of the EPA Lead-Safe Certified firm that performed the work.</xs:documentation>
 							</xs:annotation>
@@ -3385,34 +3004,27 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="StartDateTime"
-										type="HPXMLDateTime"/>
-									<xs:element minOccurs="0" name="EndDateTime"
-										type="HPXMLDateTime"/>
-									<xs:element minOccurs="0" name="TestLocation"
-										type="RadonTestLocation"/>
-									<xs:element name="RadonTestResults" type="HPXMLDouble"
-										minOccurs="0">
+									<xs:element minOccurs="0" name="StartDateTime" type="HPXMLDateTime"/>
+									<xs:element minOccurs="0" name="EndDateTime" type="HPXMLDateTime"/>
+									<xs:element minOccurs="0" name="TestLocation" type="RadonTestLocation"/>
+									<xs:element name="RadonTestResults" type="HPXMLDouble" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>in pCi/L</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RadonTestMethod"
-										type="RadonTestTypes"/>
+									<xs:element minOccurs="0" name="RadonTestMethod" type="RadonTestTypes"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
-						<xs:element minOccurs="0" name="EducationMaterialProvided"
-							type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="EducationMaterialProvided" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Was the homeowner provided with educational material?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element minOccurs="0" name="ActionsTaken" type="HPXMLString"/>
-						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecs"
-							type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecs" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>If moisture management of a crawlspace (e.g., installation of polyethylene sheeting) or radon mitigation measures were a part of the scope of
 									work,were measures installed to be compliant with one of the following: - Specifications of EPA’s Indoor airPLUS program - Techniques detailed in EPA's
@@ -3433,14 +3045,12 @@
 			<xs:element minOccurs="0" name="SourcePollutants">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="UnventedCombustionAppliancesinLivingArea"
-							type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="UnventedCombustionAppliancesinLivingArea" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Are there unvented combustion heating or hearth appliances present in the living area?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="ConformanceWithANSIZ21_11_2"
-							type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="ConformanceWithANSIZ21_11_2" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>If yes, does the appliance conform with ANSI Z21.11.2? </xs:documentation>
 							</xs:annotation>
@@ -3455,8 +3065,7 @@
 								<xs:documentation>Does home have attached garage?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="GarageContinuousAirBarrier"
-							type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="GarageContinuousAirBarrier" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>If yes, is there a continuous air barrier between garage and living space?</xs:documentation>
 							</xs:annotation>
@@ -3484,8 +3093,7 @@
 								<xs:documentation>Evidence of pesticide, insecticide use?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="IndustryStandardCompliance"
-							type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="IndustryStandardCompliance" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Do measures comply with industry standards to prevent pest entry? NOTE: This is for ALL measures that may create entry points for vermin. For example,
 									air sealing measures identified to reduce infiltration should have proper sealants - even if those measures were not recommended/installed for pest control
@@ -3515,11 +3123,9 @@
 								<xs:documentation>Was asbestos found?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="TypeofBlowerDoorTest"
-							type="TypeofBlowerDoorTest"/>
+						<xs:element minOccurs="0" name="TypeofBlowerDoorTest" type="TypeofBlowerDoorTest"/>
 						<xs:element minOccurs="0" name="ActionsTaken" type="HPXMLString"/>
-						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecifications"
-							type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecifications" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -3651,8 +3257,7 @@
 				</xs:element>
 				<xs:element name="RequiredVentilationRateUnits" type="VentilationRateUnits"/>
 			</xs:sequence>
-			<xs:element minOccurs="0" name="VentilationImprovementRecommendation"
-				type="Recommendation"/>
+			<xs:element minOccurs="0" name="VentilationImprovementRecommendation" type="Recommendation"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -3748,8 +3353,7 @@
 					<xs:documentation>should be represented as a fraction (ie 0.5 instead of 50%)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="EndUseSavings"
-				type="EndUseInfoType"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="EndUseSavings" type="EndUseInfoType"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -3789,19 +3393,16 @@
 					<xs:documentation>A multiplier on the performance of the system. A value of 1 implies no performance adjustment.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification"
-				type="HVACThirdPartyCertification"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="HVACThirdPartyCertification"/>
 			<xs:element minOccurs="0" name="HasSharedCombustionVentilation" type="HPXMLBoolean"/>
 			<xs:element minOccurs="0" name="CombustionVentingSystem" type="LocalReference"/>
-			<xs:element name="DistributionSystem" type="LocalReference" minOccurs="0"
-				maxOccurs="unbounded"/>
+			<xs:element name="DistributionSystem" type="LocalReference" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element minOccurs="0" name="Installation">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element minOccurs="0" name="Standard" type="HVACInstallationStandard"/>
 						<xs:element minOccurs="0" name="SizingCalculation" type="HVACSizingCalcs"/>
-						<xs:element minOccurs="0" name="EnvelopeImprovementsUsedinSizing"
-							type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="EnvelopeImprovementsUsedinSizing" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Air sealing and insulation implemented prior to replacement and used in calculations for sizing new / replacement system?</xs:documentation>
 							</xs:annotation>
@@ -3845,8 +3446,7 @@
 							<xs:documentation>[Btuh] Output Heating Capacity</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="AnnualHeatingEfficiency"
-						type="HeatingEfficiencyType" maxOccurs="unbounded"/>
+					<xs:element minOccurs="0" name="AnnualHeatingEfficiency" type="HeatingEfficiencyType" maxOccurs="unbounded"/>
 					<xs:element name="FractionHeatLoadServed" type="Fraction" minOccurs="0"/>
 					<xs:element minOccurs="0" name="FloorAreaServed" type="SurfaceArea">
 						<xs:annotation>
@@ -3862,8 +3462,7 @@
 					<xs:element minOccurs="0" name="HeatingDetailedPerformanceData">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element maxOccurs="unbounded" name="PerformanceDataPoint"
-									type="HeatingPerformanceDataPoint"> </xs:element>
+								<xs:element maxOccurs="unbounded" name="PerformanceDataPoint" type="HeatingPerformanceDataPoint"> </xs:element>
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -3883,8 +3482,7 @@
 						<xs:element minOccurs="0" name="PowerBurner" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
-						<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
-							type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="RetentionHead" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
@@ -3904,8 +3502,7 @@
 						<xs:element minOccurs="0" name="RotaryCup" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
-						<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
-							type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="RetentionHead" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
@@ -3915,8 +3512,7 @@
 			<xs:element name="ElectricResistance">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="ElectricDistribution" type="ElectricDistributionType"
-							minOccurs="0"/>
+						<xs:element name="ElectricDistribution" type="ElectricDistributionType" minOccurs="0"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -3932,8 +3528,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
-						<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
-							type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -3949,8 +3544,7 @@
 						</xs:element>
 						<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
-						<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
-							type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -4034,8 +3628,7 @@
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="BackupSystemFuel" type="FuelType" minOccurs="0"/>
-					<xs:element name="BackupAnnualHeatingEfficiency" minOccurs="0"
-						type="HeatingEfficiencyType" maxOccurs="unbounded"/>
+					<xs:element name="BackupAnnualHeatingEfficiency" minOccurs="0" type="HeatingEfficiencyType" maxOccurs="unbounded"/>
 					<xs:element minOccurs="0" name="BackupHeatingInputRating" type="Capacity">
 						<xs:annotation>
 							<xs:documentation>[Btuh] Input heating capacity</xs:documentation>
@@ -4046,14 +3639,12 @@
 							<xs:documentation>[Btuh] Output heating capacity</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="BackupHeatingSwitchoverTemperature"
-						type="Temperature">
+					<xs:element minOccurs="0" name="BackupHeatingSwitchoverTemperature" type="Temperature">
 						<xs:annotation>
 							<xs:documentation>[deg F] Temperature at which the backup heating is activated and the compressor is disabled in, e.g., a dual-fuel heat pump.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="BackupHeatingLockoutTemperature"
-						type="Temperature">
+					<xs:element minOccurs="0" name="BackupHeatingLockoutTemperature" type="Temperature">
 						<xs:annotation>
 							<xs:documentation>[deg F] Temperature above which the backup heating is disabled, often to prevent backup heating usage during recovery from a thermostat heating setback. For a duel-fuel heat pump, use the BackupHeatingSwitchoverTemperature element.</xs:documentation>
 						</xs:annotation>
@@ -4065,24 +3656,20 @@
 							<xs:documentation>[sq.ft.]</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType"
-						minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="AnnualHeatingEfficiency" minOccurs="0"
-						type="HeatingEfficiencyType" maxOccurs="unbounded"/>
+					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="AnnualHeatingEfficiency" minOccurs="0" type="HeatingEfficiencyType" maxOccurs="unbounded"/>
 					<xs:element minOccurs="0" name="AttachedToGeothermalLoop" type="LocalReference"/>
 					<xs:element minOccurs="0" name="CoolingDetailedPerformanceData">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element maxOccurs="unbounded" name="PerformanceDataPoint"
-									type="CoolingPerformanceDataPoint"> </xs:element>
+								<xs:element maxOccurs="unbounded" name="PerformanceDataPoint" type="CoolingPerformanceDataPoint"> </xs:element>
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
 					<xs:element minOccurs="0" name="HeatingDetailedPerformanceData">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element maxOccurs="unbounded" name="PerformanceDataPoint"
-									type="HeatingPerformanceDataPoint"> </xs:element>
+								<xs:element maxOccurs="unbounded" name="PerformanceDataPoint" type="HeatingPerformanceDataPoint"> </xs:element>
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -4109,14 +3696,12 @@
 							<xs:documentation>[sq.ft.]</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType"
-						minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType" minOccurs="0" maxOccurs="unbounded"/>
 					<xs:element minOccurs="0" name="SensibleHeatFraction" type="Fraction"/>
 					<xs:element minOccurs="0" name="CoolingDetailedPerformanceData">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element maxOccurs="unbounded" name="PerformanceDataPoint"
-									type="CoolingPerformanceDataPoint"> </xs:element>
+								<xs:element maxOccurs="unbounded" name="PerformanceDataPoint" type="CoolingPerformanceDataPoint"> </xs:element>
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -4257,8 +3842,7 @@
 				</xs:annotation>
 			</xs:element>
 			<xs:element minOccurs="0" name="PipeDiameter" type="PipeDiameterType"/>
-			<xs:element name="HydronicDistributionType" type="HydronicDistributionType"
-				minOccurs="0"/>
+			<xs:element name="HydronicDistributionType" type="HydronicDistributionType" minOccurs="0"/>
 			<xs:element minOccurs="0" name="SupplyTemperature" type="Temperature">
 				<xs:annotation>
 					<xs:documentation>[degF]</xs:documentation>
@@ -4277,8 +3861,7 @@
 								<xs:documentation>System Pump and Zone Valve Corrections made</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="ThermostaticRadiatorValves"
-							type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="ThermostaticRadiatorValves" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="VariableSpeedPump" type="HPXMLBoolean"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -4292,8 +3875,7 @@
 		<xs:sequence>
 			<xs:element name="AirDistributionType" type="AirDistributionType" minOccurs="0"/>
 			<xs:element name="AirHandlerMotorType" type="AirHandlerMotorType" minOccurs="0"/>
-			<xs:element minOccurs="0" name="DuctLeakageMeasurement"
-				type="DuctLeakageMeasurementType" maxOccurs="unbounded"/>
+			<xs:element minOccurs="0" name="DuctLeakageMeasurement" type="DuctLeakageMeasurementType" maxOccurs="unbounded"/>
 			<xs:element minOccurs="0" name="DuctSystemSizingAppropriate" type="HPXMLBoolean"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="Ducts">
 				<xs:complexType>
@@ -4301,23 +3883,19 @@
 						<xs:group ref="SystemInfo"/>
 						<xs:element name="DuctType" type="DuctType" minOccurs="0"/>
 						<xs:element name="DuctMaterial" type="DuctMaterial" minOccurs="0"/>
-						<xs:element minOccurs="0" name="DuctInsulationMaterial"
-							type="InsulationMaterial"/>
+						<xs:element minOccurs="0" name="DuctInsulationMaterial" type="InsulationMaterial"/>
 						<xs:element name="DuctInsulationRValue" type="RValue" minOccurs="0">
 							<xs:annotation>
 								<xs:documentation>This should exclude the exterior air film -- e.g., use zero for uninsulated ducts. For ducts buried in insulation, this should only represent any surrounding insulation duct wrap and not the entire attic insulation R-value.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DuctInsulationThickness"
-							type="LengthMeasurement">
+						<xs:element minOccurs="0" name="DuctInsulationThickness" type="LengthMeasurement">
 							<xs:annotation>
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DuctInsulationCondition"
-							type="InsulationCondition"/>
-						<xs:element minOccurs="0" name="DuctBuriedInsulationLevel"
-							type="DuctBuriedInsulationLevel">
+						<xs:element minOccurs="0" name="DuctInsulationCondition" type="InsulationCondition"/>
+						<xs:element minOccurs="0" name="DuctBuriedInsulationLevel" type="DuctBuriedInsulationLevel">
 							<xs:annotation>
 								<xs:documentation>Describes ducts buried in, e.g., attic loose-fill insulation. Partially buried ducts have insulation that does not cover the top of the ducts. Fully buried ducts have insulation that just covers the top of the ducts. Deeply buried ducts have insulation that continues above the top of the ducts. See https://basc.pnnl.gov/resource-guides/ducts-buried-attic-insulation for more information.</xs:documentation>
 							</xs:annotation>
@@ -4344,15 +3922,12 @@
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="NumberofReturnRegisters"
-				type="IntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="NumberofReturnRegisters" type="IntegerGreaterThanOrEqualToZero"/>
 			<xs:element minOccurs="0" name="TotalExternalStaticPressureMeasurement">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="Supply"
-							type="TotalExternalStaticPressureMeasurement"/>
-						<xs:element minOccurs="0" name="Return"
-							type="TotalExternalStaticPressureMeasurement"/>
+						<xs:element minOccurs="0" name="Supply" type="TotalExternalStaticPressureMeasurement"/>
+						<xs:element minOccurs="0" name="Return" type="TotalExternalStaticPressureMeasurement"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -4402,61 +3977,50 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:element minOccurs="0" name="SiteType" type="SiteType"/>
-									<xs:element minOccurs="0" name="Surroundings"
-										type="Surroundings">
+									<xs:element minOccurs="0" name="Surroundings" type="Surroundings">
 										<xs:annotation>
 											<xs:documentation>If the building is attached to other units in the horizontal plane.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="VerticalSurroundings"
-										type="VerticalSurroundings">
+									<xs:element minOccurs="0" name="VerticalSurroundings" type="VerticalSurroundings">
 										<xs:annotation>
 											<xs:documentation>If the building is attached to other units on the vertical plane.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ShieldingofHome" type="ShieldingofHome"
-										minOccurs="0"/>
-									<xs:element minOccurs="0" name="OrientationOfFrontOfHome"
-										type="OrientationType"/>
-									<xs:element minOccurs="0" name="AzimuthOfFrontOfHome"
-										type="AzimuthType"/>
+									<xs:element name="ShieldingofHome" type="ShieldingofHome" minOccurs="0"/>
+									<xs:element minOccurs="0" name="OrientationOfFrontOfHome" type="OrientationType"/>
+									<xs:element minOccurs="0" name="AzimuthOfFrontOfHome" type="AzimuthType"/>
 									<xs:element minOccurs="0" name="PublicTransportation">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="DistanceFromSubway"
-												type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>[ft]</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="DistanceFromSubway" type="LengthMeasurement">
+													<xs:annotation>
+														<xs:documentation>[ft]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="DistanceFromBus"
-												type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>[ft]</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="DistanceFromBus" type="LengthMeasurement">
+													<xs:annotation>
+														<xs:documentation>[ft]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="DistanceFromTrain"
-												type="LengthMeasurement">
-												<xs:annotation>
-												<xs:documentation>[ft]</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="DistanceFromTrain" type="LengthMeasurement">
+													<xs:annotation>
+														<xs:documentation>[ft]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="WalkingScore"
-										type="IntegerGreaterThanOrEqualToZero"/>
-									<xs:element minOccurs="0" name="WalkingScoreSource"
-										type="HPXMLString"/>
+									<xs:element minOccurs="0" name="WalkingScore" type="IntegerGreaterThanOrEqualToZero"/>
+									<xs:element minOccurs="0" name="WalkingScoreSource" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="FuelTypesAvailable">
 										<xs:annotation>
 											<xs:documentation>Fuels available on site via utility lines/pipes or delivery.</xs:documentation>
 										</xs:annotation>
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element maxOccurs="unbounded" name="Fuel"
-												type="FuelType"/>
+												<xs:element maxOccurs="unbounded" name="Fuel" type="FuelType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -4464,15 +4028,12 @@
 									<xs:element minOccurs="0" name="Soil">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="SoilType"
-												type="SoilType"/>
-												<xs:element minOccurs="0" name="MoistureType"
-												type="MoisureType"/>
-												<xs:element minOccurs="0" name="Conductivity"
-												type="HPXMLDouble">
-												<xs:annotation>
-												<xs:documentation>[Btu/hr-ft-F]</xs:documentation>
-												</xs:annotation>
+												<xs:element minOccurs="0" name="SoilType" type="SoilType"/>
+												<xs:element minOccurs="0" name="MoistureType" type="MoisureType"/>
+												<xs:element minOccurs="0" name="Conductivity" type="HPXMLDouble">
+													<xs:annotation>
+														<xs:documentation>[Btu/hr-ft-F]</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -4486,47 +4047,38 @@
 						<xs:element minOccurs="0" name="BuildingOccupancy">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element minOccurs="0" name="HouseholdType"
-										type="HouseholdType"/>
+									<xs:element minOccurs="0" name="HouseholdType" type="HouseholdType"/>
 									<xs:element minOccurs="0" name="YearOccupied" type="Year">
 										<xs:annotation>
 											<xs:documentation>The year the current occupants moved into the building</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="ResidentPopulationType"
-										type="ResidentPopulationType"/>
+									<xs:element minOccurs="0" name="ResidentPopulationType" type="ResidentPopulationType"/>
 									<xs:element minOccurs="0" name="Occupancy" type="Occupancy"/>
-									<xs:element name="NumberofResidents" type="PeopleCount"
-										minOccurs="0"/>
-									<xs:element minOccurs="0" name="NumberofAdults"
-										type="PeopleCount">
+									<xs:element name="NumberofResidents" type="PeopleCount" minOccurs="0"/>
+									<xs:element minOccurs="0" name="NumberofAdults" type="PeopleCount">
 										<xs:annotation>
 											<xs:documentation>18 or older</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofChildren"
-										type="IntegerGreaterThanOrEqualToZero">
+									<xs:element minOccurs="0" name="NumberofChildren" type="IntegerGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>less than 18 years old</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="PubliclySubsidized"
-										type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="PubliclySubsidized" type="HPXMLBoolean"/>
 									<xs:element minOccurs="0" name="LowIncome" type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="OccupantIncomeRange"
-										type="FractionGreaterThanOne">
+									<xs:element minOccurs="0" name="OccupantIncomeRange" type="FractionGreaterThanOne">
 										<xs:annotation>
 											<xs:documentation>Percentage as a fraction (50% = 0.5)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="OccupantIncomeRangeUnits"
-										type="OccupantIncomeRangeUnits">
+									<xs:element minOccurs="0" name="OccupantIncomeRangeUnits" type="OccupantIncomeRangeUnits">
 										<xs:annotation>
 											<xs:documentation>AMI = Area Median Income; FPL = Federal Poverty Level</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HighestLevelofOccupantEducation"
-										type="EducationLevels"/>
+									<xs:element minOccurs="0" name="HighestLevelofOccupantEducation" type="EducationLevels"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -4536,90 +4088,71 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:element name="YearBuilt" type="Year" minOccurs="0"/>
-									<xs:element minOccurs="0" name="YearBuiltKnownOrEstimated"
-										type="KnownOrEstimated"/>
+									<xs:element minOccurs="0" name="YearBuiltKnownOrEstimated" type="KnownOrEstimated"/>
 									<xs:element minOccurs="0" name="YearofLastRemodel" type="Year"/>
-									<xs:element name="ResidentialFacilityType"
-										type="ResidentialFacilityType" minOccurs="0"/>
-									<xs:element minOccurs="0" name="PassiveSolar"
-										type="HPXMLBoolean">
+									<xs:element name="ResidentialFacilityType" type="ResidentialFacilityType" minOccurs="0"/>
+									<xs:element minOccurs="0" name="PassiveSolar" type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Passive solar design—also known as climatic design—involves using a building's windows, walls, and floors to collect, store, and
 												distribute solar energy in the form of heat in the winter and reject solar heat in the summer. (source:
 												http://www.eere.energy.gov/basics/buildings/passive_solar_design.html)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="BuildingHeight"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="BuildingHeight" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] height of building</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofUnits"
-										type="IntegerGreaterThanZero">
+									<xs:element minOccurs="0" name="NumberofUnits" type="IntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Number of dwelling units represented by the HPXML Building element. Used as a multiplier.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofUnitsInBuilding"
-										type="IntegerGreaterThanZero">
+									<xs:element minOccurs="0" name="NumberofUnitsInBuilding" type="IntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Total number of dwelling units in the physical building.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofFloors"
-										type="NumberOfFloorsType">
+									<xs:element minOccurs="0" name="NumberofFloors" type="NumberOfFloorsType">
 										<xs:annotation>
 											<xs:documentation>Total number of floors including a basement, whether conditioned or unconditioned</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofConditionedFloors"
-										type="NumberOfFloorsType">
+									<xs:element minOccurs="0" name="NumberofConditionedFloors" type="NumberOfFloorsType">
 										<xs:annotation>
 											<xs:documentation>Number of floors that are heated/cooled including a basement</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0"
-										name="NumberofConditionedFloorsAboveGrade"
-										type="NumberOfFloorsType">
+									<xs:element minOccurs="0" name="NumberofConditionedFloorsAboveGrade" type="NumberOfFloorsType">
 										<xs:annotation>
 											<xs:documentation>Number of floors above grade that are heated/cooled</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="AverageCeilingHeight" type="LengthMeasurement"
-										minOccurs="0">
+									<xs:element name="AverageCeilingHeight" type="LengthMeasurement" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[ft] Average distance from the floor to the ceiling</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FloorToFloorHeight"
-										type="LengthMeasurement">
+									<xs:element minOccurs="0" name="FloorToFloorHeight" type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] distance between floors</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofRooms"
-										type="IntegerGreaterThanZero"/>
-									<xs:element name="NumberofBedrooms"
-										type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
-									<xs:element name="NumberofBathrooms"
-										type="IntegerGreaterThanZero" minOccurs="0"/>
-									<xs:element minOccurs="0" name="NumberofCompleteBathrooms"
-										type="IntegerGreaterThanZero">
+									<xs:element minOccurs="0" name="NumberofRooms" type="IntegerGreaterThanZero"/>
+									<xs:element name="NumberofBedrooms" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+									<xs:element name="NumberofBathrooms" type="IntegerGreaterThanZero" minOccurs="0"/>
+									<xs:element minOccurs="0" name="NumberofCompleteBathrooms" type="IntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Number of bathrooms with a tub or shower</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="BuildingFootprintArea"
-										type="SurfaceArea">
+									<xs:element minOccurs="0" name="BuildingFootprintArea" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FootprintShape"
-										type="FootprintShape"/>
-									<xs:element minOccurs="0" name="GrossFloorArea"
-										type="SurfaceArea">
+									<xs:element minOccurs="0" name="FootprintShape" type="FootprintShape"/>
+									<xs:element minOccurs="0" name="GrossFloorArea" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Gross floor area (based on ASHRAE definition) is the sum of the floor areas of the spaces within the building, including
 												basements, mezzanine and intermediate‐floored tiers, and penthouses with headroom height of 7.5 ft (2.2 meters) or greater. Measurements must be taken
@@ -4637,39 +4170,33 @@
 												area.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ConditionedFloorArea" type="SurfaceArea"
-										minOccurs="0">
+									<xs:element name="ConditionedFloorArea" type="SurfaceArea" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] All finished space that is within the (insulated) conditioned space boundary (that is, within the insulated envelope), regardless
 												of HVAC configuration.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FinishedFloorArea"
-										type="SurfaceArea">
+									<xs:element minOccurs="0" name="FinishedFloorArea" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Floor area of home that is finished and assumed to be occupied.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="NumberofStoriesAboveGrade"
-										type="IntegerGreaterThanZero" minOccurs="0"/>
-									<xs:element minOccurs="0" name="CooledFloorArea"
-										type="SurfaceArea">
+									<xs:element name="NumberofStoriesAboveGrade" type="IntegerGreaterThanZero" minOccurs="0"/>
+									<xs:element minOccurs="0" name="CooledFloorArea" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] The total area of all enclosed spaces measured to the internal face of the external walls. Included are areas of sloping surfaces
 												such as staircases, galleries, raked auditoria, and tiered terraces where the area taken is from the area on the plan. Excluded are areas that are not
 												enclosed such as open floors, covered ways and balconies.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HeatedFloorArea"
-										type="SurfaceArea">
+									<xs:element minOccurs="0" name="HeatedFloorArea" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] The total area of all enclosed spaces measured to the internal face of the external walls. Included are areas of sloping surfaces
 												such as staircases, galleries, raked auditoria, and tiered terraces where the area taken is from the area on the plan. Excluded are areas that are not
 												enclosed such as open floors, covered ways and balconies.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="UnconditionedFloorArea"
-										type="SurfaceArea">
+									<xs:element minOccurs="0" name="UnconditionedFloorArea" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] An enclosed space within a building that does not meet the requirements of a conditioned space. Spaces that have no control over
 												thermal conditions but intentionally or unintentionally receive thermal energy from adjacent spaces are considered unconditioned spaces (such as an
@@ -4685,8 +4212,7 @@
 												building.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ConditionedBuildingVolume" type="Volume"
-										minOccurs="0">
+									<xs:element name="ConditionedBuildingVolume" type="Volume" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[cu.ft.] Volume inside the building envelope of the conditioned spaces. This metric can be calculated as the volume of the building if
 												every space is conditioned or on a floor-by-floor basis. For spaces with vertical walls and horizontal ceilings and floors, this is calculated as the
@@ -4696,8 +4222,7 @@
 												return air plenums.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="FoundationType" minOccurs="0"
-										type="FoundationType">
+									<xs:element name="FoundationType" minOccurs="0" type="FoundationType">
 										<xs:annotation>
 											<xs:documentation>Primary foundation type of building</xs:documentation>
 										</xs:annotation>
@@ -4707,20 +4232,14 @@
 											<xs:documentation>Primary attic type of building</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="AverageAtticRValue" type="RValue"
-										minOccurs="0"/>
+									<xs:element name="AverageAtticRValue" type="RValue" minOccurs="0"/>
 									<xs:element name="AverageWallRValue" type="RValue" minOccurs="0"/>
-									<xs:element name="AverageFloorRValue" type="RValue"
-										minOccurs="0"/>
+									<xs:element name="AverageFloorRValue" type="RValue" minOccurs="0"/>
 									<xs:element name="AverageDuctRValue" type="RValue" minOccurs="0"/>
-									<xs:element minOccurs="0" name="GaragePresent"
-										type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="GarageLocation"
-										type="GarageLocation"/>
-									<xs:element minOccurs="0" name="SpaceAboveGarage"
-										type="SpaceAboveGarage"/>
-									<xs:element minOccurs="0" name="ManufacturedHomeSections"
-										type="ManufacturedHomeSections">
+									<xs:element minOccurs="0" name="GaragePresent" type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="GarageLocation" type="GarageLocation"/>
+									<xs:element minOccurs="0" name="SpaceAboveGarage" type="SpaceAboveGarage"/>
+									<xs:element minOccurs="0" name="ManufacturedHomeSections" type="ManufacturedHomeSections">
 										<xs:annotation>
 											<xs:documentation>The number of sections (width) of the manufactured home. CrossMod is a new style of manufactured home with more flexibility in configuration, higher roof pitch, covered porches, and garages or carports. They look more like a site-built single family detached home, but are manufactured in a factory and assembled on site. </xs:documentation>
 										</xs:annotation>
@@ -4733,8 +4252,7 @@
 						<xs:element name="AnnualEnergyUse" minOccurs="0">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"
-										maxOccurs="unbounded"/>
+									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType" maxOccurs="unbounded"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
@@ -4748,15 +4266,13 @@
 				<xs:complexType>
 					<xs:sequence minOccurs="0">
 						<xs:element name="ClimateZoneDOE" type="ClimateZoneDOE" minOccurs="0"/>
-						<xs:element name="ClimateZoneIECC" minOccurs="0" type="IECCClimateZoneType"
-							maxOccurs="unbounded"/>
+						<xs:element name="ClimateZoneIECC" minOccurs="0" type="IECCClimateZoneType" maxOccurs="unbounded"/>
 						<xs:element name="RadonZone" type="RadonZone" minOccurs="0"/>
 						<xs:element name="TermiteZone" type="TermiteZone" minOccurs="0"/>
 						<xs:element name="HurricaneZone" type="HPXMLBoolean" minOccurs="0"/>
 						<xs:element name="FloodZone" type="HPXMLBoolean" minOccurs="0"/>
 						<xs:element name="EarthquakeZone" type="EarthquakeZone" minOccurs="0"/>
-						<xs:element maxOccurs="unbounded" minOccurs="0" name="WeatherStation"
-							type="WeatherStation">
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="WeatherStation" type="WeatherStation">
 							<xs:annotation>
 								<xs:documentation>Weather location used in model simulation and/or utility bill regression analysis</xs:documentation>
 							</xs:annotation>
@@ -4810,15 +4326,13 @@
 												which is the purpose of this field.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Source"
-										type="GreenBuildingVerificationSource">
+									<xs:element minOccurs="0" name="Source" type="GreenBuildingVerificationSource">
 										<xs:annotation>
 											<xs:documentation>The source of the green data. May address photovoltaic characteristics, or a verified score, certification, label, etc. This may be a pick
 												list of options showing the source. i.e. Program Sponsor, Program Verifier, Public Record, Assessor, etc.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Status"
-										type="GreenBuildingVerificationStatus">
+									<xs:element minOccurs="0" name="Status" type="GreenBuildingVerificationStatus">
 										<xs:annotation>
 											<xs:documentation>Many verification programs include a multi-step process that may begin with plans and specs, involve testing and/or submission of building
 												specifications along the way and include a final verification step. When ratings are involved it is not uncommon for the final rating to be either
@@ -4909,14 +4423,12 @@
 			<xs:element name="Incentives" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="Incentive"
-							type="IncentiveDetailsType"/>
+						<xs:element maxOccurs="unbounded" name="Incentive" type="IncentiveDetailsType"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType"
-				maxOccurs="2"/>
+			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType" maxOccurs="2"/>
 			<xs:element maxOccurs="2" minOccurs="0" name="WaterSavingsInfo" type="WaterSavingsType"/>
 			<xs:element minOccurs="0" name="Measures">
 				<xs:complexType>
@@ -4932,10 +4444,8 @@
 	</xs:complexType>
 	<xs:complexType name="TotalCostType">
 		<xs:sequence>
-			<xs:element name="TotalCostHealthSafetyMeasures" type="TotalCostHealthSafetyMeasures"
-				minOccurs="1"/>
-			<xs:element name="TotalCostQualEnergyMeasures" type="TotalCostQualEnergyMeasures"
-				minOccurs="1"/>
+			<xs:element name="TotalCostHealthSafetyMeasures" type="TotalCostHealthSafetyMeasures" minOccurs="1"/>
+			<xs:element name="TotalCostQualEnergyMeasures" type="TotalCostQualEnergyMeasures" minOccurs="1"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
@@ -4972,8 +4482,7 @@
 			<xs:element minOccurs="0" name="Incentives">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="Incentive"
-							type="IncentiveDetailsType"/>
+						<xs:element maxOccurs="unbounded" name="Incentive" type="IncentiveDetailsType"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -4992,8 +4501,7 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element name="Quantity" type="Quantity"/>
-									<xs:element name="AnnualAmount" type="AnnualAmount"
-										minOccurs="0"/>
+									<xs:element name="AnnualAmount" type="AnnualAmount" minOccurs="0"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -5003,8 +4511,7 @@
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType"
-				maxOccurs="2"/>
+			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType" maxOccurs="2"/>
 			<xs:element maxOccurs="2" minOccurs="0" name="WaterSavingsInfo" type="WaterSavingsType"/>
 			<xs:element minOccurs="0" name="CustomerNotes" type="Notes"/>
 			<xs:element minOccurs="0" name="WorkscopeNotes" type="Notes"/>
@@ -5031,8 +4538,7 @@
 				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="ReplacedComponent"
-							type="RemoteReference"/>
+						<xs:element maxOccurs="unbounded" name="ReplacedComponent" type="RemoteReference"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -5040,8 +4546,7 @@
 			<xs:element minOccurs="0" name="InstalledComponents">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="1" name="InstalledComponent" type="RemoteReference"
-							maxOccurs="unbounded"/>
+						<xs:element minOccurs="1" name="InstalledComponent" type="RemoteReference" maxOccurs="unbounded"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -5058,8 +4563,7 @@
 				</xs:annotation>
 			</xs:element>
 			<xs:element minOccurs="0" name="EnergySavingsReported" type="GrossOrNet"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="FuelSavings"
-				type="FuelSavingsType"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="FuelSavings" type="FuelSavingsType"/>
 			<xs:element name="DemandSavings" minOccurs="0" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[kW] Demand savings from energy efficiency programs</xs:documentation>
@@ -5094,8 +4598,7 @@
 	<xs:complexType name="DuctLeakageMeasurementType">
 		<xs:sequence>
 			<xs:element minOccurs="0" name="DuctType" type="DuctType"/>
-			<xs:element name="LeakinessObservedVisualInspection"
-				type="LeakinessObservedVisualInspection" minOccurs="0"/>
+			<xs:element name="LeakinessObservedVisualInspection" type="LeakinessObservedVisualInspection" minOccurs="0"/>
 			<xs:element name="DuctLeakageTestMethod" type="DuctLeakageTestMethod" minOccurs="0"/>
 			<xs:element minOccurs="0" name="DuctLeakage">
 				<xs:complexType>
@@ -5106,8 +4609,7 @@
 							</xs:annotation>
 						</xs:element>
 						<xs:element name="Value" type="MeasuredDuctLeakage" minOccurs="0"/>
-						<xs:element minOccurs="0" name="TotalOrToOutside"
-							type="DuctLeakageTotalOrToOutside"/>
+						<xs:element minOccurs="0" name="TotalOrToOutside" type="DuctLeakageTotalOrToOutside"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -5175,8 +4677,7 @@
 		<xs:sequence>
 			<xs:element minOccurs="0" name="WeatherRegressionBeginDate" type="HPXMLDate"/>
 			<xs:element minOccurs="0" name="WeatherRegressionEndDate" type="HPXMLDate"/>
-			<xs:element minOccurs="0" name="CalibrationQualification"
-				type="BPI2400CalibrationQualification">
+			<xs:element minOccurs="0" name="CalibrationQualification" type="BPI2400CalibrationQualification">
 				<xs:annotation>
 					<xs:documentation>This identifies which data quality requirements (if any) were met by the bills for the relevant energy source and therefore which calibration metrics (if any) are
 						used to determine whether the calibrated model is accepted.</xs:documentation>
@@ -5202,65 +4703,55 @@
 					<xs:documentation>Weather Normalized Annual Baseload Usage</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingBiasError"
-				type="HPXMLDouble">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingBiasError" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Eqn. 3.2.3.A.i of BPI-2400. Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingAbsoluteError"
-				type="HPXMLDouble">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingAbsoluteError" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Eqn. 3.2.3.A.ii of BPI-2400. In either kWh for electricity or MBtu (million Btu) for all other fuels.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingBiasError"
-				type="HPXMLDouble">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingBiasError" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingAbsoluteError"
-				type="HPXMLDouble">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingAbsoluteError" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>In either kWh for electricity or MBtu (million Btu) for all other fuels.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadBiasError"
-				type="HPXMLDouble">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadBiasError" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadAbsoluteError"
-				type="HPXMLDouble">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadAbsoluteError" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>In either kWh for electricity or MBtu (million Btu) for all other fuels.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SimplifiedModelCalibrationHeatingBiasError"
-				nillable="true" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationHeatingBiasError" nillable="true" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% =
 						0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SimplifiedModelCalibrationCoolingBiasError"
-				type="HPXMLDouble">
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationCoolingBiasError" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% =
 						0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SimplifiedModelCalibrationBaseloadBiasError"
-				nillable="true" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationBaseloadBiasError" nillable="true" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% =
 						0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SimplifiedModelCalibrationTotalBiasError"
-				type="HPXMLDouble">
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationTotalBiasError" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% =
 						0.1)</xs:documentation>
@@ -5281,8 +4772,7 @@
 							</xs:annotation>
 						</xs:element>
 						<xs:element name="UnitofMeasure" type="energyUnitType"/>
-						<xs:element minOccurs="0" name="MeteringConfiguration"
-							type="MeteringConfiguration">
+						<xs:element minOccurs="0" name="MeteringConfiguration" type="MeteringConfiguration">
 							<xs:annotation>
 								<xs:documentation>direct metering = tenants directly metered; master meter without sub-metering = tenants not sub metered; master meter with sub-metering = tenant
 									sub-metered by building owner</xs:documentation>
@@ -5295,8 +4785,7 @@
 										<xs:complexType>
 											<xs:sequence>
 												<xs:element name="EmissionType" type="EmissionType"/>
-												<xs:element name="EmissionUnits"
-												type="EmissionUnits"/>
+												<xs:element name="EmissionUnits" type="EmissionUnits"/>
 												<xs:element name="Emissions" type="HPXMLDouble"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
@@ -5306,10 +4795,8 @@
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
-						<xs:element minOccurs="0" name="FuelInterruptibility"
-							type="FuelInterruptibility"/>
-						<xs:element minOccurs="0" name="SharedEnergySystem"
-							type="SharedEnergySystem"/>
+						<xs:element minOccurs="0" name="FuelInterruptibility" type="FuelInterruptibility"/>
+						<xs:element minOccurs="0" name="SharedEnergySystem" type="SharedEnergySystem"/>
 						<xs:element minOccurs="0" name="IntervalType" type="IntervalType"/>
 						<xs:element minOccurs="0" name="ReadingTimeZone" type="HPXMLString"/>
 						<xs:element minOccurs="0" name="MarginalEnergyCostRate" type="HPXMLDouble">
@@ -5370,8 +4857,7 @@
 			<xs:element name="UnitofMeasure" type="energyUnitType"/>
 			<xs:element minOccurs="0" name="AnnualConsumption" type="HPXMLDouble"/>
 			<xs:element minOccurs="0" name="AnnualFuelCost" type="HPXMLDouble"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="ConsumptionByEndUse"
-				type="EndUseInfoType"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ConsumptionByEndUse" type="EndUseInfoType"/>
 			<xs:element minOccurs="0" name="BaseLoad" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Baseload power is the energy consumed for the day-to-day operation of a home that is not used as a response to outside weather (i.e. excludes heating and cooling)
@@ -5426,12 +4912,9 @@
 			<xs:element name="BusinessName" type="HPXMLString"/>
 			<xs:element name="BusinessType" type="BusinessType" minOccurs="0"/>
 			<xs:element name="BusinessSpecialization" type="BusinessSpecialization" minOccurs="0"/>
-			<xs:element name="Certification" type="BusinessCertification" minOccurs="0"
-				maxOccurs="unbounded"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="BusinessContact"
-				type="BusinessContactInfoType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="TelephoneInfo"
-				type="TelephoneInfoType"/>
+			<xs:element name="Certification" type="BusinessCertification" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="BusinessContact" type="BusinessContactInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="TelephoneInfo" type="TelephoneInfoType"/>
 			<xs:element minOccurs="0" maxOccurs="unbounded" name="EmailInfo" type="EmailInfoType"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
@@ -5473,8 +4956,7 @@
 			<xs:element name="SHGC" type="SHGC" minOccurs="0"/>
 			<xs:element minOccurs="0" name="VisibleTransmittance" type="Fraction"/>
 			<xs:element name="NFRCCertified" type="HPXMLBoolean" minOccurs="0"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification"
-				type="WindowThirdPartyCertification"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="WindowThirdPartyCertification"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="WindowFilm">
 				<xs:complexType>
 					<xs:sequence>
@@ -5572,14 +5054,12 @@
 								<xs:documentation>[ft] Depth of overhang</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DistanceToTopOfWindow"
-							type="LengthMeasurement">
+						<xs:element minOccurs="0" name="DistanceToTopOfWindow" type="LengthMeasurement">
 							<xs:annotation>
 								<xs:documentation>[ft] Vertical distance from overhang to top of window</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DistanceToBottomOfWindow"
-							type="LengthMeasurement">
+						<xs:element minOccurs="0" name="DistanceToBottomOfWindow" type="LengthMeasurement">
 							<xs:annotation>
 								<xs:documentation>[ft] Vertical distance from overhang to bottom of window</xs:documentation>
 							</xs:annotation>
@@ -5716,11 +5196,9 @@
 				</xs:annotation>
 			</xs:element>
 			<xs:element minOccurs="0" name="WindConditions" type="WindConditions"/>
-			<xs:element name="TypeOfInfiltrationMeasurement" type="TypeofInfiltrationMeasurement"
-				minOccurs="0"/>
+			<xs:element name="TypeOfInfiltrationMeasurement" type="TypeofInfiltrationMeasurement" minOccurs="0"/>
 			<xs:element name="TypeOfBlowerDoorTest" type="TypeofBlowerDoorTest" minOccurs="0"/>
-			<xs:element minOccurs="0" name="TypeOfInfiltrationLeakage"
-				type="TypeofInfiltrationLeakage">
+			<xs:element minOccurs="0" name="TypeOfInfiltrationLeakage" type="TypeofInfiltrationLeakage">
 				<xs:annotation>
 					<xs:documentation>This element is intended to describe the type of infiltration measured, e.g., for an individual single-family attached or multifamily dwelling unit. Either whole building or single unit infiltration can be measured. For single unit infiltration, leakage can occur through exterior surfaces, interior surfaces, or both. For example, guarded tests measure unit exterior leakage, unguarded or compartmentalization tests measure unit total leakage, and combining both tests can measure unit interior leakage.</xs:documentation>
 				</xs:annotation>
@@ -5770,10 +5248,8 @@
 	<xs:complexType name="MoistureControlInfoType">
 		<xs:sequence>
 			<xs:group ref="SystemInfo"/>
-			<xs:element name="ExteriorLocationsWaterIntrusionorDamage"
-				type="ExteriorLocationsWaterIntrusionorDamage" minOccurs="0" maxOccurs="unbounded"/>
-			<xs:element name="InteriorLocationsofWaterLeaksorDamage"
-				type="InteriorLocationsofWaterLeaksorDamage" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ExteriorLocationsWaterIntrusionorDamage" type="ExteriorLocationsWaterIntrusionorDamage" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="InteriorLocationsofWaterLeaksorDamage" type="InteriorLocationsofWaterLeaksorDamage" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -5867,8 +5343,7 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element minOccurs="0" name="SkirtPresent" type="HPXMLBoolean"/>
-						<xs:element minOccurs="0" name="BellyWrapCondition"
-							type="ManufacturedHomeBellyWrapCondition">
+						<xs:element minOccurs="0" name="BellyWrapCondition" type="ManufacturedHomeBellyWrapCondition">
 							<xs:annotation>
 								<xs:documentation>Use the 'none' choice for cases where the belly wrap is functionally missing even if pieces of the wrap are still present. </xs:documentation>
 							</xs:annotation>
@@ -5894,8 +5369,7 @@
 			<xs:element name="WoodStud">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="ExpandedPolystyreneSheathing"
-							type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="ExpandedPolystyreneSheathing" type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Sheathing insulation should be specified in the Insulation element as well.</xs:documentation>
 							</xs:annotation>
@@ -6109,8 +5583,7 @@
 					<xs:documentation>Percent of rooms controlled by electronic zone valves with thermostats</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="HVACSystemsServed" type="LocalReference" minOccurs="0"
-				maxOccurs="unbounded"/>
+			<xs:element name="HVACSystemsServed" type="LocalReference" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element maxOccurs="1" minOccurs="0" name="HeatingSeason" type="Season"/>
 			<xs:element maxOccurs="1" minOccurs="0" name="CoolingSeason" type="Season"/>
 			<xs:element ref="extension" minOccurs="0"/>
@@ -6144,11 +5617,9 @@
 					<xs:documentation>The year and month the duct system was sealed.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="DuctOutsideEnvelopeInsulatedaspartofRetrofit" type="HPXMLBoolean"
-				minOccurs="0"/>
+			<xs:element name="DuctOutsideEnvelopeInsulatedaspartofRetrofit" type="HPXMLBoolean" minOccurs="0"/>
 			<xs:element name="DuctSystemReplaced" type="HPXMLBoolean" minOccurs="0"/>
-			<xs:element name="SystemPumpandZoneValveCorrectionsMade" type="HPXMLBoolean"
-				minOccurs="0"/>
+			<xs:element name="SystemPumpandZoneValveCorrectionsMade" type="HPXMLBoolean" minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -6161,10 +5632,8 @@
 					<xs:documentation>Year and month of the last tune and repair for this HVAC equipment.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="NumberofCoilsReplaced"
-				type="IntegerGreaterThanOrEqualToZero"/>
-			<xs:element minOccurs="0" name="NumberofAirHandlersReplaced"
-				type="IntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="NumberofCoilsReplaced" type="IntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="NumberofAirHandlersReplaced" type="IntegerGreaterThanOrEqualToZero"/>
 			<xs:element minOccurs="0" name="AirFilter">
 				<xs:complexType>
 					<xs:sequence>
@@ -6217,10 +5686,8 @@
 	<xs:complexType name="WaterHeaterImprovementInfo">
 		<xs:sequence>
 			<xs:element name="JacketInstalledIndicator" type="HPXMLBoolean" minOccurs="0"/>
-			<xs:element name="DispositionofExistingSystem" type="DispositionofExistingSystem"
-				minOccurs="0"/>
-			<xs:element name="RepairsDescription" type="HPXMLString" minOccurs="0"
-				maxOccurs="unbounded"/>
+			<xs:element name="DispositionofExistingSystem" type="DispositionofExistingSystem" minOccurs="0"/>
+			<xs:element name="RepairsDescription" type="HPXMLString" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="PipeInsulated" type="PipeInsulated" minOccurs="0"/>
 			<xs:element name="LengthofPipeInsulated" type="LengthMeasurement" minOccurs="0">
 				<xs:annotation>
@@ -6316,8 +5783,7 @@
 									Building/BuildingDetails/ClimateAndRiskZones/WeatherStation</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element maxOccurs="unbounded" name="ModeledUsage"
-							type="ModeledUsageType"/>
+						<xs:element maxOccurs="unbounded" name="ModeledUsage" type="ModeledUsageType"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -6408,8 +5874,7 @@
 			<xs:element minOccurs="0" name="ConsumptionDetails">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="ConsumptionInfo"
-							type="ConsumptionInfoType"/>
+						<xs:element maxOccurs="unbounded" name="ConsumptionInfo" type="ConsumptionInfoType"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -6457,8 +5922,7 @@
 					<xs:documentation>[Pa] positive for supply side measurements, negative for return side.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="MeasurementLocation"
-				type="AirHandlerStaticPressureMeasurementLocation"/>
+			<xs:element minOccurs="0" name="MeasurementLocation" type="AirHandlerStaticPressureMeasurementLocation"/>
 			<xs:element minOccurs="0" name="LocationDescription" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="StaticPressureSource" type="StaticPressureSource"/>
 			<xs:element minOccurs="0" ref="extension"/>
@@ -6568,10 +6032,8 @@
 			<xs:sequence>
 				<xs:group ref="SystemInfo"/>
 				<xs:element name="IsConnected" type="HPXMLBoolean"/>
-				<xs:element maxOccurs="unbounded" minOccurs="0" name="CommunicatesWith"
-					type="LocalReference"/>
-				<xs:element minOccurs="0" name="CommunicationProtocol"
-					type="ConnectedDeviceCommunicationProtocol" maxOccurs="unbounded"/>
+				<xs:element maxOccurs="unbounded" minOccurs="0" name="CommunicatesWith" type="LocalReference"/>
+				<xs:element minOccurs="0" name="CommunicationProtocol" type="ConnectedDeviceCommunicationProtocol" maxOccurs="unbounded"/>
 				<xs:element minOccurs="0" name="DemandResponseCapability" type="HPXMLBoolean"/>
 				<xs:element minOccurs="0" name="OccupancySensor" type="HPXMLBoolean"/>
 				<xs:element minOccurs="0" ref="extension"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.1">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10"
+	targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.1">
 	<xs:include schemaLocation="HPXMLDataTypes.xsd"/>
 	<xs:element name="XMLTransactionHeaderInformation">
 		<xs:annotation>
@@ -64,10 +65,14 @@
 				systems, and have it identified in the two systems. Also, there is an id attribute to define a local id to be used internally. </xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType" minOccurs="0"/>
-			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue" minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType" minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue" minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType"
+				minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue"
+				minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType"
+				minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue"
+				minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="id" type="xs:ID" use="required">
 			<xs:annotation>
@@ -91,10 +96,14 @@
 				elements in other xml transactions.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType" minOccurs="0"/>
-			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue" minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType" minOccurs="0"/>
-			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue" minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierType" type="SendingSystemIdentifierType"
+				minOccurs="0"/>
+			<xs:element name="SendingSystemIdentifierValue" type="SendingSystemIdentifierValue"
+				minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierType" type="ReceivingSystemIdentifierType"
+				minOccurs="0"/>
+			<xs:element name="ReceivingSystemIdentifierValue" type="ReceivingSystemIdentifierValue"
+				minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="idref" type="xs:IDREF">
 			<xs:annotation>
@@ -153,7 +162,8 @@
 				</xs:complexType>
 			</xs:element>
 			<xs:element minOccurs="0" name="IndividualType" type="IndividualType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="Telephone" type="TelephoneInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="Telephone"
+				type="TelephoneInfoType"/>
 			<xs:element minOccurs="0" maxOccurs="unbounded" name="Email" type="EmailInfoType"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
@@ -170,9 +180,11 @@
 				<xs:element minOccurs="0" name="MeterNumber" type="HPXMLString"/>
 				<xs:element name="UtilityAccountNumber" type="HPXMLString" minOccurs="0"/>
 				<xs:element minOccurs="0" name="Permission" type="HPXMLBoolean"/>
-				<xs:element name="UtilityServiceTypeProvided" type="ConsumptionType" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element name="UtilityServiceTypeProvided" type="ConsumptionType" minOccurs="0"
+					maxOccurs="unbounded"/>
 				<xs:element minOccurs="0" name="BusinessInfo" type="BusinessInfoType"/>
-				<xs:element maxOccurs="unbounded" minOccurs="0" name="BusinessContactInfo" type="BusinessContactInfoType"/>
+				<xs:element maxOccurs="unbounded" minOccurs="0" name="BusinessContactInfo"
+					type="BusinessContactInfoType"/>
 				<xs:element ref="extension" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attribute name="dataSource" type="DataSource"/>
@@ -228,7 +240,8 @@
 		<xs:complexContent>
 			<xs:extension base="InsulationInfoBase">
 				<xs:sequence>
-					<xs:element maxOccurs="unbounded" minOccurs="0" name="Layer" type="InsulationLayerInfo"> </xs:element>
+					<xs:element maxOccurs="unbounded" minOccurs="0" name="Layer"
+						type="InsulationLayerInfo"> </xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -238,7 +251,8 @@
 		<xs:complexContent>
 			<xs:extension base="InsulationInfoBase">
 				<xs:sequence>
-					<xs:element maxOccurs="unbounded" minOccurs="0" name="Layer" type="FoundationWallInsulationLayerInfo"> </xs:element>
+					<xs:element maxOccurs="unbounded" minOccurs="0" name="Layer"
+						type="FoundationWallInsulationLayerInfo"> </xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -248,7 +262,8 @@
 		<xs:complexContent>
 			<xs:extension base="InsulationInfoBase">
 				<xs:sequence>
-					<xs:element maxOccurs="unbounded" minOccurs="0" name="Layer" type="SlabPerimeterInsulationLayerInfo"> </xs:element>
+					<xs:element maxOccurs="unbounded" minOccurs="0" name="Layer"
+						type="SlabPerimeterInsulationLayerInfo"> </xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -258,7 +273,8 @@
 		<xs:complexContent>
 			<xs:extension base="InsulationInfoBase">
 				<xs:sequence>
-					<xs:element maxOccurs="unbounded" minOccurs="0" name="Layer" type="UnderSlabInsulationLayerInfo"> </xs:element>
+					<xs:element maxOccurs="unbounded" minOccurs="0" name="Layer"
+						type="UnderSlabInsulationLayerInfo"> </xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -290,12 +306,14 @@
 		<xs:complexContent>
 			<xs:extension base="InsulationLayerInfoBase">
 				<xs:sequence>
-					<xs:element name="DistanceToTopOfInsulation" type="LengthMeasurement" minOccurs="0">
+					<xs:element name="DistanceToTopOfInsulation" type="LengthMeasurement"
+						minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>[ft] Vertical distance from top of foundation wall to top of insulation.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="DistanceToBottomOfInsulation" type="LengthMeasurement" minOccurs="0">
+					<xs:element name="DistanceToBottomOfInsulation" type="LengthMeasurement"
+						minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>[ft] Vertical distance from top of foundation wall to bottom of insulation.</xs:documentation>
 						</xs:annotation>
@@ -365,7 +383,8 @@
 			<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 			<xs:element name="ModelYear" type="Year" minOccurs="0"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="ApplianceThirdPartyCertifications"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification"
+				type="ApplianceThirdPartyCertifications"/>
 			<xs:element minOccurs="0" name="IsSharedAppliance" type="HPXMLBoolean">
 				<xs:annotation>
 					<xs:documentation>Does the appliance serve multiple building/dwelling units?</xs:documentation>
@@ -399,7 +418,8 @@
 								drying cycle energy as well as energy consumed during Stand-by and Off modes.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element maxOccurs="unbounded" minOccurs="0" name="ControlType" type="ClothesDryerControlType"/>
+					<xs:element maxOccurs="unbounded" minOccurs="0" name="ControlType"
+						type="ClothesDryerControlType"/>
 					<xs:element minOccurs="0" name="Vented" type="HPXMLBoolean"/>
 					<xs:element minOccurs="0" name="VentedFlowRate" type="FlowRate"/>
 					<xs:element ref="extension" minOccurs="0"/>
@@ -423,7 +443,8 @@
 								Factor.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="IntegratedModifiedEnergyFactor" type="HPXMLDouble" minOccurs="0">
+					<xs:element name="IntegratedModifiedEnergyFactor" type="HPXMLDouble"
+						minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>The energy performance metric for ENERGY STAR certified residential clothes washers as of March 7, 2015.</xs:documentation>
 						</xs:annotation>
@@ -491,11 +512,14 @@
 					<xs:element minOccurs="0" name="Location" type="RefrigeratorLocation"/>
 					<xs:element minOccurs="0" name="Fuel" type="FuelType"/>
 					<xs:element name="HeatDryDefaultOff" type="HPXMLBoolean" minOccurs="0"/>
-					<xs:element name="AuxillaryWaterHeaterDefaultOff" type="HPXMLBoolean" minOccurs="0"/>
+					<xs:element name="AuxillaryWaterHeaterDefaultOff" type="HPXMLBoolean"
+						minOccurs="0"/>
 					<xs:element minOccurs="0" name="RatedAnnualkWh" type="RatedAnnualkWh"/>
 					<xs:element minOccurs="0" name="EnergyFactor" type="EnergyFactor"/>
-					<xs:element minOccurs="0" name="RatedWaterGalPerCycle" type="RatedWaterGalPerCycle"/>
-					<xs:element minOccurs="0" name="PlaceSettingCapacity" type="IntegerGreaterThanZero"/>
+					<xs:element minOccurs="0" name="RatedWaterGalPerCycle"
+						type="RatedWaterGalPerCycle"/>
+					<xs:element minOccurs="0" name="PlaceSettingCapacity"
+						type="IntegerGreaterThanZero"/>
 					<xs:element minOccurs="0" name="Usage" type="HPXMLDouble">
 						<xs:annotation>
 							<xs:documentation>loads/week of actual usage by the occupants; use LabelUsage instead for the loads/week on the EnergyGuide label</xs:documentation>
@@ -625,7 +649,8 @@
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
-					<xs:element minOccurs="0" name="FractionDehumidificationLoadServed" type="Fraction"/>
+					<xs:element minOccurs="0" name="FractionDehumidificationLoadServed"
+						type="Fraction"/>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -659,7 +684,8 @@
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element name="SoftwareProgramUsed" type="SoftwareProgramUsed" minOccurs="0"/>
-				<xs:element name="SoftwareProgramVersion" type="SoftwareProgramVersion" minOccurs="0"/>
+				<xs:element name="SoftwareProgramVersion" type="SoftwareProgramVersion"
+					minOccurs="0"/>
 				<xs:element ref="extension" minOccurs="0"/>
 			</xs:sequence>
 			<xs:attribute name="dataSource" type="DataSource"/>
@@ -678,9 +704,12 @@
 			<xs:element name="Auditor">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="Qualification" type="AuditorQualification" maxOccurs="unbounded"/>
-						<xs:element minOccurs="0" name="StateWhereQualificationHeld" type="StateCode"/>
-						<xs:element minOccurs="0" name="YearsExperience" type="IntegerGreaterThanOrEqualToZero"/>
+						<xs:element minOccurs="0" name="Qualification" type="AuditorQualification"
+							maxOccurs="unbounded"/>
+						<xs:element minOccurs="0" name="StateWhereQualificationHeld"
+							type="StateCode"/>
+						<xs:element minOccurs="0" name="YearsExperience"
+							type="IntegerGreaterThanOrEqualToZero"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -689,8 +718,10 @@
 			<xs:element name="Implementer">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" minOccurs="0" name="Qualification" type="ImplementerQualification"/>
-						<xs:element minOccurs="0" name="StateWhereQualificationHeld" type="StateCode"/>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="Qualification"
+							type="ImplementerQualification"/>
+						<xs:element minOccurs="0" name="StateWhereQualificationHeld"
+							type="StateCode"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -712,7 +743,8 @@
 		<xs:sequence>
 			<xs:group maxOccurs="unbounded" ref="SystemInfo"/>
 			<xs:element name="BusinessInfo" type="BusinessInfoType"/>
-			<xs:element name="SubContractor" type="ContractorType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="SubContractor" type="ContractorType" minOccurs="0"
+				maxOccurs="unbounded"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -726,7 +758,8 @@
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element name="SpaceName" type="HPXMLString" minOccurs="0"/>
-						<xs:element minOccurs="0" name="NumberOfBedrooms" type="IntegerGreaterThanOrEqualToZero"/>
+						<xs:element minOccurs="0" name="NumberOfBedrooms"
+							type="IntegerGreaterThanOrEqualToZero"/>
 						<xs:element minOccurs="0" name="FloorArea" type="SurfaceArea">
 							<xs:annotation>
 								<xs:documentation>[sq.ft.]</xs:documentation>
@@ -772,7 +805,8 @@
 			<xs:element name="AirInfiltration" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="AirInfiltrationMeasurement" type="AirInfiltrationMeasurementType" maxOccurs="unbounded"/>
+						<xs:element minOccurs="0" name="AirInfiltrationMeasurement"
+							type="AirInfiltrationMeasurementType" maxOccurs="unbounded"/>
 						<xs:element minOccurs="0" name="AirSealing" maxOccurs="unbounded">
 							<xs:complexType>
 								<xs:sequence>
@@ -781,9 +815,14 @@
 									<xs:element minOccurs="0" name="ComponentsAirSealed">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element maxOccurs="unbounded" minOccurs="0" name="Attic" type="AtticComponentsAirSealed"/>
-												<xs:element maxOccurs="unbounded" minOccurs="0" name="BasementCrawlspace" type="BasementCrawlspaceComponentsAirSealed"/>
-												<xs:element maxOccurs="unbounded" minOccurs="0" name="LivingSpace" type="LivingSpaceComponentsAirSealed"/>
+												<xs:element maxOccurs="unbounded" minOccurs="0"
+												name="Attic" type="AtticComponentsAirSealed"/>
+												<xs:element maxOccurs="unbounded" minOccurs="0"
+												name="BasementCrawlspace"
+												type="BasementCrawlspaceComponentsAirSealed"/>
+												<xs:element maxOccurs="unbounded" minOccurs="0"
+												name="LivingSpace"
+												type="LivingSpaceComponentsAirSealed"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -821,19 +860,25 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="1" name="AtticType" type="AtticType"/>
-									<xs:element minOccurs="0" name="VentilationRate" type="VentilationType"/>
-									<xs:element minOccurs="0" name="WithinInfiltrationVolume" type="HPXMLBoolean">
+									<xs:element minOccurs="0" name="VentilationRate"
+										type="VentilationType"/>
+									<xs:element minOccurs="0" name="WithinInfiltrationVolume"
+										type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Specifies whether the attic is within the infiltration volume impacted by an air leakage test.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AttachedToRoof" type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFloor" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToRoof"
+										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToWall"
+										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFloor"
+										type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -859,22 +904,31 @@
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
 									<xs:element name="FoundationType" type="FoundationType"/>
-									<xs:element minOccurs="0" name="VentilationRate" type="VentilationType"/>
-									<xs:element minOccurs="0" name="ThermalBoundary" type="FoundationThermalBoundary"/>
-									<xs:element minOccurs="0" name="WithinInfiltrationVolume" type="HPXMLBoolean">
+									<xs:element minOccurs="0" name="VentilationRate"
+										type="VentilationType"/>
+									<xs:element minOccurs="0" name="ThermalBoundary"
+										type="FoundationThermalBoundary"/>
+									<xs:element minOccurs="0" name="WithinInfiltrationVolume"
+										type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Specifies whether the foundation is within the infiltration volume impacted by an air leakage test.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AttachedToRimJoist" type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFoundationWall" type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFloor" type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToSlab" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToRimJoist"
+										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToWall"
+										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFoundationWall"
+										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFloor"
+										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToSlab"
+										type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -906,23 +960,32 @@
 									<xs:element minOccurs="1" name="GarageType">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="AttachedtoHouse" type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="Vented" type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="Conditioned" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="AttachedtoHouse"
+												type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="Vented"
+												type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="Conditioned"
+												type="HPXMLBoolean"/>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="AttachedToRoof" type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFoundationWall" type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToFloor" type="LocalReference" maxOccurs="unbounded"/>
-									<xs:element minOccurs="0" name="AttachedToSlab" type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToRoof"
+										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToWall"
+										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFoundationWall"
+										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToFloor"
+										type="LocalReference" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="AttachedToSlab"
+										type="LocalReference" maxOccurs="unbounded"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -947,23 +1010,28 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo"
+										type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Surface area of the roof itself</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation"
+										type="OrientationType"/>
 									<xs:element name="Azimuth" type="AzimuthType" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="RoofType" type="RoofType"/>
-									<xs:element minOccurs="0" name="RoofColor" type="WallAndRoofColor"/>
-									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
+									<xs:element minOccurs="0" name="RoofColor"
+										type="WallAndRoofColor"/>
+									<xs:element minOccurs="0" name="SolarAbsorptance"
+										type="SolarAbsorptance"/>
 									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
-									<xs:element minOccurs="0" name="InteriorFinish" type="InteriorFinishInfo"/>
+									<xs:element minOccurs="0" name="InteriorFinish"
+										type="InteriorFinishInfo"/>
 									<xs:element minOccurs="0" name="Rafters" type="StudProperties"/>
 									<xs:element minOccurs="0" name="DeckType" type="DeckType"/>
 									<xs:element minOccurs="0" name="Pitch" type="Pitch">
@@ -971,10 +1039,14 @@
 											<xs:documentation>Pitch of roof ?/12</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="RadiantBarrier" type="HPXMLBoolean" minOccurs="0"/>
-									<xs:element name="RadiantBarrierLocation" type="RadiantBarrierLocation" minOccurs="0"/>
-									<xs:element name="RadiantBarrierGrade" type="InsulationGrade" minOccurs="0"/>
-									<xs:element minOccurs="0" name="Insulation" type="InsulationInfo"/>
+									<xs:element name="RadiantBarrier" type="HPXMLBoolean"
+										minOccurs="0"/>
+									<xs:element name="RadiantBarrierLocation"
+										type="RadiantBarrierLocation_roof" minOccurs="0"/>
+									<xs:element name="RadiantBarrierGrade" type="InsulationGrade"
+										minOccurs="0"/>
+									<xs:element minOccurs="0" name="Insulation"
+										type="InsulationInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -992,34 +1064,42 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element minOccurs="0" name="ExteriorAdjacentTo" type="AdjacentTo"/>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="ExteriorAdjacentTo"
+										type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo"
+										type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation"
+										type="OrientationType"/>
 									<xs:element name="Azimuth" type="AzimuthType" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Perimeter" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Perimeter"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="Siding" type="Siding"/>
 									<xs:element minOccurs="0" name="Color" type="WallAndRoofColor"/>
-									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
+									<xs:element minOccurs="0" name="SolarAbsorptance"
+										type="SolarAbsorptance"/>
 									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
-									<xs:element minOccurs="0" name="Insulation" type="InsulationInfo"/>
-									<xs:element minOccurs="0" name="FloorJoists" type="StudProperties"/>
+									<xs:element minOccurs="0" name="Insulation"
+										type="InsulationInfo"/>
+									<xs:element minOccurs="0" name="FloorJoists"
+										type="StudProperties"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -1041,11 +1121,15 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo" minOccurs="0"/>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
-									<xs:element minOccurs="0" name="AtticWallType" type="AtticWallType"/>
+									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo"
+										minOccurs="0"/>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo"
+										type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="AtticWallType"
+										type="AtticWallType"/>
 									<xs:element name="WallType" type="WallType" minOccurs="0"/>
-									<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Thickness"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[in] Thickness of the entire wall assembly, including any siding, sheathing, continuous insulation, and interior finish.</xs:documentation>
 										</xs:annotation>
@@ -1055,7 +1139,8 @@
 											<xs:documentation>[sq.ft.] Gross wall area</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation"
+										type="OrientationType"/>
 									<xs:element name="Azimuth" type="AzimuthType" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
@@ -1064,14 +1149,24 @@
 									<xs:element minOccurs="0" name="Studs" type="StudProperties"/>
 									<xs:element minOccurs="0" name="Siding" type="Siding"/>
 									<xs:element minOccurs="0" name="Color" type="WallAndRoofColor"/>
-									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
+									<xs:element minOccurs="0" name="SolarAbsorptance"
+										type="SolarAbsorptance"/>
 									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
-									<xs:element minOccurs="0" name="InteriorFinish" type="InteriorFinishInfo"/>
-									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"/>
+									<xs:element minOccurs="0" name="InteriorFinish"
+										type="InteriorFinishInfo"/>
+									<xs:element minOccurs="0" maxOccurs="1" name="Insulation"
+										type="InsulationInfo"/>
+									<xs:element name="RadiantBarrier" type="HPXMLBoolean"
+										minOccurs="0"/>
+									<xs:element name="RadiantBarrierLocation"
+										type="RadiantBarrierLocation_wall" minOccurs="0"/>
+									<xs:element name="RadiantBarrierGrade" type="InsulationGrade"
+										minOccurs="0"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -1093,8 +1188,10 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo" minOccurs="0"/>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
+									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo"
+										minOccurs="0"/>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo"
+										type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="Type" type="FoundationWallType"/>
 									<xs:element minOccurs="0" name="Length" type="LengthMeasurement">
 										<xs:annotation>
@@ -1111,30 +1208,37 @@
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation"
+										type="OrientationType"/>
 									<xs:element name="Azimuth" type="AzimuthType" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Thickness"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[in] Thickness of the foundation wall structural element (e.g., concrete), excluding any interior framing and continuous insulation.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="DepthBelowGrade" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="DepthBelowGrade"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Depth below grade of foundation wall</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AdjacentToFoundation" type="LocalReference">
+									<xs:element minOccurs="0" name="AdjacentToFoundation"
+										type="LocalReference">
 										<xs:annotation>
 											<xs:documentation>If this foundation wall is adjacent to another foundation, use this reference to indicate which one.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="InteriorStuds" type="StudProperties"/>
-									<xs:element minOccurs="0" name="InteriorFinish" type="InteriorFinishInfo"/>
-									<xs:element maxOccurs="1" minOccurs="0" name="Insulation" type="FoundationWallInsulationInfo"/>
+									<xs:element minOccurs="0" name="InteriorStuds"
+										type="StudProperties"/>
+									<xs:element minOccurs="0" name="InteriorFinish"
+										type="InteriorFinishInfo"/>
+									<xs:element maxOccurs="1" minOccurs="0" name="Insulation"
+										type="FoundationWallInsulationInfo"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1156,24 +1260,38 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo" minOccurs="0"/>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
-									<xs:element minOccurs="0" name="FloorOrCeiling" type="FloorOrCeiling">
+									<xs:element name="ExteriorAdjacentTo" type="AdjacentTo"
+										minOccurs="0"/>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo"
+										type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="FloorOrCeiling"
+										type="FloorOrCeiling">
 										<xs:annotation>
 											<xs:documentation>From the perspective of the living/conditioned space.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="FloorType" type="FloorType"/>
-									<xs:element minOccurs="0" name="FloorJoists" type="StudProperties"/>
-									<xs:element minOccurs="0" name="FloorTrusses" type="StudProperties"/>
-									<xs:element minOccurs="0" name="FloorCovering" type="FloorCovering"/>
+									<xs:element minOccurs="0" name="FloorJoists"
+										type="StudProperties"/>
+									<xs:element minOccurs="0" name="FloorTrusses"
+										type="StudProperties"/>
+									<xs:element minOccurs="0" name="FloorCovering"
+										type="FloorCovering"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="InteriorFinish" type="InteriorFinishInfo"/>
-									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"/>
+									<xs:element minOccurs="0" name="InteriorFinish"
+										type="InteriorFinishInfo"/>
+									<xs:element minOccurs="0" maxOccurs="1" name="Insulation"
+										type="InsulationInfo"/>
+									<xs:element name="RadiantBarrier" type="HPXMLBoolean"
+										minOccurs="0"/>
+									<xs:element name="RadiantBarrierLocation"
+										type="RadiantBarrierLocation_floor" minOccurs="0"/>
+									<xs:element name="RadiantBarrierGrade" type="InsulationGrade"
+										minOccurs="0"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1194,40 +1312,50 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="AttachedToSpace"/>
-									<xs:element minOccurs="0" name="InteriorAdjacentTo" type="AdjacentTo"/>
+									<xs:element minOccurs="0" name="InteriorAdjacentTo"
+										type="AdjacentTo"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Area of the slab</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Thickness"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[in] Thickness of the foundation slab structural element (e.g., concrete), excluding any floor coverings and continuous insulation.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Perimeter" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="Perimeter"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Length of slab perimeter.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="ExposedPerimeter" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="ExposedPerimeter"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Perimeter of the slab exposed to ambient conditions</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="OnGradeExposedPerimeter" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="OnGradeExposedPerimeter"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Perimeter of slab measured in feet that is on-grade (2 ft. below grade or less) and exposed to ambient conditions.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="DepthBelowGrade" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="DepthBelowGrade"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] Depth from the top of the slab surface to grade</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FloorCovering" type="FloorCovering"/>
-									<xs:element maxOccurs="1" minOccurs="0" name="PerimeterInsulation" type="SlabPerimeterInsulationInfo"/>
-									<xs:element minOccurs="0" name="UnderSlabInsulation" type="UnderSlabInsulationInfo"/>
+									<xs:element minOccurs="0" name="FloorCovering"
+										type="FloorCovering"/>
+									<xs:element maxOccurs="1" minOccurs="0"
+										name="PerimeterInsulation"
+										type="SlabPerimeterInsulationInfo"/>
+									<xs:element minOccurs="0" name="UnderSlabInsulation"
+										type="UnderSlabInsulationInfo"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1249,12 +1377,15 @@
 								<xs:sequence>
 									<xs:group ref="WindowInfo"/>
 									<xs:element minOccurs="0" name="WindowType" type="WindowType"/>
-									<xs:element minOccurs="0" name="WindowtoWallRatio" type="Fraction"/>
-									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference"/>
+									<xs:element minOccurs="0" name="WindowtoWallRatio"
+										type="Fraction"/>
+									<xs:element minOccurs="0" name="AttachedToWall"
+										type="LocalReference"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -1285,8 +1416,10 @@
 											<xs:documentation>Pitch of skylight ?/12</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AttachedToRoof" type="LocalReference"/>
-									<xs:element minOccurs="0" name="AttachedToFloor" type="LocalReference">
+									<xs:element minOccurs="0" name="AttachedToRoof"
+										type="LocalReference"/>
+									<xs:element minOccurs="0" name="AttachedToFloor"
+										type="LocalReference">
 										<xs:annotation>
 											<xs:documentation>For a skylight that includes a shaft or a sun tunnel, reference the attic floor that it penetrates.</xs:documentation>
 										</xs:annotation>
@@ -1294,7 +1427,8 @@
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -1315,8 +1449,10 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="AttachedToWall" type="LocalReference"/>
-									<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero"/>
+									<xs:element minOccurs="0" name="AttachedToWall"
+										type="LocalReference"/>
+									<xs:element minOccurs="0" name="Count"
+										type="IntegerGreaterThanZero"/>
 									<xs:element minOccurs="0" name="Area" type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Total door surface area for this group of doors</xs:documentation>
@@ -1327,19 +1463,27 @@
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Orientation" type="OrientationType"/>
+									<xs:element minOccurs="0" name="Orientation"
+										type="OrientationType"/>
 									<xs:element minOccurs="0" name="DoorType" type="DoorType"/>
-									<xs:element name="DoorMaterial" type="DoorMaterial" minOccurs="0"/>
-									<xs:element minOccurs="0" name="WeatherStripping" type="HPXMLBoolean"/>
+									<xs:element name="DoorMaterial" type="DoorMaterial"
+										minOccurs="0"/>
+									<xs:element minOccurs="0" name="WeatherStripping"
+										type="HPXMLBoolean"/>
 									<xs:element name="StormDoor" type="HPXMLBoolean" minOccurs="0"/>
 									<xs:element name="RValue" type="RValue" minOccurs="0"/>
-									<xs:element minOccurs="0" name="LeakinessDescription" type="BuildingLeakiness"/>
-									<xs:element minOccurs="0" name="PerformanceClass" type="PerformanceClass"/>
-									<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="DoorThirdPartyCertifications"/>
+									<xs:element minOccurs="0" name="LeakinessDescription"
+										type="BuildingLeakiness"/>
+									<xs:element minOccurs="0" name="PerformanceClass"
+										type="PerformanceClass"/>
+									<xs:element maxOccurs="unbounded" minOccurs="0"
+										name="ThirdPartyCertification"
+										type="DoorThirdPartyCertifications"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"/>
+												<xs:element name="ConsumptionInfo"
+												type="ConsumptionInfoType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -1371,22 +1515,30 @@
 										</xs:annotation>
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="PrimaryHeatingSystem" type="LocalReference"/>
-												<xs:element minOccurs="0" name="PrimaryCoolingSystem" type="LocalReference"/>
+												<xs:element minOccurs="0"
+												name="PrimaryHeatingSystem" type="LocalReference"/>
+												<xs:element minOccurs="0"
+												name="PrimaryCoolingSystem" type="LocalReference"
+												/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" maxOccurs="unbounded" name="HeatingSystem" type="HeatingSystemInfoType"/>
-									<xs:element minOccurs="0" maxOccurs="unbounded" name="CoolingSystem" type="CoolingSystemInfoType"/>
-									<xs:element minOccurs="0" maxOccurs="unbounded" name="HeatPump" type="HeatPumpInfoType"/>
-									<xs:element maxOccurs="unbounded" minOccurs="0" name="GeothermalLoop" type="GeothermalLoopType"/>
+									<xs:element minOccurs="0" maxOccurs="unbounded"
+										name="HeatingSystem" type="HeatingSystemInfoType"/>
+									<xs:element minOccurs="0" maxOccurs="unbounded"
+										name="CoolingSystem" type="CoolingSystemInfoType"/>
+									<xs:element minOccurs="0" maxOccurs="unbounded" name="HeatPump"
+										type="HeatPumpInfoType"/>
+									<xs:element maxOccurs="unbounded" minOccurs="0"
+										name="GeothermalLoop" type="GeothermalLoopType"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
-						<xs:element maxOccurs="unbounded" minOccurs="0" name="HVACControl" type="HVACControlType"/>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="HVACControl"
+							type="HVACControlType"/>
 						<xs:element maxOccurs="unbounded" minOccurs="0" name="HVACDistribution">
 							<xs:complexType>
 								<xs:sequence>
@@ -1395,33 +1547,41 @@
 									<xs:element minOccurs="0" name="DistributionSystemType">
 										<xs:complexType>
 											<xs:choice>
-												<xs:element name="AirDistribution" type="AirDistributionInfo"/>
-												<xs:element name="HydronicDistribution" type="HydronicDistributionInfo"/>
+												<xs:element name="AirDistribution"
+												type="AirDistributionInfo"/>
+												<xs:element name="HydronicDistribution"
+												type="HydronicDistributionInfo"/>
 												<xs:element name="Other" type="HPXMLString">
-													<xs:annotation>
-														<xs:documentation>describe</xs:documentation>
-													</xs:annotation>
+												<xs:annotation>
+												<xs:documentation>describe</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 											</xs:choice>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="ConditionedFloorAreaServed" type="SurfaceArea">
+									<xs:element minOccurs="0" name="ConditionedFloorAreaServed"
+										type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Conditioned floor area that this distribution system serves.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AnnualHeatingDistributionSystemEfficiency" type="FractionExcludingZero">
+									<xs:element minOccurs="0"
+										name="AnnualHeatingDistributionSystemEfficiency"
+										type="FractionExcludingZero">
 										<xs:annotation>
 											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for heating, the DSE may be approximated by equation 3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use History. Enter values as a fractional number between 0 and 1, i.e. 80% = 0.8</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AnnualCoolingDistributionSystemEfficiency" type="FractionExcludingZero">
+									<xs:element minOccurs="0"
+										name="AnnualCoolingDistributionSystemEfficiency"
+										type="FractionExcludingZero">
 										<xs:annotation>
 											<xs:documentation>For software that does not calculate an annual distribution system efficiency (DSE) for cooling, the DSE may be approximated by equation 3.4.i in ANSI/BPI-2400-S-2012: Standard Practice for Standardized Qualification of Whole-House Energy Savings, Predictions by Calibration to Energy Use History. Enter values as a fractional number between 0 and 1, i.e. 80% = 0.8</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HVACDistributionImprovement" type="HVACDistributionImprovementInfo"/>
+									<xs:element minOccurs="0" name="HVACDistributionImprovement"
+										type="HVACDistributionImprovementInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1430,8 +1590,10 @@
 						<xs:element minOccurs="0" name="Maintenance">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element minOccurs="0" name="Schedule" type="HVACMaintenanceSchedule"/>
-									<xs:element minOccurs="0" name="ACReplacedinLastTenYears" type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="Schedule"
+										type="HVACMaintenanceSchedule"/>
+									<xs:element minOccurs="0" name="ACReplacedinLastTenYears"
+										type="HPXMLBoolean"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1440,7 +1602,8 @@
 						<xs:element name="AnnualEnergyUse" minOccurs="0">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType" maxOccurs="unbounded"/>
+									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"
+										maxOccurs="unbounded"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
@@ -1461,131 +1624,171 @@
 											<xs:sequence>
 												<xs:group ref="SystemInfo"/>
 												<xs:element minOccurs="0" ref="ConnectedDevice"/>
-												<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
-												<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
-												<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero">
-													<xs:annotation>
-														<xs:documentation>Number of similar ventilation fans (e.g., bath fans).</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="Manufacturer"
+												type="HPXMLString"/>
+												<xs:element minOccurs="0" name="SerialNumber"
+												type="HPXMLString"/>
+												<xs:element minOccurs="0" name="Count"
+												type="IntegerGreaterThanZero">
+												<xs:annotation>
+												<xs:documentation>Number of similar ventilation fans (e.g., bath fans).</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="FanType" type="VentilationFanType"/>
+												<xs:element minOccurs="0" name="FanType"
+												type="VentilationFanType"/>
 												<xs:element minOccurs="0" name="CFISControls">
-													<xs:annotation>
-														<xs:documentation>Relevant when FanType="central fan integrated supply".</xs:documentation>
-													</xs:annotation>
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element minOccurs="0" name="HasOutdoorAirControl" type="HPXMLBoolean">
-																<xs:annotation>
-																	<xs:documentation>Has controls to block the flow of outside air when the CFIS system is not ventilating. For example, an electronically-controlled mechanical damper, or an in-line fan that substantially blocks the flow when not running.</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" name="AdditionalRuntimeOperatingMode" type="AdditionalRuntimeOperatingMode">
-																<xs:annotation>
-																	<xs:documentation>Describes if/how the CFIS system provides additional ventilation beyond when the HVAC system is running to meet a given ventilation target.</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element name="SupplementalFan" type="LocalReference" minOccurs="0" maxOccurs="1">
-																<xs:annotation>
-																	<xs:documentation>When AdditionalRuntimeOperatingMode="supplemental fan", specifies the VentilationFan that serves as that supplemental fan.</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" ref="extension"/>
-														</xs:sequence>
-													</xs:complexType>
+												<xs:annotation>
+												<xs:documentation>Relevant when FanType="central fan integrated supply".</xs:documentation>
+												</xs:annotation>
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element minOccurs="0"
+												name="HasOutdoorAirControl" type="HPXMLBoolean">
+												<xs:annotation>
+												<xs:documentation>Has controls to block the flow of outside air when the CFIS system is not ventilating. For example, an electronically-controlled mechanical damper, or an in-line fan that substantially blocks the flow when not running.</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="RatedFlowRate" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>[CFM] as rated by manufacturer</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0"
+												name="AdditionalRuntimeOperatingMode"
+												type="AdditionalRuntimeOperatingMode">
+												<xs:annotation>
+												<xs:documentation>Describes if/how the CFIS system provides additional ventilation beyond when the HVAC system is running to meet a given ventilation target.</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="CalculatedFlowRate" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>[CFM] as calculated using duct size, prescriptive approach</xs:documentation>
-													</xs:annotation>
+												<xs:element name="SupplementalFan"
+												type="LocalReference" minOccurs="0" maxOccurs="1">
+												<xs:annotation>
+												<xs:documentation>When AdditionalRuntimeOperatingMode="supplemental fan", specifies the VentilationFan that serves as that supplemental fan.</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="TestedFlowRate" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>[CFM] as tested by assessor/auditor/inspector</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												</xs:complexType>
 												</xs:element>
-												<xs:element minOccurs="0" name="HoursInOperation" type="HoursPerDay">
-													<xs:annotation>
-														<xs:documentation>24 = continuous, less than 24 = intermittent</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="RatedFlowRate"
+												type="HPXMLDouble">
+												<xs:annotation>
+												<xs:documentation>[CFM] as rated by manufacturer</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="DeliveredVentilation" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>[CFM]</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="CalculatedFlowRate"
+												type="HPXMLDouble">
+												<xs:annotation>
+												<xs:documentation>[CFM] as calculated using duct size, prescriptive approach</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="FanControlProperlyLabeled" type="BooleanWithNA"/>
-												<xs:element minOccurs="0" name="ProperlyVented" type="BooleanWithNA"/>
-												<xs:element minOccurs="0" name="FanLocation" type="VentilationFanLocation"/>
-												<xs:element minOccurs="0" name="UsedForLocalVentilation" type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="UsedForWholeBuildingVentilation" type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="UsedForSeasonalCoolingLoadReduction" type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="UsedForGarageVentilation" type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="IsSharedSystem" type="HPXMLBoolean">
-													<xs:annotation>
-														<xs:documentation>Does the system serve multiple building/dwelling units?</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="TestedFlowRate"
+												type="HPXMLDouble">
+												<xs:annotation>
+												<xs:documentation>[CFM] as tested by assessor/auditor/inspector</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="NumberofUnitsServed" type="HPXMLInteger"/>
-												<xs:element minOccurs="0" name="RatedNoise" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>[sones] from manufacturer's info</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="HoursInOperation"
+												type="HoursPerDay">
+												<xs:annotation>
+												<xs:documentation>24 = continuous, less than 24 = intermittent</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="TestedNoise" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>[sones] as tested in field</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0"
+												name="DeliveredVentilation" type="HPXMLDouble">
+												<xs:annotation>
+												<xs:documentation>[CFM]</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="TotalRecoveryEfficiency" type="FractionExcludingZero">
-													<xs:annotation>
-														<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by electric
+												<xs:element minOccurs="0"
+												name="FanControlProperlyLabeled"
+												type="BooleanWithNA"/>
+												<xs:element minOccurs="0" name="ProperlyVented"
+												type="BooleanWithNA"/>
+												<xs:element minOccurs="0" name="FanLocation"
+												type="VentilationFanLocation"/>
+												<xs:element minOccurs="0"
+												name="UsedForLocalVentilation" type="HPXMLBoolean"/>
+												<xs:element minOccurs="0"
+												name="UsedForWholeBuildingVentilation"
+												type="HPXMLBoolean"/>
+												<xs:element minOccurs="0"
+												name="UsedForSeasonalCoolingLoadReduction"
+												type="HPXMLBoolean"/>
+												<xs:element minOccurs="0"
+												name="UsedForGarageVentilation"
+												type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="IsSharedSystem"
+												type="HPXMLBoolean">
+												<xs:annotation>
+												<xs:documentation>Does the system serve multiple building/dwelling units?</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="NumberofUnitsServed"
+												type="HPXMLInteger"/>
+												<xs:element minOccurs="0" name="RatedNoise"
+												type="HPXMLDouble">
+												<xs:annotation>
+												<xs:documentation>[sones] from manufacturer's info</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="TestedNoise"
+												type="HPXMLDouble">
+												<xs:annotation>
+												<xs:documentation>[sones] as tested in field</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0"
+												name="TotalRecoveryEfficiency"
+												type="FractionExcludingZero">
+												<xs:annotation>
+												<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by electric
 															consumption, case heat loss or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential
 															total energy that could be recovered plus the exhaust fan energy. Values for some products can be found at the Home Ventilating Institute
 															(hvi.org).</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="SensibleRecoveryEfficiency" type="FractionExcludingZero">
-													<xs:annotation>
-														<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by electric consumption, case heat loss or heat gain,
+												<xs:element minOccurs="0"
+												name="SensibleRecoveryEfficiency"
+												type="FractionExcludingZero">
+												<xs:annotation>
+												<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by electric consumption, case heat loss or heat gain,
 															air leakage, airflow mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test),
 															as a percent of the potential sensible energy that could be recovered plus the exhaust fan energy. Values for some products can be found at
 															the Home Ventilating Institute (hvi.org).</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="AdjustedTotalRecoveryEfficiency" type="FractionExcludingZero">
-													<xs:annotation>
-														<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by case heat loss
+												<xs:element minOccurs="0"
+												name="AdjustedTotalRecoveryEfficiency"
+												type="FractionExcludingZero">
+												<xs:annotation>
+												<xs:documentation>The net total energy (sensible plus latent, also called enthalpy) recovered by the supply airstream adjusted by case heat loss
 															or heat gain, air leakage and airflow mass imbalance between the two airstreams, as a percent of the potential total energy that could be
 															recovered. This value is used to predict and compare Cooling Season Performance for the HRV/ERV unit. This value should be used for energy
 															modeling when wattage for air movement is separately accounted for in the energy model. Values for some products can be found at the Home
 															Ventilating Institute (hvi.org).</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="AdjustedSensibleRecoveryEfficiency" type="FractionExcludingZero">
-													<xs:annotation>
-														<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by case heat loss or heat gain, air leakage, airflow
+												<xs:element minOccurs="0"
+												name="AdjustedSensibleRecoveryEfficiency"
+												type="FractionExcludingZero">
+												<xs:annotation>
+												<xs:documentation>The net sensible energy recovered by the supply airstream as adjusted by case heat loss or heat gain, air leakage, airflow
 															mass imbalance between the two airstreams and the energy used for defrost (when running the Very Low Temperature Test), as a percent of the
 															potential sensible energy that could be recovered. This value should be used for energy modeling when wattage for air movement is separately
 															accounted for in the energy model. Values for some products can be found at the Home Ventilating Institute (hvi.org).</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="FanPower" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>[W]</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="FanPower"
+												type="HPXMLDouble">
+												<xs:annotation>
+												<xs:documentation>[W]</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="VentilationFanThirdPartyCertification"/>
-												<xs:element name="AttachedToHVACDistributionSystem" type="LocalReference" minOccurs="0" maxOccurs="1">
-													<xs:annotation>
-														<xs:documentation>For central fan integrated supply mechanical ventilation, specifies the HVAC distribution system it is attached
+												<xs:element maxOccurs="unbounded" minOccurs="0"
+												name="ThirdPartyCertification"
+												type="VentilationFanThirdPartyCertification"/>
+												<xs:element name="AttachedToHVACDistributionSystem"
+												type="LocalReference" minOccurs="0" maxOccurs="1">
+												<xs:annotation>
+												<xs:documentation>For central fan integrated supply mechanical ventilation, specifies the HVAC distribution system it is attached
 															to.</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -1608,7 +1811,8 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="VentSystemType" type="VentSystem"/>
+									<xs:element minOccurs="0" name="VentSystemType"
+										type="VentSystem"/>
 									<xs:element minOccurs="0" ref="AttachedToZone"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
@@ -1628,56 +1832,68 @@
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
 									<xs:element minOccurs="0" ref="AttachedToZone"/>
-									<xs:element minOccurs="0" name="AttachedToCAZ" type="LocalReference"/>
+									<xs:element minOccurs="0" name="AttachedToCAZ"
+										type="LocalReference"/>
 									<xs:element name="FuelType" type="FuelType" minOccurs="0"/>
-									<xs:element name="WaterHeaterType" type="WaterHeaterType" minOccurs="0"/>
+									<xs:element name="WaterHeaterType" type="WaterHeaterType"
+										minOccurs="0"/>
 									<xs:element name="Location" type="UnitLocation" minOccurs="0"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
 									<xs:element name="ModelYear" type="Year" minOccurs="0"/>
-									<xs:element name="Manufacturer" type="Manufacturer" minOccurs="0"/>
+									<xs:element name="Manufacturer" type="Manufacturer"
+										minOccurs="0"/>
 									<xs:element name="ModelNumber" type="Model" minOccurs="0"/>
 									<xs:element minOccurs="0" name="AHRINumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
-									<xs:element minOccurs="0" name="IsSharedSystem" type="HPXMLBoolean">
+									<xs:element minOccurs="0" name="IsSharedSystem"
+										type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Does the system serve multiple building/dwelling units or a shared laundry/equipment room?</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofUnitsServed" type="HPXMLInteger"/>
-									<xs:element minOccurs="0" name="PerformanceAdjustment" type="Fraction">
+									<xs:element minOccurs="0" name="NumberofUnitsServed"
+										type="HPXMLInteger"/>
+									<xs:element minOccurs="0" name="PerformanceAdjustment"
+										type="Fraction">
 										<xs:annotation>
 											<xs:documentation>A multiplier on the performance of the system. A value of 1 implies no performance adjustment.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="ThirdPartyCertification" type="DHWThirdPartyCertification" maxOccurs="unbounded"/>
+									<xs:element minOccurs="0" name="ThirdPartyCertification"
+										type="DHWThirdPartyCertification" maxOccurs="unbounded"/>
 									<xs:element name="TankVolume" type="Volume" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[gal] Nominal capacity</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="MeasuredTankVolume" type="Volume" minOccurs="0">
+									<xs:element name="MeasuredTankVolume" type="Volume"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[gal] Measured capacity</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FractionDHWLoadServed" type="Fraction"/>
+									<xs:element minOccurs="0" name="FractionDHWLoadServed"
+										type="Fraction"/>
 									<xs:element name="HeatingCapacity" type="Capacity" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[Btuh] For a heat pump water heater, the capacity of the heat pump.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="BackupHeatingCapacity" type="Capacity" minOccurs="0">
+									<xs:element name="BackupHeatingCapacity" type="Capacity"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[Btuh] The capacity of the electric resistance heating in a heat pump water heater.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="EnergyFactor" type="EnergyFactor" minOccurs="0">
+									<xs:element name="EnergyFactor" type="EnergyFactor"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>The amount of energy delivered as heated water in a day divided by the total daily energy consumption of a residential water heater, as
 												determined following standardized DOE testing procedure.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="UniformEnergyFactor" type="EnergyFactor" minOccurs="0">
+									<xs:element name="UniformEnergyFactor" type="EnergyFactor"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>DOE’s new metric for communicating the energy efficiency of a residential water heater, which replaces the Energy Factor (EF) metric. More
 												efficient water heaters have a higher Uniform Energy Factor (UEF). UEF is determined by the Department of Energy’s test method outlined in 10 CFR Part
@@ -1689,19 +1905,22 @@
 											<xs:documentation>The dimensionless coefficient of performance, used to measure the efficiency of a commercial heat pump water heater.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HPWHOperatingMode" type="HPWHOperatingMode"/>
+									<xs:element minOccurs="0" name="HPWHOperatingMode"
+										type="HPWHOperatingMode"/>
 									<xs:element minOccurs="0" name="HPWHDucting">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="SupplyAirSource" type="AdjacentTo">
-													<xs:annotation>
-														<xs:documentation>Where the air is supplied from; not the location where the supply ducts are running through.</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="SupplyAirSource"
+												type="AdjacentTo">
+												<xs:annotation>
+												<xs:documentation>Where the air is supplied from; not the location where the supply ducts are running through.</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="ExhaustAirTermination" type="AdjacentTo">
-													<xs:annotation>
-														<xs:documentation>Where the air is exhausted to; not the location where the exhaust ducts are running through.</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0"
+												name="ExhaustAirTermination" type="AdjacentTo">
+												<xs:annotation>
+												<xs:documentation>Where the air is exhausted to; not the location where the exhaust ducts are running through.</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element ref="extension" minOccurs="0"/>
 											</xs:sequence>
@@ -1724,79 +1943,102 @@
 												nominal temperature rise of 77°F during steady state operation.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="RecoveryEfficiency" type="RecoveryEfficiency" minOccurs="0">
+									<xs:element name="RecoveryEfficiency" type="RecoveryEfficiency"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>The ratio of energy delivered to heat cold water compared to the energy consumed by the water heater, as determined following standardized
 												DOE testing procedure.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ThermalEfficiency" type="ThermalEfficiency" minOccurs="0"/>
+									<xs:element name="ThermalEfficiency" type="ThermalEfficiency"
+										minOccurs="0"/>
 									<xs:element minOccurs="0" name="WaterHeaterInsulation">
 										<xs:complexType>
 											<xs:sequence>
 												<xs:element minOccurs="0" name="Jacket">
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element minOccurs="0" name="InsulationMaterial" type="InsulationMaterial"/>
-															<xs:element name="JacketRValue" type="RValue" minOccurs="0"/>
-															<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
-																<xs:annotation>
-																	<xs:documentation>[in]</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" ref="extension"/>
-														</xs:sequence>
-														<xs:attribute name="dataSource" type="DataSource"/>
-													</xs:complexType>
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element minOccurs="0"
+												name="InsulationMaterial"
+												type="InsulationMaterial"/>
+												<xs:element name="JacketRValue" type="RValue"
+												minOccurs="0"/>
+												<xs:element minOccurs="0" name="Thickness"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[in]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												<xs:attribute name="dataSource" type="DataSource"
+												/>
+												</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="TankWall">
-													<xs:annotation>
-														<xs:documentation>Refers to the insulation in the tank wall itself. This information is sometimes available on the water heater's name plate or
+												<xs:annotation>
+												<xs:documentation>Refers to the insulation in the tank wall itself. This information is sometimes available on the water heater's name plate or
 															the units specification sheet, or can be estimated by removing the water heater's access plate.</xs:documentation>
-													</xs:annotation>
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element minOccurs="0" name="InsulationMaterial" type="InsulationMaterial"/>
-															<xs:element name="TankWallRValue" type="RValue" minOccurs="0"/>
-															<xs:element minOccurs="0" name="Thickness" type="LengthMeasurement">
-																<xs:annotation>
-																	<xs:documentation>[in]</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" ref="extension"/>
-														</xs:sequence>
-														<xs:attribute name="dataSource" type="DataSource"/>
-													</xs:complexType>
+												</xs:annotation>
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element minOccurs="0"
+												name="InsulationMaterial"
+												type="InsulationMaterial"/>
+												<xs:element name="TankWallRValue" type="RValue"
+												minOccurs="0"/>
+												<xs:element minOccurs="0" name="Thickness"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[in]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												<xs:attribute name="dataSource" type="DataSource"
+												/>
+												</xs:complexType>
 												</xs:element>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="StandbyLoss" type="StandbyLossType">
+									<xs:element minOccurs="0" name="StandbyLoss"
+										type="StandbyLossType">
 										<xs:annotation>
 											<xs:documentation>The standby heat loss rate for, e.g., indirect or commercial water heaters. Published in the AHRI Consumer’s Directory of Certified Efficiency Ratings.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="MeetsACCA5QIHVACSpecification" type="HPXMLBoolean" minOccurs="0"/>
-									<xs:element name="HotWaterTemperature" type="Temperature" minOccurs="0">
+									<xs:element name="MeetsACCA5QIHVACSpecification"
+										type="HPXMLBoolean" minOccurs="0"/>
+									<xs:element name="HotWaterTemperature" type="Temperature"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[deg F]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HasMixingValve" type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="UsesDesuperheater" type="HPXMLBoolean">
+									<xs:element minOccurs="0" name="HasMixingValve"
+										type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="UsesDesuperheater"
+										type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Indicates whether this water heater uses a desuperheater. The attached heat pump or air conditioner can be referenced in the
 												RelatedHVACSystem element.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HasSharedCombustionVentilation" type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="CombustionVentilationOrphaned" type="HPXMLBoolean"/>
-									<xs:element name="CombustionVentingSystem" minOccurs="0" type="LocalReference"/>
-									<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="HasSharedCombustionVentilation"
+										type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="CombustionVentilationOrphaned"
+										type="HPXMLBoolean"/>
+									<xs:element name="CombustionVentingSystem" minOccurs="0"
+										type="LocalReference"/>
+									<xs:element minOccurs="0" name="AutomaticVentDamper"
+										type="HPXMLBoolean"/>
 									<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
-									<xs:element name="RelatedHVACSystem" type="LocalReference" minOccurs="0">
+									<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
+										type="HPXMLBoolean"/>
+									<xs:element name="RelatedHVACSystem" type="LocalReference"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>Reference a HeatingSystem, HeatPump, or CoolingSystem.</xs:documentation>
 										</xs:annotation>
@@ -1804,13 +2046,15 @@
 									<xs:element minOccurs="0" name="Installation">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="Standard" type="HVACInstallationStandard"/>
+												<xs:element minOccurs="0" name="Standard"
+												type="HVACInstallationStandard"/>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="WaterHeaterImprovement" type="WaterHeaterImprovementInfo"/>
+									<xs:element minOccurs="0" name="WaterHeaterImprovement"
+										type="WaterHeaterImprovementInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1824,8 +2068,10 @@
 									<xs:element minOccurs="0" name="Model" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
-									<xs:element minOccurs="0" name="ControlTechnology" type="DHWControllerTechnology"/>
-									<xs:element minOccurs="0" name="TemperatureControl" type="DHWTemperatureControl"/>
+									<xs:element minOccurs="0" name="ControlTechnology"
+										type="DHWControllerTechnology"/>
+									<xs:element minOccurs="0" name="TemperatureControl"
+										type="DHWTemperatureControl"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -1835,7 +2081,8 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="AttachedToWaterHeatingSystem" type="LocalReference">
+									<xs:element minOccurs="0" name="AttachedToWaterHeatingSystem"
+										type="LocalReference">
 										<xs:annotation>
 											<xs:documentation>The water heating system that this distribution system serves.</xs:documentation>
 										</xs:annotation>
@@ -1844,61 +2091,73 @@
 										<xs:complexType>
 											<xs:choice>
 												<xs:element name="Standard">
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element minOccurs="0" name="PipingLength" type="LengthMeasurement">
-																<xs:annotation>
-																	<xs:documentation>Measured length of hot water piping from the hot water heater to the farthest hot water fixture, measured
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element minOccurs="0" name="PipingLength"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>Measured length of hot water piping from the hot water heater to the farthest hot water fixture, measured
 																		longitudinally from plans, assuming the hot water piping does not run diagonally, plus 10 feet of piping for each floor level,
 																		plus 5 feet of piping for unconditioned basements. [ft]</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" ref="extension"/>
-														</xs:sequence>
-														<xs:attribute name="dataSource" type="DataSource"/>
-													</xs:complexType>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												<xs:attribute name="dataSource" type="DataSource"
+												/>
+												</xs:complexType>
 												</xs:element>
 												<xs:element name="Recirculation">
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element minOccurs="0" name="ControlType" type="RecirculationControlType"/>
-															<xs:element minOccurs="0" name="RecirculationPipingLoopLength" type="LengthMeasurement">
-																<xs:annotation>
-																	<xs:documentation>Hot water recirculation loop piping length including both supply and return sides of the loop, measured
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element minOccurs="0" name="ControlType"
+												type="RecirculationControlType"/>
+												<xs:element minOccurs="0"
+												name="RecirculationPipingLoopLength"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>Hot water recirculation loop piping length including both supply and return sides of the loop, measured
 																		longitudinally from plans, assuming the hot water piping does not run diagonally. [ft]</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" name="BranchPipingLength" type="LengthMeasurement">
-																<xs:annotation>
-																	<xs:documentation>Length of the branch hot water piping from the recirculation loop to the farthest hot water fixture from the
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0"
+												name="BranchPipingLength" type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>Length of the branch hot water piping from the recirculation loop to the farthest hot water fixture from the
 																		recirculation loop, measured longitudinally from plans, assuming the branch hot water piping does not run diagonally, plus 20
 																		feet of piping for each floor level greater than one plus 10 feet of piping for unconditioned basements. [ft]</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" name="PumpPower" type="Power">
-																<xs:annotation>
-																	<xs:documentation>[W]</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" ref="extension"/>
-														</xs:sequence>
-														<xs:attribute name="dataSource" type="DataSource"/>
-													</xs:complexType>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="PumpPower"
+												type="Power">
+												<xs:annotation>
+												<xs:documentation>[W]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												<xs:attribute name="dataSource" type="DataSource"
+												/>
+												</xs:complexType>
 												</xs:element>
 											</xs:choice>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="PipeInsulation" type="PipeInsulationType"/>
+									<xs:element minOccurs="0" name="PipeInsulation"
+										type="PipeInsulationType"/>
 									<xs:element minOccurs="0" name="DrainWaterHeatRecovery">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="FacilitiesConnected" type="DrainWaterHeatRecoveryFacilitiesConnected"/>
-												<xs:element minOccurs="0" name="EqualFlow" type="HPXMLBoolean"/>
-												<xs:element minOccurs="0" name="Efficiency" type="FractionExcludingZero">
-													<xs:annotation>
-														<xs:documentation>Efficiency percent expressed as a fraction from 0-1.</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="FacilitiesConnected"
+												type="DrainWaterHeatRecoveryFacilitiesConnected"/>
+												<xs:element minOccurs="0" name="EqualFlow"
+												type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="Efficiency"
+												type="FractionExcludingZero">
+												<xs:annotation>
+												<xs:documentation>Efficiency percent expressed as a fraction from 0-1.</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -1915,11 +2174,15 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:choice minOccurs="0">
-										<xs:element name="AttachedToWaterHeatingSystem" type="LocalReference"/>
-										<xs:element name="AttachedToHotWaterDistribution" type="LocalReference"/>
+										<xs:element name="AttachedToWaterHeatingSystem"
+											type="LocalReference"/>
+										<xs:element name="AttachedToHotWaterDistribution"
+											type="LocalReference"/>
 									</xs:choice>
-									<xs:element minOccurs="1" name="WaterFixtureType" type="WaterFixtureType"/>
-									<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero">
+									<xs:element minOccurs="1" name="WaterFixtureType"
+										type="WaterFixtureType"/>
+									<xs:element minOccurs="0" name="Count"
+										type="IntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Number of similar water fixtures.</xs:documentation>
 										</xs:annotation>
@@ -1934,22 +2197,28 @@
 											<xs:documentation>Is the fixture considered low-flow?</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FaucetAerator" type="HPXMLBoolean">
+									<xs:element minOccurs="0" name="FaucetAerator"
+										type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Does this faucet have an aerator?</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="MinutesPerDay" type="MinutesPerDay">
+									<xs:element minOccurs="0" name="MinutesPerDay"
+										type="MinutesPerDay">
 										<xs:annotation>
 											<xs:documentation>[minutes] Number of minutes per day a water fixture operates.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="TemperatureInitiatedShowerFlowRestrictionValve" type="HPXMLBoolean">
+									<xs:element minOccurs="0"
+										name="TemperatureInitiatedShowerFlowRestrictionValve"
+										type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Does the shower have a device that restricts the flow of water automatically once it has reached temperature?</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="WaterFixtureThirdPartyCertification">
+									<xs:element maxOccurs="unbounded" minOccurs="0"
+										name="ThirdPartyCertification"
+										type="WaterFixtureThirdPartyCertification">
 										<xs:annotation>
 											<xs:documentation>Independent organization has verified that product or appliance meets or exceeds the standard in question.</xs:documentation>
 										</xs:annotation>
@@ -1983,28 +2252,36 @@
 									<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="ModelNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" ref="AttachedToZone"/>
-									<xs:element name="SystemType" minOccurs="0" type="SolarThermalSystemType"/>
-									<xs:element name="CollectorArea" type="SurfaceArea" minOccurs="0">
+									<xs:element name="SystemType" minOccurs="0"
+										type="SolarThermalSystemType"/>
+									<xs:element name="CollectorArea" type="SurfaceArea"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorLoopType" type="SolarThermalCollectorLoopType"/>
-									<xs:element minOccurs="0" name="CollectorType" type="SolarThermalCollectorType"/>
-									<xs:element minOccurs="0" name="CollectorOrientation" type="OrientationType"/>
-									<xs:element minOccurs="0" name="CollectorAzimuth" type="AzimuthType"/>
+									<xs:element minOccurs="0" name="CollectorLoopType"
+										type="SolarThermalCollectorLoopType"/>
+									<xs:element minOccurs="0" name="CollectorType"
+										type="SolarThermalCollectorType"/>
+									<xs:element minOccurs="0" name="CollectorOrientation"
+										type="OrientationType"/>
+									<xs:element minOccurs="0" name="CollectorAzimuth"
+										type="AzimuthType"/>
 									<xs:element minOccurs="0" name="CollectorTilt" type="Tilt">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorRatedOpticalEfficiency" type="CollectorRatedOpticalEfficiency">
+									<xs:element minOccurs="0" name="CollectorRatedOpticalEfficiency"
+										type="CollectorRatedOpticalEfficiency">
 										<xs:annotation>
 											<xs:documentation>[Btu/h-ft^2-F] Often referred to as Fr-tau-alpha (FRta), this describes the optical efficiency portion of the overall collector efficiency. 
 												In the OG-100 SRCC Certified Solar Thermal Collector Directory, this is the y-intercept of the efficiency curve.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorRatedThermalLosses" type="CollectorRatedThermalLosses">
+									<xs:element minOccurs="0" name="CollectorRatedThermalLosses"
+										type="CollectorRatedThermalLosses">
 										<xs:annotation>
 											<xs:documentation>Often referred to as Fr-Ul (FRUl), this describes the collector thermal losses portion of the overall collector efficiency. In the OG-100
 												SRCC Certified Solar Thermal Collector Directory, this is the slope of the efficiency curve.</xs:documentation>
@@ -2015,15 +2292,18 @@
 											<xs:documentation>[gal]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="ConnectedTo" type="LocalReference"/>
-									<xs:element minOccurs="0" name="SolarFraction" type="SolarFraction">
+									<xs:element minOccurs="0" name="ConnectedTo"
+										type="LocalReference"/>
+									<xs:element minOccurs="0" name="SolarFraction"
+										type="SolarFraction">
 										<xs:annotation>
 											<xs:documentation>The Solar Fraction is the portion of the total conventional hot water heating load (delivered energy and tank standby losses). The higher
 												the solar fraction, the greater the solar contribution to water heating, which reduces the energy required by the backup water heater. This value can be
 												found in the OG-300 SRCC Certified Solar Water Heating System Directory.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="SolarEnergyFactor" type="SolarThermalSystemEnergyFactor">
+									<xs:element minOccurs="0" name="SolarEnergyFactor"
+										type="SolarThermalSystemEnergyFactor">
 										<xs:annotation>
 											<xs:documentation>The Solar Energy Factor is defined as the energy delivered by the system divided by the electrical or gas energy put into the system. The
 												higher the number, the more energy efficient. This value can be found in the OG-300 SRCC Certified Solar Water Heating System
@@ -2047,17 +2327,23 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
-									<xs:element minOccurs="0" name="IsSharedSystem" type="HPXMLBoolean">
+									<xs:element minOccurs="0" name="IsSharedSystem"
+										type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Does the system serve multiple building/dwelling units?</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofUnitsServed" type="HPXMLInteger"/>
-									<xs:element minOccurs="0" name="Location" type="PVSystemLocation"/>
-									<xs:element minOccurs="0" name="Ownership" type="PVSystemOwnership"/>
+									<xs:element minOccurs="0" name="NumberofUnitsServed"
+										type="HPXMLInteger"/>
+									<xs:element minOccurs="0" name="Location"
+										type="PVSystemLocation"/>
+									<xs:element minOccurs="0" name="Ownership"
+										type="PVSystemOwnership"/>
 									<xs:element minOccurs="0" name="ModuleType" type="PVModuleType"/>
-									<xs:element maxOccurs="1" minOccurs="0" name="Tracking" type="PVTracking"/>
-									<xs:element minOccurs="0" name="ArrayOrientation" type="OrientationType"/>
+									<xs:element maxOccurs="1" minOccurs="0" name="Tracking"
+										type="PVTracking"/>
+									<xs:element minOccurs="0" name="ArrayOrientation"
+										type="OrientationType"/>
 									<xs:element minOccurs="0" name="ArrayAzimuth" type="AzimuthType">
 										<xs:annotation>
 											<xs:documentation>[deg]</xs:documentation>
@@ -2073,33 +2359,40 @@
 											<xs:documentation>[DC Watts] Peak power as supplied by the manufacturer</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="CollectorArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="CollectorArea"
+										type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberOfPanels" type="IntegerGreaterThanZero"/>
-									<xs:element minOccurs="0" name="SystemLossesFraction" type="Fraction">
+									<xs:element minOccurs="0" name="NumberOfPanels"
+										type="IntegerGreaterThanZero"/>
+									<xs:element minOccurs="0" name="SystemLossesFraction"
+										type="Fraction">
 										<xs:annotation>
 											<xs:documentation>System losses can be due to soiling, shading, snow, mismatch, wiring, electrical connections, light-induced degradation, nameplate rating
 												inaccuracies, age, and availability.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="YearModulesManufactured" type="Year"/>
+									<xs:element minOccurs="0" name="YearModulesManufactured"
+										type="Year"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
-									<xs:element minOccurs="0" name="AnnualOutput" type="RatedAnnualkWh">
+									<xs:element minOccurs="0" name="AnnualOutput"
+										type="RatedAnnualkWh">
 										<xs:annotation>
 											<xs:documentation>[kWh] Projected Annual Output for a typical meteorological year as determined by PVWatts or similar. </xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="LevelizedCostOfElectricity" type="Cost">
+									<xs:element minOccurs="0" name="LevelizedCostOfElectricity"
+										type="Cost">
 										<xs:annotation>
 											<xs:documentation>[$] The LCOE is the total cost of installing and operating a project expressed in dollars per kilowatt-hour of electricity generated by
 												the system over its life. Can be calculated with System Advisor Model, a similar software, or through a simplified calculation at
 												http://www.nrel.gov/analysis/tech_lcoe.html.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AttachedToInverter" type="LocalReference"/>
+									<xs:element minOccurs="0" name="AttachedToInverter"
+										type="LocalReference"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -2109,9 +2402,12 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="InverterType" type="InverterType"/>
-									<xs:element minOccurs="0" name="InverterEfficiency" type="FractionExcludingZero"/>
-									<xs:element minOccurs="0" name="YearInverterManufactured" type="Year"/>
+									<xs:element minOccurs="0" name="InverterType"
+										type="InverterType"/>
+									<xs:element minOccurs="0" name="InverterEfficiency"
+										type="FractionExcludingZero"/>
+									<xs:element minOccurs="0" name="YearInverterManufactured"
+										type="Year"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
 									<xs:element ref="extension" minOccurs="0"/>
 								</xs:sequence>
@@ -2128,30 +2424,36 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="Manufacturer" type="Manufacturer"/>
+									<xs:element minOccurs="0" name="Manufacturer"
+										type="Manufacturer"/>
 									<xs:element minOccurs="0" name="ModelNumber" type="Model"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
-									<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero">
+									<xs:element minOccurs="0" name="Count"
+										type="IntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Number of similar batteries.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="Location" type="BatteryLocation"/>
-									<xs:element minOccurs="0" name="GridConnected" type="HPXMLBoolean">
+									<xs:element minOccurs="0" name="GridConnected"
+										type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Has the ability to feed electricity back on to the grid.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="BatteryType" type="BatteryType"/>
-									<xs:element minOccurs="0" name="CoolingStrategy" type="BatteryCoolingStrategy"/>
-									<xs:element minOccurs="0" name="NominalCapacity" type="BatteryCapacityType" maxOccurs="unbounded">
+									<xs:element minOccurs="0" name="CoolingStrategy"
+										type="BatteryCoolingStrategy"/>
+									<xs:element minOccurs="0" name="NominalCapacity"
+										type="BatteryCapacityType" maxOccurs="unbounded">
 										<xs:annotation>
 											<xs:documentation>The total energy available when the battery is discharged starting from 100% state of charge until it reaches the cut-off voltage.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="UsableCapacity" type="BatteryCapacityType" maxOccurs="unbounded">
+									<xs:element minOccurs="0" name="UsableCapacity"
+										type="BatteryCapacityType" maxOccurs="unbounded">
 										<xs:annotation>
 											<xs:documentation>The stored energy that can actually be used. In most cases usable capacity is less than the nominal capacity.</xs:documentation>
 										</xs:annotation>
@@ -2166,13 +2468,15 @@
 											<xs:documentation>[W] The peak power that the battery can generate for a short period of time.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NominalVoltage" type="HPXMLDecimal">
+									<xs:element minOccurs="0" name="NominalVoltage"
+										type="HPXMLDecimal">
 										<xs:annotation>
 											<xs:documentation>[V] The nominal voltage is the battery voltage when the state of charge is 0.5 (midway between being fully charged, and fully discharged)
 												with a 0.2C discharge current.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RoundTripEfficiency" type="FractionExcludingZero">
+									<xs:element minOccurs="0" name="RoundTripEfficiency"
+										type="FractionExcludingZero">
 										<xs:annotation>
 											<xs:documentation>Not all the power that is used to charge the battery is available during discharge. Round trip efficiency is the ratio of the energy put
 												in to the energy retrieved from storage.</xs:documentation>
@@ -2194,15 +2498,22 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanOrEqualToZero"/>
-									<xs:element minOccurs="0" name="Manufacturer" type="Manufacturer"/>
-									<xs:element maxOccurs="1" minOccurs="0" name="ModelNumber" type="Model"/>
+									<xs:element minOccurs="0" name="Count"
+										type="IntegerGreaterThanOrEqualToZero"/>
+									<xs:element minOccurs="0" name="Manufacturer"
+										type="Manufacturer"/>
+									<xs:element maxOccurs="1" minOccurs="0" name="ModelNumber"
+										type="Model"/>
 									<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
-									<xs:element minOccurs="0" name="ChargingLevel" type="EVChargingLevel"/>
-									<xs:element minOccurs="0" name="ChargingConnector" type="EVChargingConnector"/>
-									<xs:element maxOccurs="1" minOccurs="0" name="ModelYear" type="Year"/>
-									<xs:element minOccurs="0" name="ACPowerSourceVoltage" type="Voltage">
+									<xs:element minOccurs="0" name="ChargingLevel"
+										type="EVChargingLevel"/>
+									<xs:element minOccurs="0" name="ChargingConnector"
+										type="EVChargingConnector"/>
+									<xs:element maxOccurs="1" minOccurs="0" name="ModelYear"
+										type="Year"/>
+									<xs:element minOccurs="0" name="ACPowerSourceVoltage"
+										type="Voltage">
 										<xs:annotation>
 											<xs:documentation>[V] Voltage of the AC power source</xs:documentation>
 										</xs:annotation>
@@ -2240,14 +2551,17 @@
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" name="Model" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
-									<xs:element minOccurs="0" name="ThirdPartyCertification" maxOccurs="unbounded" type="WindThirdPartyCertification"/>
-									<xs:element minOccurs="0" name="AWEARatedAnnualEnergy" type="RatedAnnualkWh">
+									<xs:element minOccurs="0" name="ThirdPartyCertification"
+										maxOccurs="unbounded" type="WindThirdPartyCertification"/>
+									<xs:element minOccurs="0" name="AWEARatedAnnualEnergy"
+										type="RatedAnnualkWh">
 										<xs:annotation>
 											<xs:documentation>[kWh] the calculated total energy that would be produced during a one-year period with an average wind speed of 5 m/s (11.2
 												mph)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="AWEARatedSoundLevel" type="HPXMLDouble">
+									<xs:element minOccurs="0" name="AWEARatedSoundLevel"
+										type="HPXMLDouble">
 										<xs:annotation>
 											<xs:documentation>[dBA] the sound pressure level not exceeded by the wind turbine 95% of the time at a distance of 60 meters from the rotor with an average
 												wind speed of 5 m/s (11.2 mph). </xs:documentation>
@@ -2264,17 +2578,20 @@
 											<xs:documentation>[kW] the highest point on the certified power curve.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RotorDiameter" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="RotorDiameter"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HubHeight" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="HubHeight"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="LevelizedCostOfElectricity" type="Cost">
+									<xs:element minOccurs="0" name="LevelizedCostOfElectricity"
+										type="Cost">
 										<xs:annotation>
 											<xs:documentation>[$] The LCOE is the total cost of installing and operating a project expressed in dollars per kilowatt-hour of electricity generated by
 												the system over its life. Can be calculated with System Advisor Model, a similar software, or through a simplified calculation at
@@ -2296,13 +2613,19 @@
 	</xs:complexType>
 	<xs:complexType name="Appliances">
 		<xs:sequence>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="ClothesWasher" type="ClothesWasherInfoType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="ClothesDryer" type="ClothesDryerInfoType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="Dishwasher" type="DishwasherInfoType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="Refrigerator" type="RefrigeratorInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="ClothesWasher"
+				type="ClothesWasherInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="ClothesDryer"
+				type="ClothesDryerInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="Dishwasher"
+				type="DishwasherInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="Refrigerator"
+				type="RefrigeratorInfoType"/>
 			<xs:element minOccurs="0" maxOccurs="unbounded" name="Freezer" type="FreezerInfoType"/>
-			<xs:element name="Dehumidifier" maxOccurs="unbounded" minOccurs="0" type="DehumidifierInfoType"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="CookingRange" type="CookingRangeInfoType"/>
+			<xs:element name="Dehumidifier" maxOccurs="unbounded" minOccurs="0"
+				type="DehumidifierInfoType"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="CookingRange"
+				type="CookingRangeInfoType"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="Oven" type="OvenInfoType"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
@@ -2345,13 +2668,15 @@
 								<xs:documentation>[W] per unit</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="LightingThirdPartyCertification"/>
+						<xs:element maxOccurs="unbounded" minOccurs="0"
+							name="ThirdPartyCertification" type="LightingThirdPartyCertification"/>
 						<xs:element name="AverageHoursPerDay" type="HoursPerDay" minOccurs="0">
 							<xs:annotation>
 								<xs:documentation>[h]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="LightingDailyHours" type="LightingDailyHours">
+						<xs:element minOccurs="0" name="LightingDailyHours"
+							type="LightingDailyHours">
 							<xs:annotation>
 								<xs:documentation>[h]</xs:documentation>
 							</xs:annotation>
@@ -2380,7 +2705,9 @@
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element minOccurs="0" ref="ConnectedDevice"/>
-						<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="LightingFixtureThirdPartyCertification"/>
+						<xs:element maxOccurs="unbounded" minOccurs="0"
+							name="ThirdPartyCertification"
+							type="LightingFixtureThirdPartyCertification"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -2391,9 +2718,11 @@
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element minOccurs="0" ref="ConnectedDevice"/>
-						<xs:element minOccurs="0" name="AttachedToLightingGroup" type="LocalReference"/>
+						<xs:element minOccurs="0" name="AttachedToLightingGroup"
+							type="LocalReference"/>
 						<xs:element name="LightingControlType" type="LightingControls" minOccurs="0"/>
-						<xs:element name="NumberofLightingControls" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+						<xs:element name="NumberofLightingControls"
+							type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
 						<xs:element name="Location" type="LightingLocation" minOccurs="0"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
@@ -2428,7 +2757,8 @@
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
-						<xs:element minOccurs="0" name="ThirdPartyCertification" type="ApplianceThirdPartyCertifications" maxOccurs="unbounded"/>
+						<xs:element minOccurs="0" name="ThirdPartyCertification"
+							type="ApplianceThirdPartyCertifications" maxOccurs="unbounded"/>
 						<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero">
 							<xs:annotation>
 								<xs:documentation>Number of similar ceiling fans.</xs:documentation>
@@ -2490,7 +2820,8 @@
 									<xs:element name="Sodium">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="Pressure" type="SodiumLight_Pressure"/>
+												<xs:element minOccurs="0" name="Pressure"
+												type="SodiumLight_Pressure"/>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
@@ -2534,7 +2865,8 @@
 								<xs:documentation>[gal] Volume of pool.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="MonthsPerYearofOperation" type="MonthsPerYear">
+						<xs:element minOccurs="0" name="MonthsPerYearofOperation"
+							type="MonthsPerYear">
 							<xs:annotation>
 								<xs:documentation>Months per year pool is in operation.</xs:documentation>
 							</xs:annotation>
@@ -2544,7 +2876,8 @@
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="SuctionPipeDiameter" type="LengthMeasurement">
+						<xs:element minOccurs="0" name="SuctionPipeDiameter"
+							type="LengthMeasurement">
 							<xs:annotation>
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
@@ -2566,91 +2899,109 @@
 											<xs:sequence>
 												<xs:group ref="SystemInfo"/>
 												<xs:element minOccurs="0" ref="ConnectedDevice"/>
-												<xs:element minOccurs="0" name="Type" type="PoolPumpType"/>
-												<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString">
-													<xs:annotation>
-														<xs:documentation>Manufacturer of pool pump.</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="Type"
+												type="PoolPumpType"/>
+												<xs:element minOccurs="0" name="Manufacturer"
+												type="HPXMLString">
+												<xs:annotation>
+												<xs:documentation>Manufacturer of pool pump.</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="SerialNumber" type="HPXMLString">
-													<xs:annotation>
-														<xs:documentation>Serial number of pool pump.</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="SerialNumber"
+												type="HPXMLString">
+												<xs:annotation>
+												<xs:documentation>Serial number of pool pump.</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="ModelNumber" type="HPXMLString">
-													<xs:annotation>
-														<xs:documentation>Model number of pool pump.</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="ModelNumber"
+												type="HPXMLString">
+												<xs:annotation>
+												<xs:documentation>Model number of pool pump.</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="ThirdPartyCertification" type="PoolPump3rdPartyCertification" maxOccurs="unbounded">
-													<xs:annotation>
-														<xs:documentation>Independent organization has verified that product or appliance meets or exceeds the standard in question (ENERGY STAR, CEE,
+												<xs:element minOccurs="0"
+												name="ThirdPartyCertification"
+												type="PoolPump3rdPartyCertification"
+												maxOccurs="unbounded">
+												<xs:annotation>
+												<xs:documentation>Independent organization has verified that product or appliance meets or exceeds the standard in question (ENERGY STAR, CEE,
 															or other)</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="EnergyFactor" type="Efficiency">
-													<xs:annotation>
-														<xs:documentation>[gal/Wh] The measure of overall pool filter pump efficiency in units of gallons per watt-hour, as determined using the
+												<xs:element minOccurs="0" name="EnergyFactor"
+												type="Efficiency">
+												<xs:annotation>
+												<xs:documentation>[gal/Wh] The measure of overall pool filter pump efficiency in units of gallons per watt-hour, as determined using the
 															applicable test method in Section 4.1.2. Energy factor is analogous to other energy factors such as miles per gallon. Energy factor (EF) is
 															calculated as: EF (gal/Wh) = flow rate (gpm) * 60 ÷ power (watts) (ANSI/APSP/ICC-15 2011).</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="SpeedSetting" type="PoolPumpSpeedSetting">
-													<xs:annotation>
-														<xs:documentation>The speed setting at which the Energy Factor was measured (ENERGY STAR, 2013).</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="SpeedSetting"
+												type="PoolPumpSpeedSetting">
+												<xs:annotation>
+												<xs:documentation>The speed setting at which the Energy Factor was measured (ENERGY STAR, 2013).</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="RatedHorsepower" type="Power">
-													<xs:annotation>
-														<xs:documentation>The motor power output designed by the manufacturer for a rated RPM, voltage and frequency. May be less than total horsepower
+												<xs:element minOccurs="0" name="RatedHorsepower"
+												type="Power">
+												<xs:annotation>
+												<xs:documentation>The motor power output designed by the manufacturer for a rated RPM, voltage and frequency. May be less than total horsepower
 															where the service factor is greater than 1.0, or equal to total horsepower where the service factor = 1.0 (ANSI/APSP/ICC-15
 															2011).</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="TotalHorsepower" type="Power">
-													<xs:annotation>
-														<xs:documentation>The total horsepower, or product of the rated horsepower and the service factor of a motor used on a pool pump (also known as
+												<xs:element minOccurs="0" name="TotalHorsepower"
+												type="Power">
+												<xs:annotation>
+												<xs:documentation>The total horsepower, or product of the rated horsepower and the service factor of a motor used on a pool pump (also known as
 															SFHP) based on the maximum continuous duty motor power output rating allowable for the nameplate ambient rating and motor insulation class
 															(e.g., total horsepower = rated horsepower * service factor) (ANSI/APSP/ICC-15 2011).</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="ServiceFactor" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>A multiplier applied to the rated horsepower of a pump motor to indicate the percent above nameplate horsepower at which the
+												<xs:element minOccurs="0" name="ServiceFactor"
+												type="HPXMLDouble">
+												<xs:annotation>
+												<xs:documentation>A multiplier applied to the rated horsepower of a pump motor to indicate the percent above nameplate horsepower at which the
 															motor can operate continuously without exceeding its allowable insulation class temperature limit, provided that other design parameters,
 															such rated voltage, frequency and ambient temperature, are within limits. A 1.5 hp pump with a 1.65 service factor produces 2.475 hp (total
 															horsepower) at the maximum service factor point (ANSI/APSP/ICC-15 2011).</xs:documentation>
-													</xs:annotation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element maxOccurs="unbounded" minOccurs="0" name="PumpSpeed">
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element minOccurs="0" name="Power" type="Power">
-																<xs:annotation>
-																	<xs:documentation>[W]</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" name="MotorNominalSpeed" type="Speed">
-																<xs:annotation>
-																	<xs:documentation>[Rev/min] The number of revolutions of the motor shaft in a given unit of time, expressed as revolutions per
+												<xs:element maxOccurs="unbounded" minOccurs="0"
+												name="PumpSpeed">
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element minOccurs="0" name="Power"
+												type="Power">
+												<xs:annotation>
+												<xs:documentation>[W]</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="MotorNominalSpeed"
+												type="Speed">
+												<xs:annotation>
+												<xs:documentation>[Rev/min] The number of revolutions of the motor shaft in a given unit of time, expressed as revolutions per
 																		minute (RPM) (ENERGY STAR, 2013).</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" name="FlowRate" type="FlowRate">
-																<xs:annotation>
-																	<xs:documentation>[gal/min] The volume of water flowing through the filtration system in a given time, usually measured in gallons
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="FlowRate"
+												type="FlowRate">
+												<xs:annotation>
+												<xs:documentation>[gal/min] The volume of water flowing through the filtration system in a given time, usually measured in gallons
 																		per minute (gpm) (ANSI/APSP/ICC-15 2011).</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" name="HoursPerDay" type="HoursPerDay">
-																<xs:annotation>
-																	<xs:documentation>[hours] Number of hours per day a pool pump operates at a particular speed setting.</xs:documentation>
-																</xs:annotation>
-															</xs:element>
-															<xs:element minOccurs="0" ref="extension"/>
-														</xs:sequence>
-														<xs:attribute name="dataSource" type="DataSource"/>
-													</xs:complexType>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" name="HoursPerDay"
+												type="HoursPerDay">
+												<xs:annotation>
+												<xs:documentation>[hours] Number of hours per day a pool pump operates at a particular speed setting.</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												<xs:attribute name="dataSource" type="DataSource"
+												/>
+												</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -2719,7 +3070,8 @@
 						<xs:element minOccurs="0" ref="AttachedToSpace"/>
 						<xs:element name="PlugLoadType" type="PlugLoadType" minOccurs="0"/>
 						<xs:element minOccurs="0" name="Location" type="PlugLoadLocation"/>
-						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero"
+							minOccurs="0"/>
 						<xs:element minOccurs="0" name="Load">
 							<xs:complexType>
 								<xs:sequence>
@@ -2741,8 +3093,10 @@
 						<xs:element minOccurs="0" ref="ConnectedDevice"/>
 						<xs:element minOccurs="0" name="ControlsPlugLoad" type="LocalReference"/>
 						<xs:element minOccurs="0" ref="AttachedToSpace"/>
-						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
-						<xs:element name="PlugLoadControlType" minOccurs="0" type="PlugLoadControlType"/>
+						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero"
+							minOccurs="0"/>
+						<xs:element name="PlugLoadControlType" minOccurs="0"
+							type="PlugLoadControlType"/>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -2756,7 +3110,8 @@
 						<xs:element minOccurs="0" ref="AttachedToSpace"/>
 						<xs:element name="FuelLoadType" type="FuelLoadType" minOccurs="0"/>
 						<xs:element minOccurs="0" name="Location" type="FuelLoadLocation"/>
-						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+						<xs:element name="Count" type="IntegerGreaterThanOrEqualToZero"
+							minOccurs="0"/>
 						<xs:element minOccurs="0" name="Load">
 							<xs:complexType>
 								<xs:sequence>
@@ -2790,10 +3145,14 @@
 			<xs:element name="Ventilation" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="WholeBuildingVentilationDesign" type="WholeBldgVentDesignInfo"/>
-						<xs:element minOccurs="0" name="SpotVentilationDesign" type="SpotVentDesignInfo"/>
-						<xs:element minOccurs="0" name="OtherVentilationIssues" type="OtherVentIssues"/>
-						<xs:element minOccurs="0" name="VentilationImprovement" type="VentilationImprovementInfo"/>
+						<xs:element minOccurs="0" name="WholeBuildingVentilationDesign"
+							type="WholeBldgVentDesignInfo"/>
+						<xs:element minOccurs="0" name="SpotVentilationDesign"
+							type="SpotVentDesignInfo"/>
+						<xs:element minOccurs="0" name="OtherVentilationIssues"
+							type="OtherVentIssues"/>
+						<xs:element minOccurs="0" name="VentilationImprovement"
+							type="VentilationImprovementInfo"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -2802,8 +3161,10 @@
 			<xs:element name="MoistureControl" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="MoistureControlInfo" type="MoistureControlInfoType"/>
-						<xs:element minOccurs="0" name="MoistureControlImprovement" type="MoistureControlImprovementInfo"/>
+						<xs:element maxOccurs="unbounded" name="MoistureControlInfo"
+							type="MoistureControlInfoType"/>
+						<xs:element minOccurs="0" name="MoistureControlImprovement"
+							type="MoistureControlImprovementInfo"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -2812,27 +3173,32 @@
 			<xs:element minOccurs="0" name="CombustionAppliances">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="MaxAmbientCOinLivingSpaceDuringAudit" minOccurs="0" type="HPXMLDouble">
+						<xs:element name="MaxAmbientCOinLivingSpaceDuringAudit" minOccurs="0"
+							type="HPXMLDouble">
 							<xs:annotation>
 								<xs:documentation>Monitored throughout assessment, not just appliance testing</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="CombustionApplianceZone" maxOccurs="unbounded">
+						<xs:element minOccurs="0" name="CombustionApplianceZone"
+							maxOccurs="unbounded">
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element name="CAZDepressurizationLimit" type="CAZDepressurizationLimit" minOccurs="0">
+									<xs:element name="CAZDepressurizationLimit"
+										type="CAZDepressurizationLimit" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>Pulled from industry standards by users (e.g. BPI Gold Sheet) or via software program</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="BaselineTest" type="CAZTestConfiguration" minOccurs="0">
+									<xs:element name="BaselineTest" type="CAZTestConfiguration"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>Baseline pressure is read under the following conditions: no items running, all fans off, all exterior doors closed, and all interior
 												doors are opened.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="PoorCaseTest" type="CAZTestConfiguration">
+									<xs:element minOccurs="0" name="PoorCaseTest"
+										type="CAZTestConfiguration">
 										<xs:annotation>
 											<xs:documentation>The poor case CAZ depressurization test is configured by determining the largest combustion appliance zone depressurization attainable at
 												the time of testing due to the combined effects of door position, exhaust appliance operation, and air handler fan operation. A base pressure must be
@@ -2840,97 +3206,116 @@
 												depressurization attained at the time of testing and the base pressure.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="NetPressureChange" type="NetPressureChange" minOccurs="0">
+									<xs:element name="NetPressureChange" type="NetPressureChange"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>With respect to the baseline pressure (e.g. no fans running, all exterior doors closed, and all interior doors opened)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="DepressurizationFindingPoorCase" type="DepressurizationFindingPoorCase" minOccurs="0"/>
-									<xs:element name="AmountAmbientCOinCAZduringTesting" type="HPXMLDouble" minOccurs="0">
+									<xs:element name="DepressurizationFindingPoorCase"
+										type="DepressurizationFindingPoorCase" minOccurs="0"/>
+									<xs:element name="AmountAmbientCOinCAZduringTesting"
+										type="HPXMLDouble" minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>parts per million (ppm)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="AmbientCOinCAZExceeded35ppmduringTesting" type="HPXMLBoolean" minOccurs="0"/>
-									<xs:element minOccurs="0" name="CombustionApplianceTest" maxOccurs="unbounded">
+									<xs:element name="AmbientCOinCAZExceeded35ppmduringTesting"
+										type="HPXMLBoolean" minOccurs="0"/>
+									<xs:element minOccurs="0" name="CombustionApplianceTest"
+										maxOccurs="unbounded">
 										<xs:complexType>
 											<xs:sequence minOccurs="0">
-												<xs:element name="CAZAppliance" type="RemoteReference">
-													<xs:annotation>
-														<xs:documentation>The ID of the system tested</xs:documentation>
-													</xs:annotation>
+												<xs:element name="CAZAppliance"
+												type="RemoteReference">
+												<xs:annotation>
+												<xs:documentation>The ID of the system tested</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="CombustionVentingSystem" type="RemoteReference"/>
-												<xs:element name="FlueVisualCondition" type="FlueCondition" minOccurs="0"/>
-												<xs:element minOccurs="0" name="FlueConditionNotes" type="HPXMLString"/>
-												<xs:element name="OutsideTemperatureFlueDraftTest" type="Temperature" minOccurs="0">
-													<xs:annotation>
-														<xs:documentation>[deg F]</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0"
+												name="CombustionVentingSystem"
+												type="RemoteReference"/>
+												<xs:element name="FlueVisualCondition"
+												type="FlueCondition" minOccurs="0"/>
+												<xs:element minOccurs="0" name="FlueConditionNotes"
+												type="HPXMLString"/>
+												<xs:element name="OutsideTemperatureFlueDraftTest"
+												type="Temperature" minOccurs="0">
+												<xs:annotation>
+												<xs:documentation>[deg F]</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" name="FlueDraftTest">
-													<xs:annotation>
-														<xs:documentation>[Pa]</xs:documentation>
-													</xs:annotation>
-													<xs:complexType>
-														<xs:complexContent>
-															<xs:extension base="CAZApplianceReading">
-																<xs:sequence>
-																	<xs:element ref="extension" minOccurs="0"/>
-																</xs:sequence>
-															</xs:extension>
-														</xs:complexContent>
-													</xs:complexType>
+												<xs:annotation>
+												<xs:documentation>[Pa]</xs:documentation>
+												</xs:annotation>
+												<xs:complexType>
+												<xs:complexContent>
+												<xs:extension base="CAZApplianceReading">
+												<xs:sequence>
+												<xs:element ref="extension" minOccurs="0"/>
+												</xs:sequence>
+												</xs:extension>
+												</xs:complexContent>
+												</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="SpillageTest">
-													<xs:annotation>
-														<xs:documentation>[seconds]</xs:documentation>
-													</xs:annotation>
-													<xs:complexType>
-														<xs:complexContent>
-															<xs:extension base="CAZApplianceReading">
-																<xs:sequence>
-																	<xs:element ref="extension" minOccurs="0"/>
-																</xs:sequence>
-															</xs:extension>
-														</xs:complexContent>
-													</xs:complexType>
+												<xs:annotation>
+												<xs:documentation>[seconds]</xs:documentation>
+												</xs:annotation>
+												<xs:complexType>
+												<xs:complexContent>
+												<xs:extension base="CAZApplianceReading">
+												<xs:sequence>
+												<xs:element ref="extension" minOccurs="0"/>
+												</xs:sequence>
+												</xs:extension>
+												</xs:complexContent>
+												</xs:complexType>
 												</xs:element>
 												<xs:element minOccurs="0" name="CarbonMonoxideTest">
-													<xs:annotation>
-														<xs:documentation>[ppm]</xs:documentation>
-													</xs:annotation>
-													<xs:complexType>
-														<xs:complexContent>
-															<xs:extension base="CAZApplianceReading">
-																<xs:sequence>
-																	<xs:element minOccurs="0" name="AmbientCOActionDuringCAZTesting" type="HPXMLString">
-																		<xs:annotation>
-																			<xs:documentation>BPI Gold Sheet is one example that shows action levels based upon decision logic</xs:documentation>
-																		</xs:annotation>
-																	</xs:element>
-																	<xs:element minOccurs="0" ref="extension"/>
-																</xs:sequence>
-															</xs:extension>
-														</xs:complexContent>
-													</xs:complexType>
+												<xs:annotation>
+												<xs:documentation>[ppm]</xs:documentation>
+												</xs:annotation>
+												<xs:complexType>
+												<xs:complexContent>
+												<xs:extension base="CAZApplianceReading">
+												<xs:sequence>
+												<xs:element minOccurs="0"
+												name="AmbientCOActionDuringCAZTesting"
+												type="HPXMLString">
+												<xs:annotation>
+												<xs:documentation>BPI Gold Sheet is one example that shows action levels based upon decision logic</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element name="StackTemperature" type="Temperature" minOccurs="0">
-													<xs:annotation>
-														<xs:documentation>[deg F] after 10 minutes run time</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												</xs:extension>
+												</xs:complexContent>
+												</xs:complexType>
 												</xs:element>
-												<xs:element name="FuelLeaks" minOccurs="0" maxOccurs="unbounded">
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element name="FuelType" type="FuelType"/>
-															<xs:element name="LeaksIdentified" type="HPXMLBoolean"/>
-															<xs:element name="LeaksAddressed" type="HPXMLBoolean"/>
-															<xs:element minOccurs="0" name="Notes" type="HPXMLString"/>
-															<xs:element minOccurs="0" ref="extension"/>
-														</xs:sequence>
-														<xs:attribute name="dataSource" type="DataSource"/>
-													</xs:complexType>
+												<xs:element name="StackTemperature"
+												type="Temperature" minOccurs="0">
+												<xs:annotation>
+												<xs:documentation>[deg F] after 10 minutes run time</xs:documentation>
+												</xs:annotation>
+												</xs:element>
+												<xs:element name="FuelLeaks" minOccurs="0"
+												maxOccurs="unbounded">
+												<xs:complexType>
+												<xs:sequence>
+												<xs:element name="FuelType" type="FuelType"/>
+												<xs:element name="LeaksIdentified"
+												type="HPXMLBoolean"/>
+												<xs:element name="LeaksAddressed"
+												type="HPXMLBoolean"/>
+												<xs:element minOccurs="0" name="Notes"
+												type="HPXMLString"/>
+												<xs:element minOccurs="0" ref="extension"/>
+												</xs:sequence>
+												<xs:attribute name="dataSource" type="DataSource"
+												/>
+												</xs:complexType>
 												</xs:element>
 												<xs:element ref="extension" minOccurs="0"/>
 											</xs:sequence>
@@ -2952,7 +3337,8 @@
 					<xs:sequence>
 						<xs:element name="StoveID" type="SystemIdentifiersInfoType"/>
 						<xs:element minOccurs="0" name="StoveFuel" type="FuelType"/>
-						<xs:element name="HeatingStoveProperlyVented" type="HPXMLBoolean" minOccurs="0"/>
+						<xs:element name="HeatingStoveProperlyVented" type="HPXMLBoolean"
+							minOccurs="0"/>
 						<xs:element name="COReading" type="COReading" minOccurs="0"/>
 						<xs:element minOccurs="0" name="TimeofCOReading" type="HPXMLDateTime"/>
 						<xs:element name="GasLeaksIdentified" type="HPXMLBoolean" minOccurs="0"/>
@@ -2980,7 +3366,8 @@
 								<xs:documentation>Did the contracted scope of work include window replacement?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="LeadSafeCertificationNumber" type="HPXMLString">
+						<xs:element minOccurs="0" name="LeadSafeCertificationNumber"
+							type="HPXMLString">
 							<xs:annotation>
 								<xs:documentation>Certification Number of the EPA Lead-Safe Certified firm that performed the work.</xs:documentation>
 							</xs:annotation>
@@ -2998,27 +3385,34 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
-									<xs:element minOccurs="0" name="StartDateTime" type="HPXMLDateTime"/>
-									<xs:element minOccurs="0" name="EndDateTime" type="HPXMLDateTime"/>
-									<xs:element minOccurs="0" name="TestLocation" type="RadonTestLocation"/>
-									<xs:element name="RadonTestResults" type="HPXMLDouble" minOccurs="0">
+									<xs:element minOccurs="0" name="StartDateTime"
+										type="HPXMLDateTime"/>
+									<xs:element minOccurs="0" name="EndDateTime"
+										type="HPXMLDateTime"/>
+									<xs:element minOccurs="0" name="TestLocation"
+										type="RadonTestLocation"/>
+									<xs:element name="RadonTestResults" type="HPXMLDouble"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>in pCi/L</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RadonTestMethod" type="RadonTestTypes"/>
+									<xs:element minOccurs="0" name="RadonTestMethod"
+										type="RadonTestTypes"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
-						<xs:element minOccurs="0" name="EducationMaterialProvided" type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="EducationMaterialProvided"
+							type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Was the homeowner provided with educational material?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element minOccurs="0" name="ActionsTaken" type="HPXMLString"/>
-						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecs" type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecs"
+							type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>If moisture management of a crawlspace (e.g., installation of polyethylene sheeting) or radon mitigation measures were a part of the scope of
 									work,were measures installed to be compliant with one of the following: - Specifications of EPA’s Indoor airPLUS program - Techniques detailed in EPA's
@@ -3039,12 +3433,14 @@
 			<xs:element minOccurs="0" name="SourcePollutants">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="UnventedCombustionAppliancesinLivingArea" type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="UnventedCombustionAppliancesinLivingArea"
+							type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Are there unvented combustion heating or hearth appliances present in the living area?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="ConformanceWithANSIZ21_11_2" type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="ConformanceWithANSIZ21_11_2"
+							type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>If yes, does the appliance conform with ANSI Z21.11.2? </xs:documentation>
 							</xs:annotation>
@@ -3059,7 +3455,8 @@
 								<xs:documentation>Does home have attached garage?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="GarageContinuousAirBarrier" type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="GarageContinuousAirBarrier"
+							type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>If yes, is there a continuous air barrier between garage and living space?</xs:documentation>
 							</xs:annotation>
@@ -3087,7 +3484,8 @@
 								<xs:documentation>Evidence of pesticide, insecticide use?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="IndustryStandardCompliance" type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="IndustryStandardCompliance"
+							type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Do measures comply with industry standards to prevent pest entry? NOTE: This is for ALL measures that may create entry points for vermin. For example,
 									air sealing measures identified to reduce infiltration should have proper sealants - even if those measures were not recommended/installed for pest control
@@ -3117,9 +3515,11 @@
 								<xs:documentation>Was asbestos found?</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="TypeofBlowerDoorTest" type="TypeofBlowerDoorTest"/>
+						<xs:element minOccurs="0" name="TypeofBlowerDoorTest"
+							type="TypeofBlowerDoorTest"/>
 						<xs:element minOccurs="0" name="ActionsTaken" type="HPXMLString"/>
-						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecifications" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="ActionsMeetIndustrySpecifications"
+							type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -3251,7 +3651,8 @@
 				</xs:element>
 				<xs:element name="RequiredVentilationRateUnits" type="VentilationRateUnits"/>
 			</xs:sequence>
-			<xs:element minOccurs="0" name="VentilationImprovementRecommendation" type="Recommendation"/>
+			<xs:element minOccurs="0" name="VentilationImprovementRecommendation"
+				type="Recommendation"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -3347,7 +3748,8 @@
 					<xs:documentation>should be represented as a fraction (ie 0.5 instead of 50%)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="EndUseSavings" type="EndUseInfoType"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="EndUseSavings"
+				type="EndUseInfoType"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -3387,16 +3789,19 @@
 					<xs:documentation>A multiplier on the performance of the system. A value of 1 implies no performance adjustment.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="HVACThirdPartyCertification"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification"
+				type="HVACThirdPartyCertification"/>
 			<xs:element minOccurs="0" name="HasSharedCombustionVentilation" type="HPXMLBoolean"/>
 			<xs:element minOccurs="0" name="CombustionVentingSystem" type="LocalReference"/>
-			<xs:element name="DistributionSystem" type="LocalReference" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="DistributionSystem" type="LocalReference" minOccurs="0"
+				maxOccurs="unbounded"/>
 			<xs:element minOccurs="0" name="Installation">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element minOccurs="0" name="Standard" type="HVACInstallationStandard"/>
 						<xs:element minOccurs="0" name="SizingCalculation" type="HVACSizingCalcs"/>
-						<xs:element minOccurs="0" name="EnvelopeImprovementsUsedinSizing" type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="EnvelopeImprovementsUsedinSizing"
+							type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Air sealing and insulation implemented prior to replacement and used in calculations for sizing new / replacement system?</xs:documentation>
 							</xs:annotation>
@@ -3440,7 +3845,8 @@
 							<xs:documentation>[Btuh] Output Heating Capacity</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="AnnualHeatingEfficiency" type="HeatingEfficiencyType" maxOccurs="unbounded"/>
+					<xs:element minOccurs="0" name="AnnualHeatingEfficiency"
+						type="HeatingEfficiencyType" maxOccurs="unbounded"/>
 					<xs:element name="FractionHeatLoadServed" type="Fraction" minOccurs="0"/>
 					<xs:element minOccurs="0" name="FloorAreaServed" type="SurfaceArea">
 						<xs:annotation>
@@ -3456,7 +3862,8 @@
 					<xs:element minOccurs="0" name="HeatingDetailedPerformanceData">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element maxOccurs="unbounded" name="PerformanceDataPoint" type="HeatingPerformanceDataPoint"> </xs:element>
+								<xs:element maxOccurs="unbounded" name="PerformanceDataPoint"
+									type="HeatingPerformanceDataPoint"> </xs:element>
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -3476,7 +3883,8 @@
 						<xs:element minOccurs="0" name="PowerBurner" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
-						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
+							type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="RetentionHead" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
@@ -3496,7 +3904,8 @@
 						<xs:element minOccurs="0" name="RotaryCup" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
-						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
+							type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="RetentionHead" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
@@ -3506,7 +3915,8 @@
 			<xs:element name="ElectricResistance">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="ElectricDistribution" type="ElectricDistributionType" minOccurs="0"/>
+						<xs:element name="ElectricDistribution" type="ElectricDistributionType"
+							minOccurs="0"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -3522,7 +3932,8 @@
 						</xs:element>
 						<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
-						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
+							type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -3538,7 +3949,8 @@
 						</xs:element>
 						<xs:element minOccurs="0" name="AutomaticVentDamper" type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="PilotLight" type="HPXMLBoolean"/>
-						<xs:element minOccurs="0" name="IntermittentIgnitionDevice" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="IntermittentIgnitionDevice"
+							type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" ref="extension"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -3622,7 +4034,8 @@
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="BackupSystemFuel" type="FuelType" minOccurs="0"/>
-					<xs:element name="BackupAnnualHeatingEfficiency" minOccurs="0" type="HeatingEfficiencyType" maxOccurs="unbounded"/>
+					<xs:element name="BackupAnnualHeatingEfficiency" minOccurs="0"
+						type="HeatingEfficiencyType" maxOccurs="unbounded"/>
 					<xs:element minOccurs="0" name="BackupHeatingInputRating" type="Capacity">
 						<xs:annotation>
 							<xs:documentation>[Btuh] Input heating capacity</xs:documentation>
@@ -3633,12 +4046,14 @@
 							<xs:documentation>[Btuh] Output heating capacity</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="BackupHeatingSwitchoverTemperature" type="Temperature">
+					<xs:element minOccurs="0" name="BackupHeatingSwitchoverTemperature"
+						type="Temperature">
 						<xs:annotation>
 							<xs:documentation>[deg F] Temperature at which the backup heating is activated and the compressor is disabled in, e.g., a dual-fuel heat pump.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="BackupHeatingLockoutTemperature" type="Temperature">
+					<xs:element minOccurs="0" name="BackupHeatingLockoutTemperature"
+						type="Temperature">
 						<xs:annotation>
 							<xs:documentation>[deg F] Temperature above which the backup heating is disabled, often to prevent backup heating usage during recovery from a thermostat heating setback. For a duel-fuel heat pump, use the BackupHeatingSwitchoverTemperature element.</xs:documentation>
 						</xs:annotation>
@@ -3650,20 +4065,24 @@
 							<xs:documentation>[sq.ft.]</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="AnnualHeatingEfficiency" minOccurs="0" type="HeatingEfficiencyType" maxOccurs="unbounded"/>
+					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType"
+						minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="AnnualHeatingEfficiency" minOccurs="0"
+						type="HeatingEfficiencyType" maxOccurs="unbounded"/>
 					<xs:element minOccurs="0" name="AttachedToGeothermalLoop" type="LocalReference"/>
 					<xs:element minOccurs="0" name="CoolingDetailedPerformanceData">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element maxOccurs="unbounded" name="PerformanceDataPoint" type="CoolingPerformanceDataPoint"> </xs:element>
+								<xs:element maxOccurs="unbounded" name="PerformanceDataPoint"
+									type="CoolingPerformanceDataPoint"> </xs:element>
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
 					<xs:element minOccurs="0" name="HeatingDetailedPerformanceData">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element maxOccurs="unbounded" name="PerformanceDataPoint" type="HeatingPerformanceDataPoint"> </xs:element>
+								<xs:element maxOccurs="unbounded" name="PerformanceDataPoint"
+									type="HeatingPerformanceDataPoint"> </xs:element>
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -3690,12 +4109,14 @@
 							<xs:documentation>[sq.ft.]</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType"
+						minOccurs="0" maxOccurs="unbounded"/>
 					<xs:element minOccurs="0" name="SensibleHeatFraction" type="Fraction"/>
 					<xs:element minOccurs="0" name="CoolingDetailedPerformanceData">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element maxOccurs="unbounded" name="PerformanceDataPoint" type="CoolingPerformanceDataPoint"> </xs:element>
+								<xs:element maxOccurs="unbounded" name="PerformanceDataPoint"
+									type="CoolingPerformanceDataPoint"> </xs:element>
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -3836,7 +4257,8 @@
 				</xs:annotation>
 			</xs:element>
 			<xs:element minOccurs="0" name="PipeDiameter" type="PipeDiameterType"/>
-			<xs:element name="HydronicDistributionType" type="HydronicDistributionType" minOccurs="0"/>
+			<xs:element name="HydronicDistributionType" type="HydronicDistributionType"
+				minOccurs="0"/>
 			<xs:element minOccurs="0" name="SupplyTemperature" type="Temperature">
 				<xs:annotation>
 					<xs:documentation>[degF]</xs:documentation>
@@ -3855,7 +4277,8 @@
 								<xs:documentation>System Pump and Zone Valve Corrections made</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="ThermostaticRadiatorValves" type="HPXMLBoolean"/>
+						<xs:element minOccurs="0" name="ThermostaticRadiatorValves"
+							type="HPXMLBoolean"/>
 						<xs:element minOccurs="0" name="VariableSpeedPump" type="HPXMLBoolean"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -3869,7 +4292,8 @@
 		<xs:sequence>
 			<xs:element name="AirDistributionType" type="AirDistributionType" minOccurs="0"/>
 			<xs:element name="AirHandlerMotorType" type="AirHandlerMotorType" minOccurs="0"/>
-			<xs:element minOccurs="0" name="DuctLeakageMeasurement" type="DuctLeakageMeasurementType" maxOccurs="unbounded"/>
+			<xs:element minOccurs="0" name="DuctLeakageMeasurement"
+				type="DuctLeakageMeasurementType" maxOccurs="unbounded"/>
 			<xs:element minOccurs="0" name="DuctSystemSizingAppropriate" type="HPXMLBoolean"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="Ducts">
 				<xs:complexType>
@@ -3877,19 +4301,23 @@
 						<xs:group ref="SystemInfo"/>
 						<xs:element name="DuctType" type="DuctType" minOccurs="0"/>
 						<xs:element name="DuctMaterial" type="DuctMaterial" minOccurs="0"/>
-						<xs:element minOccurs="0" name="DuctInsulationMaterial" type="InsulationMaterial"/>
+						<xs:element minOccurs="0" name="DuctInsulationMaterial"
+							type="InsulationMaterial"/>
 						<xs:element name="DuctInsulationRValue" type="RValue" minOccurs="0">
 							<xs:annotation>
 								<xs:documentation>This should exclude the exterior air film -- e.g., use zero for uninsulated ducts. For ducts buried in insulation, this should only represent any surrounding insulation duct wrap and not the entire attic insulation R-value.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DuctInsulationThickness" type="LengthMeasurement">
+						<xs:element minOccurs="0" name="DuctInsulationThickness"
+							type="LengthMeasurement">
 							<xs:annotation>
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DuctInsulationCondition" type="InsulationCondition"/>
-						<xs:element minOccurs="0" name="DuctBuriedInsulationLevel" type="DuctBuriedInsulationLevel">
+						<xs:element minOccurs="0" name="DuctInsulationCondition"
+							type="InsulationCondition"/>
+						<xs:element minOccurs="0" name="DuctBuriedInsulationLevel"
+							type="DuctBuriedInsulationLevel">
 							<xs:annotation>
 								<xs:documentation>Describes ducts buried in, e.g., attic loose-fill insulation. Partially buried ducts have insulation that does not cover the top of the ducts. Fully buried ducts have insulation that just covers the top of the ducts. Deeply buried ducts have insulation that continues above the top of the ducts. See https://basc.pnnl.gov/resource-guides/ducts-buried-attic-insulation for more information.</xs:documentation>
 							</xs:annotation>
@@ -3916,12 +4344,15 @@
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="NumberofReturnRegisters" type="IntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="NumberofReturnRegisters"
+				type="IntegerGreaterThanOrEqualToZero"/>
 			<xs:element minOccurs="0" name="TotalExternalStaticPressureMeasurement">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="Supply" type="TotalExternalStaticPressureMeasurement"/>
-						<xs:element minOccurs="0" name="Return" type="TotalExternalStaticPressureMeasurement"/>
+						<xs:element minOccurs="0" name="Supply"
+							type="TotalExternalStaticPressureMeasurement"/>
+						<xs:element minOccurs="0" name="Return"
+							type="TotalExternalStaticPressureMeasurement"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -3971,50 +4402,61 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:element minOccurs="0" name="SiteType" type="SiteType"/>
-									<xs:element minOccurs="0" name="Surroundings" type="Surroundings">
+									<xs:element minOccurs="0" name="Surroundings"
+										type="Surroundings">
 										<xs:annotation>
 											<xs:documentation>If the building is attached to other units in the horizontal plane.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="VerticalSurroundings" type="VerticalSurroundings">
+									<xs:element minOccurs="0" name="VerticalSurroundings"
+										type="VerticalSurroundings">
 										<xs:annotation>
 											<xs:documentation>If the building is attached to other units on the vertical plane.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ShieldingofHome" type="ShieldingofHome" minOccurs="0"/>
-									<xs:element minOccurs="0" name="OrientationOfFrontOfHome" type="OrientationType"/>
-									<xs:element minOccurs="0" name="AzimuthOfFrontOfHome" type="AzimuthType"/>
+									<xs:element name="ShieldingofHome" type="ShieldingofHome"
+										minOccurs="0"/>
+									<xs:element minOccurs="0" name="OrientationOfFrontOfHome"
+										type="OrientationType"/>
+									<xs:element minOccurs="0" name="AzimuthOfFrontOfHome"
+										type="AzimuthType"/>
 									<xs:element minOccurs="0" name="PublicTransportation">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="DistanceFromSubway" type="LengthMeasurement">
-													<xs:annotation>
-														<xs:documentation>[ft]</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="DistanceFromSubway"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft]</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="DistanceFromBus" type="LengthMeasurement">
-													<xs:annotation>
-														<xs:documentation>[ft]</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="DistanceFromBus"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft]</xs:documentation>
+												</xs:annotation>
 												</xs:element>
-												<xs:element minOccurs="0" name="DistanceFromTrain" type="LengthMeasurement">
-													<xs:annotation>
-														<xs:documentation>[ft]</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="DistanceFromTrain"
+												type="LengthMeasurement">
+												<xs:annotation>
+												<xs:documentation>[ft]</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
 									</xs:element>
-									<xs:element minOccurs="0" name="WalkingScore" type="IntegerGreaterThanOrEqualToZero"/>
-									<xs:element minOccurs="0" name="WalkingScoreSource" type="HPXMLString"/>
+									<xs:element minOccurs="0" name="WalkingScore"
+										type="IntegerGreaterThanOrEqualToZero"/>
+									<xs:element minOccurs="0" name="WalkingScoreSource"
+										type="HPXMLString"/>
 									<xs:element minOccurs="0" name="FuelTypesAvailable">
 										<xs:annotation>
 											<xs:documentation>Fuels available on site via utility lines/pipes or delivery.</xs:documentation>
 										</xs:annotation>
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element maxOccurs="unbounded" name="Fuel" type="FuelType"/>
+												<xs:element maxOccurs="unbounded" name="Fuel"
+												type="FuelType"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -4022,12 +4464,15 @@
 									<xs:element minOccurs="0" name="Soil">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="SoilType" type="SoilType"/>
-												<xs:element minOccurs="0" name="MoistureType" type="MoisureType"/>
-												<xs:element minOccurs="0" name="Conductivity" type="HPXMLDouble">
-													<xs:annotation>
-														<xs:documentation>[Btu/hr-ft-F]</xs:documentation>
-													</xs:annotation>
+												<xs:element minOccurs="0" name="SoilType"
+												type="SoilType"/>
+												<xs:element minOccurs="0" name="MoistureType"
+												type="MoisureType"/>
+												<xs:element minOccurs="0" name="Conductivity"
+												type="HPXMLDouble">
+												<xs:annotation>
+												<xs:documentation>[Btu/hr-ft-F]</xs:documentation>
+												</xs:annotation>
 												</xs:element>
 												<xs:element minOccurs="0" ref="extension"/>
 											</xs:sequence>
@@ -4041,38 +4486,47 @@
 						<xs:element minOccurs="0" name="BuildingOccupancy">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element minOccurs="0" name="HouseholdType" type="HouseholdType"/>
+									<xs:element minOccurs="0" name="HouseholdType"
+										type="HouseholdType"/>
 									<xs:element minOccurs="0" name="YearOccupied" type="Year">
 										<xs:annotation>
 											<xs:documentation>The year the current occupants moved into the building</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="ResidentPopulationType" type="ResidentPopulationType"/>
+									<xs:element minOccurs="0" name="ResidentPopulationType"
+										type="ResidentPopulationType"/>
 									<xs:element minOccurs="0" name="Occupancy" type="Occupancy"/>
-									<xs:element name="NumberofResidents" type="PeopleCount" minOccurs="0"/>
-									<xs:element minOccurs="0" name="NumberofAdults" type="PeopleCount">
+									<xs:element name="NumberofResidents" type="PeopleCount"
+										minOccurs="0"/>
+									<xs:element minOccurs="0" name="NumberofAdults"
+										type="PeopleCount">
 										<xs:annotation>
 											<xs:documentation>18 or older</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofChildren" type="IntegerGreaterThanOrEqualToZero">
+									<xs:element minOccurs="0" name="NumberofChildren"
+										type="IntegerGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>less than 18 years old</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="PubliclySubsidized" type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="PubliclySubsidized"
+										type="HPXMLBoolean"/>
 									<xs:element minOccurs="0" name="LowIncome" type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="OccupantIncomeRange" type="FractionGreaterThanOne">
+									<xs:element minOccurs="0" name="OccupantIncomeRange"
+										type="FractionGreaterThanOne">
 										<xs:annotation>
 											<xs:documentation>Percentage as a fraction (50% = 0.5)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="OccupantIncomeRangeUnits" type="OccupantIncomeRangeUnits">
+									<xs:element minOccurs="0" name="OccupantIncomeRangeUnits"
+										type="OccupantIncomeRangeUnits">
 										<xs:annotation>
 											<xs:documentation>AMI = Area Median Income; FPL = Federal Poverty Level</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HighestLevelofOccupantEducation" type="EducationLevels"/>
+									<xs:element minOccurs="0" name="HighestLevelofOccupantEducation"
+										type="EducationLevels"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -4082,71 +4536,90 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:element name="YearBuilt" type="Year" minOccurs="0"/>
-									<xs:element minOccurs="0" name="YearBuiltKnownOrEstimated" type="KnownOrEstimated"/>
+									<xs:element minOccurs="0" name="YearBuiltKnownOrEstimated"
+										type="KnownOrEstimated"/>
 									<xs:element minOccurs="0" name="YearofLastRemodel" type="Year"/>
-									<xs:element name="ResidentialFacilityType" type="ResidentialFacilityType" minOccurs="0"/>
-									<xs:element minOccurs="0" name="PassiveSolar" type="HPXMLBoolean">
+									<xs:element name="ResidentialFacilityType"
+										type="ResidentialFacilityType" minOccurs="0"/>
+									<xs:element minOccurs="0" name="PassiveSolar"
+										type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Passive solar design—also known as climatic design—involves using a building's windows, walls, and floors to collect, store, and
 												distribute solar energy in the form of heat in the winter and reject solar heat in the summer. (source:
 												http://www.eere.energy.gov/basics/buildings/passive_solar_design.html)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="BuildingHeight" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="BuildingHeight"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] height of building</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofUnits" type="IntegerGreaterThanZero">
+									<xs:element minOccurs="0" name="NumberofUnits"
+										type="IntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Number of dwelling units represented by the HPXML Building element. Used as a multiplier.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofUnitsInBuilding" type="IntegerGreaterThanZero">
+									<xs:element minOccurs="0" name="NumberofUnitsInBuilding"
+										type="IntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Total number of dwelling units in the physical building.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofFloors" type="NumberOfFloorsType">
+									<xs:element minOccurs="0" name="NumberofFloors"
+										type="NumberOfFloorsType">
 										<xs:annotation>
 											<xs:documentation>Total number of floors including a basement, whether conditioned or unconditioned</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofConditionedFloors" type="NumberOfFloorsType">
+									<xs:element minOccurs="0" name="NumberofConditionedFloors"
+										type="NumberOfFloorsType">
 										<xs:annotation>
 											<xs:documentation>Number of floors that are heated/cooled including a basement</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofConditionedFloorsAboveGrade" type="NumberOfFloorsType">
+									<xs:element minOccurs="0"
+										name="NumberofConditionedFloorsAboveGrade"
+										type="NumberOfFloorsType">
 										<xs:annotation>
 											<xs:documentation>Number of floors above grade that are heated/cooled</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="AverageCeilingHeight" type="LengthMeasurement" minOccurs="0">
+									<xs:element name="AverageCeilingHeight" type="LengthMeasurement"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[ft] Average distance from the floor to the ceiling</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FloorToFloorHeight" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="FloorToFloorHeight"
+										type="LengthMeasurement">
 										<xs:annotation>
 											<xs:documentation>[ft] distance between floors</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="NumberofRooms" type="IntegerGreaterThanZero"/>
-									<xs:element name="NumberofBedrooms" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
-									<xs:element name="NumberofBathrooms" type="IntegerGreaterThanZero" minOccurs="0"/>
-									<xs:element minOccurs="0" name="NumberofCompleteBathrooms" type="IntegerGreaterThanZero">
+									<xs:element minOccurs="0" name="NumberofRooms"
+										type="IntegerGreaterThanZero"/>
+									<xs:element name="NumberofBedrooms"
+										type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+									<xs:element name="NumberofBathrooms"
+										type="IntegerGreaterThanZero" minOccurs="0"/>
+									<xs:element minOccurs="0" name="NumberofCompleteBathrooms"
+										type="IntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Number of bathrooms with a tub or shower</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="BuildingFootprintArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="BuildingFootprintArea"
+										type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FootprintShape" type="FootprintShape"/>
-									<xs:element minOccurs="0" name="GrossFloorArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="FootprintShape"
+										type="FootprintShape"/>
+									<xs:element minOccurs="0" name="GrossFloorArea"
+										type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Gross floor area (based on ASHRAE definition) is the sum of the floor areas of the spaces within the building, including
 												basements, mezzanine and intermediate‐floored tiers, and penthouses with headroom height of 7.5 ft (2.2 meters) or greater. Measurements must be taken
@@ -4164,33 +4637,39 @@
 												area.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ConditionedFloorArea" type="SurfaceArea" minOccurs="0">
+									<xs:element name="ConditionedFloorArea" type="SurfaceArea"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] All finished space that is within the (insulated) conditioned space boundary (that is, within the insulated envelope), regardless
 												of HVAC configuration.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FinishedFloorArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="FinishedFloorArea"
+										type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] Floor area of home that is finished and assumed to be occupied.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="NumberofStoriesAboveGrade" type="IntegerGreaterThanZero" minOccurs="0"/>
-									<xs:element minOccurs="0" name="CooledFloorArea" type="SurfaceArea">
+									<xs:element name="NumberofStoriesAboveGrade"
+										type="IntegerGreaterThanZero" minOccurs="0"/>
+									<xs:element minOccurs="0" name="CooledFloorArea"
+										type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] The total area of all enclosed spaces measured to the internal face of the external walls. Included are areas of sloping surfaces
 												such as staircases, galleries, raked auditoria, and tiered terraces where the area taken is from the area on the plan. Excluded are areas that are not
 												enclosed such as open floors, covered ways and balconies.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="HeatedFloorArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="HeatedFloorArea"
+										type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] The total area of all enclosed spaces measured to the internal face of the external walls. Included are areas of sloping surfaces
 												such as staircases, galleries, raked auditoria, and tiered terraces where the area taken is from the area on the plan. Excluded are areas that are not
 												enclosed such as open floors, covered ways and balconies.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="UnconditionedFloorArea" type="SurfaceArea">
+									<xs:element minOccurs="0" name="UnconditionedFloorArea"
+										type="SurfaceArea">
 										<xs:annotation>
 											<xs:documentation>[sq.ft.] An enclosed space within a building that does not meet the requirements of a conditioned space. Spaces that have no control over
 												thermal conditions but intentionally or unintentionally receive thermal energy from adjacent spaces are considered unconditioned spaces (such as an
@@ -4206,7 +4685,8 @@
 												building.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="ConditionedBuildingVolume" type="Volume" minOccurs="0">
+									<xs:element name="ConditionedBuildingVolume" type="Volume"
+										minOccurs="0">
 										<xs:annotation>
 											<xs:documentation>[cu.ft.] Volume inside the building envelope of the conditioned spaces. This metric can be calculated as the volume of the building if
 												every space is conditioned or on a floor-by-floor basis. For spaces with vertical walls and horizontal ceilings and floors, this is calculated as the
@@ -4216,7 +4696,8 @@
 												return air plenums.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="FoundationType" minOccurs="0" type="FoundationType">
+									<xs:element name="FoundationType" minOccurs="0"
+										type="FoundationType">
 										<xs:annotation>
 											<xs:documentation>Primary foundation type of building</xs:documentation>
 										</xs:annotation>
@@ -4226,14 +4707,20 @@
 											<xs:documentation>Primary attic type of building</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="AverageAtticRValue" type="RValue" minOccurs="0"/>
+									<xs:element name="AverageAtticRValue" type="RValue"
+										minOccurs="0"/>
 									<xs:element name="AverageWallRValue" type="RValue" minOccurs="0"/>
-									<xs:element name="AverageFloorRValue" type="RValue" minOccurs="0"/>
+									<xs:element name="AverageFloorRValue" type="RValue"
+										minOccurs="0"/>
 									<xs:element name="AverageDuctRValue" type="RValue" minOccurs="0"/>
-									<xs:element minOccurs="0" name="GaragePresent" type="HPXMLBoolean"/>
-									<xs:element minOccurs="0" name="GarageLocation" type="GarageLocation"/>
-									<xs:element minOccurs="0" name="SpaceAboveGarage" type="SpaceAboveGarage"/>
-									<xs:element minOccurs="0" name="ManufacturedHomeSections" type="ManufacturedHomeSections">
+									<xs:element minOccurs="0" name="GaragePresent"
+										type="HPXMLBoolean"/>
+									<xs:element minOccurs="0" name="GarageLocation"
+										type="GarageLocation"/>
+									<xs:element minOccurs="0" name="SpaceAboveGarage"
+										type="SpaceAboveGarage"/>
+									<xs:element minOccurs="0" name="ManufacturedHomeSections"
+										type="ManufacturedHomeSections">
 										<xs:annotation>
 											<xs:documentation>The number of sections (width) of the manufactured home. CrossMod is a new style of manufactured home with more flexibility in configuration, higher roof pitch, covered porches, and garages or carports. They look more like a site-built single family detached home, but are manufactured in a factory and assembled on site. </xs:documentation>
 										</xs:annotation>
@@ -4246,7 +4733,8 @@
 						<xs:element name="AnnualEnergyUse" minOccurs="0">
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType" maxOccurs="unbounded"/>
+									<xs:element name="ConsumptionInfo" type="ConsumptionInfoType"
+										maxOccurs="unbounded"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
@@ -4260,13 +4748,15 @@
 				<xs:complexType>
 					<xs:sequence minOccurs="0">
 						<xs:element name="ClimateZoneDOE" type="ClimateZoneDOE" minOccurs="0"/>
-						<xs:element name="ClimateZoneIECC" minOccurs="0" type="IECCClimateZoneType" maxOccurs="unbounded"/>
+						<xs:element name="ClimateZoneIECC" minOccurs="0" type="IECCClimateZoneType"
+							maxOccurs="unbounded"/>
 						<xs:element name="RadonZone" type="RadonZone" minOccurs="0"/>
 						<xs:element name="TermiteZone" type="TermiteZone" minOccurs="0"/>
 						<xs:element name="HurricaneZone" type="HPXMLBoolean" minOccurs="0"/>
 						<xs:element name="FloodZone" type="HPXMLBoolean" minOccurs="0"/>
 						<xs:element name="EarthquakeZone" type="EarthquakeZone" minOccurs="0"/>
-						<xs:element maxOccurs="unbounded" minOccurs="0" name="WeatherStation" type="WeatherStation">
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="WeatherStation"
+							type="WeatherStation">
 							<xs:annotation>
 								<xs:documentation>Weather location used in model simulation and/or utility bill regression analysis</xs:documentation>
 							</xs:annotation>
@@ -4320,13 +4810,15 @@
 												which is the purpose of this field.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Source" type="GreenBuildingVerificationSource">
+									<xs:element minOccurs="0" name="Source"
+										type="GreenBuildingVerificationSource">
 										<xs:annotation>
 											<xs:documentation>The source of the green data. May address photovoltaic characteristics, or a verified score, certification, label, etc. This may be a pick
 												list of options showing the source. i.e. Program Sponsor, Program Verifier, Public Record, Assessor, etc.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="Status" type="GreenBuildingVerificationStatus">
+									<xs:element minOccurs="0" name="Status"
+										type="GreenBuildingVerificationStatus">
 										<xs:annotation>
 											<xs:documentation>Many verification programs include a multi-step process that may begin with plans and specs, involve testing and/or submission of building
 												specifications along the way and include a final verification step. When ratings are involved it is not uncommon for the final rating to be either
@@ -4417,12 +4909,14 @@
 			<xs:element name="Incentives" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="Incentive" type="IncentiveDetailsType"/>
+						<xs:element maxOccurs="unbounded" name="Incentive"
+							type="IncentiveDetailsType"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType" maxOccurs="2"/>
+			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType"
+				maxOccurs="2"/>
 			<xs:element maxOccurs="2" minOccurs="0" name="WaterSavingsInfo" type="WaterSavingsType"/>
 			<xs:element minOccurs="0" name="Measures">
 				<xs:complexType>
@@ -4438,8 +4932,10 @@
 	</xs:complexType>
 	<xs:complexType name="TotalCostType">
 		<xs:sequence>
-			<xs:element name="TotalCostHealthSafetyMeasures" type="TotalCostHealthSafetyMeasures" minOccurs="1"/>
-			<xs:element name="TotalCostQualEnergyMeasures" type="TotalCostQualEnergyMeasures" minOccurs="1"/>
+			<xs:element name="TotalCostHealthSafetyMeasures" type="TotalCostHealthSafetyMeasures"
+				minOccurs="1"/>
+			<xs:element name="TotalCostQualEnergyMeasures" type="TotalCostQualEnergyMeasures"
+				minOccurs="1"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
@@ -4476,7 +4972,8 @@
 			<xs:element minOccurs="0" name="Incentives">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="Incentive" type="IncentiveDetailsType"/>
+						<xs:element maxOccurs="unbounded" name="Incentive"
+							type="IncentiveDetailsType"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -4495,7 +4992,8 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element name="Quantity" type="Quantity"/>
-									<xs:element name="AnnualAmount" type="AnnualAmount" minOccurs="0"/>
+									<xs:element name="AnnualAmount" type="AnnualAmount"
+										minOccurs="0"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>
@@ -4505,7 +5003,8 @@
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType" maxOccurs="2"/>
+			<xs:element minOccurs="0" name="EnergySavingsInfo" type="EnergySavingsType"
+				maxOccurs="2"/>
 			<xs:element maxOccurs="2" minOccurs="0" name="WaterSavingsInfo" type="WaterSavingsType"/>
 			<xs:element minOccurs="0" name="CustomerNotes" type="Notes"/>
 			<xs:element minOccurs="0" name="WorkscopeNotes" type="Notes"/>
@@ -4532,7 +5031,8 @@
 				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="ReplacedComponent" type="RemoteReference"/>
+						<xs:element maxOccurs="unbounded" name="ReplacedComponent"
+							type="RemoteReference"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -4540,7 +5040,8 @@
 			<xs:element minOccurs="0" name="InstalledComponents">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="1" name="InstalledComponent" type="RemoteReference" maxOccurs="unbounded"/>
+						<xs:element minOccurs="1" name="InstalledComponent" type="RemoteReference"
+							maxOccurs="unbounded"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -4557,7 +5058,8 @@
 				</xs:annotation>
 			</xs:element>
 			<xs:element minOccurs="0" name="EnergySavingsReported" type="GrossOrNet"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="FuelSavings" type="FuelSavingsType"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="FuelSavings"
+				type="FuelSavingsType"/>
 			<xs:element name="DemandSavings" minOccurs="0" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>[kW] Demand savings from energy efficiency programs</xs:documentation>
@@ -4592,7 +5094,8 @@
 	<xs:complexType name="DuctLeakageMeasurementType">
 		<xs:sequence>
 			<xs:element minOccurs="0" name="DuctType" type="DuctType"/>
-			<xs:element name="LeakinessObservedVisualInspection" type="LeakinessObservedVisualInspection" minOccurs="0"/>
+			<xs:element name="LeakinessObservedVisualInspection"
+				type="LeakinessObservedVisualInspection" minOccurs="0"/>
 			<xs:element name="DuctLeakageTestMethod" type="DuctLeakageTestMethod" minOccurs="0"/>
 			<xs:element minOccurs="0" name="DuctLeakage">
 				<xs:complexType>
@@ -4603,7 +5106,8 @@
 							</xs:annotation>
 						</xs:element>
 						<xs:element name="Value" type="MeasuredDuctLeakage" minOccurs="0"/>
-						<xs:element minOccurs="0" name="TotalOrToOutside" type="DuctLeakageTotalOrToOutside"/>
+						<xs:element minOccurs="0" name="TotalOrToOutside"
+							type="DuctLeakageTotalOrToOutside"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -4671,7 +5175,8 @@
 		<xs:sequence>
 			<xs:element minOccurs="0" name="WeatherRegressionBeginDate" type="HPXMLDate"/>
 			<xs:element minOccurs="0" name="WeatherRegressionEndDate" type="HPXMLDate"/>
-			<xs:element minOccurs="0" name="CalibrationQualification" type="BPI2400CalibrationQualification">
+			<xs:element minOccurs="0" name="CalibrationQualification"
+				type="BPI2400CalibrationQualification">
 				<xs:annotation>
 					<xs:documentation>This identifies which data quality requirements (if any) were met by the bills for the relevant energy source and therefore which calibration metrics (if any) are
 						used to determine whether the calibrated model is accepted.</xs:documentation>
@@ -4697,55 +5202,65 @@
 					<xs:documentation>Weather Normalized Annual Baseload Usage</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingBiasError" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingBiasError"
+				type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Eqn. 3.2.3.A.i of BPI-2400. Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingAbsoluteError" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationHeatingAbsoluteError"
+				type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Eqn. 3.2.3.A.ii of BPI-2400. In either kWh for electricity or MBtu (million Btu) for all other fuels.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingBiasError" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingBiasError"
+				type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingAbsoluteError" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationCoolingAbsoluteError"
+				type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>In either kWh for electricity or MBtu (million Btu) for all other fuels.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadBiasError" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadBiasError"
+				type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Percentage expressed as a fraction (ie 10% = 0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadAbsoluteError" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="DetailedModelCalibrationBaseloadAbsoluteError"
+				type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>In either kWh for electricity or MBtu (million Btu) for all other fuels.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SimplifiedModelCalibrationHeatingBiasError" nillable="true" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationHeatingBiasError"
+				nillable="true" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% =
 						0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SimplifiedModelCalibrationCoolingBiasError" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationCoolingBiasError"
+				type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% =
 						0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SimplifiedModelCalibrationBaseloadBiasError" nillable="true" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationBaseloadBiasError"
+				nillable="true" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% =
 						0.1)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="SimplifiedModelCalibrationTotalBiasError" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="SimplifiedModelCalibrationTotalBiasError"
+				type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Used to determine model calibration acceptance when bills fail Detailed criteria, but meet simple criteria. Percentage expressed as a fraction (ie 10% =
 						0.1)</xs:documentation>
@@ -4766,7 +5281,8 @@
 							</xs:annotation>
 						</xs:element>
 						<xs:element name="UnitofMeasure" type="energyUnitType"/>
-						<xs:element minOccurs="0" name="MeteringConfiguration" type="MeteringConfiguration">
+						<xs:element minOccurs="0" name="MeteringConfiguration"
+							type="MeteringConfiguration">
 							<xs:annotation>
 								<xs:documentation>direct metering = tenants directly metered; master meter without sub-metering = tenants not sub metered; master meter with sub-metering = tenant
 									sub-metered by building owner</xs:documentation>
@@ -4779,7 +5295,8 @@
 										<xs:complexType>
 											<xs:sequence>
 												<xs:element name="EmissionType" type="EmissionType"/>
-												<xs:element name="EmissionUnits" type="EmissionUnits"/>
+												<xs:element name="EmissionUnits"
+												type="EmissionUnits"/>
 												<xs:element name="Emissions" type="HPXMLDouble"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
@@ -4789,8 +5306,10 @@
 								<xs:attribute name="dataSource" type="DataSource"/>
 							</xs:complexType>
 						</xs:element>
-						<xs:element minOccurs="0" name="FuelInterruptibility" type="FuelInterruptibility"/>
-						<xs:element minOccurs="0" name="SharedEnergySystem" type="SharedEnergySystem"/>
+						<xs:element minOccurs="0" name="FuelInterruptibility"
+							type="FuelInterruptibility"/>
+						<xs:element minOccurs="0" name="SharedEnergySystem"
+							type="SharedEnergySystem"/>
 						<xs:element minOccurs="0" name="IntervalType" type="IntervalType"/>
 						<xs:element minOccurs="0" name="ReadingTimeZone" type="HPXMLString"/>
 						<xs:element minOccurs="0" name="MarginalEnergyCostRate" type="HPXMLDouble">
@@ -4851,7 +5370,8 @@
 			<xs:element name="UnitofMeasure" type="energyUnitType"/>
 			<xs:element minOccurs="0" name="AnnualConsumption" type="HPXMLDouble"/>
 			<xs:element minOccurs="0" name="AnnualFuelCost" type="HPXMLDouble"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="ConsumptionByEndUse" type="EndUseInfoType"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ConsumptionByEndUse"
+				type="EndUseInfoType"/>
 			<xs:element minOccurs="0" name="BaseLoad" type="HPXMLDouble">
 				<xs:annotation>
 					<xs:documentation>Baseload power is the energy consumed for the day-to-day operation of a home that is not used as a response to outside weather (i.e. excludes heating and cooling)
@@ -4906,9 +5426,12 @@
 			<xs:element name="BusinessName" type="HPXMLString"/>
 			<xs:element name="BusinessType" type="BusinessType" minOccurs="0"/>
 			<xs:element name="BusinessSpecialization" type="BusinessSpecialization" minOccurs="0"/>
-			<xs:element name="Certification" type="BusinessCertification" minOccurs="0" maxOccurs="unbounded"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="BusinessContact" type="BusinessContactInfoType"/>
-			<xs:element minOccurs="0" maxOccurs="unbounded" name="TelephoneInfo" type="TelephoneInfoType"/>
+			<xs:element name="Certification" type="BusinessCertification" minOccurs="0"
+				maxOccurs="unbounded"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="BusinessContact"
+				type="BusinessContactInfoType"/>
+			<xs:element minOccurs="0" maxOccurs="unbounded" name="TelephoneInfo"
+				type="TelephoneInfoType"/>
 			<xs:element minOccurs="0" maxOccurs="unbounded" name="EmailInfo" type="EmailInfoType"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
@@ -4950,7 +5473,8 @@
 			<xs:element name="SHGC" type="SHGC" minOccurs="0"/>
 			<xs:element minOccurs="0" name="VisibleTransmittance" type="Fraction"/>
 			<xs:element name="NFRCCertified" type="HPXMLBoolean" minOccurs="0"/>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification" type="WindowThirdPartyCertification"/>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="ThirdPartyCertification"
+				type="WindowThirdPartyCertification"/>
 			<xs:element maxOccurs="unbounded" minOccurs="0" name="WindowFilm">
 				<xs:complexType>
 					<xs:sequence>
@@ -5048,12 +5572,14 @@
 								<xs:documentation>[ft] Depth of overhang</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DistanceToTopOfWindow" type="LengthMeasurement">
+						<xs:element minOccurs="0" name="DistanceToTopOfWindow"
+							type="LengthMeasurement">
 							<xs:annotation>
 								<xs:documentation>[ft] Vertical distance from overhang to top of window</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="DistanceToBottomOfWindow" type="LengthMeasurement">
+						<xs:element minOccurs="0" name="DistanceToBottomOfWindow"
+							type="LengthMeasurement">
 							<xs:annotation>
 								<xs:documentation>[ft] Vertical distance from overhang to bottom of window</xs:documentation>
 							</xs:annotation>
@@ -5190,9 +5716,11 @@
 				</xs:annotation>
 			</xs:element>
 			<xs:element minOccurs="0" name="WindConditions" type="WindConditions"/>
-			<xs:element name="TypeOfInfiltrationMeasurement" type="TypeofInfiltrationMeasurement" minOccurs="0"/>
+			<xs:element name="TypeOfInfiltrationMeasurement" type="TypeofInfiltrationMeasurement"
+				minOccurs="0"/>
 			<xs:element name="TypeOfBlowerDoorTest" type="TypeofBlowerDoorTest" minOccurs="0"/>
-			<xs:element minOccurs="0" name="TypeOfInfiltrationLeakage" type="TypeofInfiltrationLeakage">
+			<xs:element minOccurs="0" name="TypeOfInfiltrationLeakage"
+				type="TypeofInfiltrationLeakage">
 				<xs:annotation>
 					<xs:documentation>This element is intended to describe the type of infiltration measured, e.g., for an individual single-family attached or multifamily dwelling unit. Either whole building or single unit infiltration can be measured. For single unit infiltration, leakage can occur through exterior surfaces, interior surfaces, or both. For example, guarded tests measure unit exterior leakage, unguarded or compartmentalization tests measure unit total leakage, and combining both tests can measure unit interior leakage.</xs:documentation>
 				</xs:annotation>
@@ -5242,8 +5770,10 @@
 	<xs:complexType name="MoistureControlInfoType">
 		<xs:sequence>
 			<xs:group ref="SystemInfo"/>
-			<xs:element name="ExteriorLocationsWaterIntrusionorDamage" type="ExteriorLocationsWaterIntrusionorDamage" minOccurs="0" maxOccurs="unbounded"/>
-			<xs:element name="InteriorLocationsofWaterLeaksorDamage" type="InteriorLocationsofWaterLeaksorDamage" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ExteriorLocationsWaterIntrusionorDamage"
+				type="ExteriorLocationsWaterIntrusionorDamage" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="InteriorLocationsofWaterLeaksorDamage"
+				type="InteriorLocationsofWaterLeaksorDamage" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element ref="extension" minOccurs="0"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -5337,7 +5867,8 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element minOccurs="0" name="SkirtPresent" type="HPXMLBoolean"/>
-						<xs:element minOccurs="0" name="BellyWrapCondition" type="ManufacturedHomeBellyWrapCondition">
+						<xs:element minOccurs="0" name="BellyWrapCondition"
+							type="ManufacturedHomeBellyWrapCondition">
 							<xs:annotation>
 								<xs:documentation>Use the 'none' choice for cases where the belly wrap is functionally missing even if pieces of the wrap are still present. </xs:documentation>
 							</xs:annotation>
@@ -5363,7 +5894,8 @@
 			<xs:element name="WoodStud">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element minOccurs="0" name="ExpandedPolystyreneSheathing" type="HPXMLBoolean">
+						<xs:element minOccurs="0" name="ExpandedPolystyreneSheathing"
+							type="HPXMLBoolean">
 							<xs:annotation>
 								<xs:documentation>Sheathing insulation should be specified in the Insulation element as well.</xs:documentation>
 							</xs:annotation>
@@ -5577,7 +6109,8 @@
 					<xs:documentation>Percent of rooms controlled by electronic zone valves with thermostats</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="HVACSystemsServed" type="LocalReference" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="HVACSystemsServed" type="LocalReference" minOccurs="0"
+				maxOccurs="unbounded"/>
 			<xs:element maxOccurs="1" minOccurs="0" name="HeatingSeason" type="Season"/>
 			<xs:element maxOccurs="1" minOccurs="0" name="CoolingSeason" type="Season"/>
 			<xs:element ref="extension" minOccurs="0"/>
@@ -5611,9 +6144,11 @@
 					<xs:documentation>The year and month the duct system was sealed.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="DuctOutsideEnvelopeInsulatedaspartofRetrofit" type="HPXMLBoolean" minOccurs="0"/>
+			<xs:element name="DuctOutsideEnvelopeInsulatedaspartofRetrofit" type="HPXMLBoolean"
+				minOccurs="0"/>
 			<xs:element name="DuctSystemReplaced" type="HPXMLBoolean" minOccurs="0"/>
-			<xs:element name="SystemPumpandZoneValveCorrectionsMade" type="HPXMLBoolean" minOccurs="0"/>
+			<xs:element name="SystemPumpandZoneValveCorrectionsMade" type="HPXMLBoolean"
+				minOccurs="0"/>
 			<xs:element minOccurs="0" ref="extension"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
@@ -5626,8 +6161,10 @@
 					<xs:documentation>Year and month of the last tune and repair for this HVAC equipment.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="NumberofCoilsReplaced" type="IntegerGreaterThanOrEqualToZero"/>
-			<xs:element minOccurs="0" name="NumberofAirHandlersReplaced" type="IntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="NumberofCoilsReplaced"
+				type="IntegerGreaterThanOrEqualToZero"/>
+			<xs:element minOccurs="0" name="NumberofAirHandlersReplaced"
+				type="IntegerGreaterThanOrEqualToZero"/>
 			<xs:element minOccurs="0" name="AirFilter">
 				<xs:complexType>
 					<xs:sequence>
@@ -5680,8 +6217,10 @@
 	<xs:complexType name="WaterHeaterImprovementInfo">
 		<xs:sequence>
 			<xs:element name="JacketInstalledIndicator" type="HPXMLBoolean" minOccurs="0"/>
-			<xs:element name="DispositionofExistingSystem" type="DispositionofExistingSystem" minOccurs="0"/>
-			<xs:element name="RepairsDescription" type="HPXMLString" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="DispositionofExistingSystem" type="DispositionofExistingSystem"
+				minOccurs="0"/>
+			<xs:element name="RepairsDescription" type="HPXMLString" minOccurs="0"
+				maxOccurs="unbounded"/>
 			<xs:element name="PipeInsulated" type="PipeInsulated" minOccurs="0"/>
 			<xs:element name="LengthofPipeInsulated" type="LengthMeasurement" minOccurs="0">
 				<xs:annotation>
@@ -5777,7 +6316,8 @@
 									Building/BuildingDetails/ClimateAndRiskZones/WeatherStation</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element maxOccurs="unbounded" name="ModeledUsage" type="ModeledUsageType"/>
+						<xs:element maxOccurs="unbounded" name="ModeledUsage"
+							type="ModeledUsageType"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -5868,7 +6408,8 @@
 			<xs:element minOccurs="0" name="ConsumptionDetails">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element maxOccurs="unbounded" name="ConsumptionInfo" type="ConsumptionInfoType"/>
+						<xs:element maxOccurs="unbounded" name="ConsumptionInfo"
+							type="ConsumptionInfoType"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -5916,7 +6457,8 @@
 					<xs:documentation>[Pa] positive for supply side measurements, negative for return side.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="MeasurementLocation" type="AirHandlerStaticPressureMeasurementLocation"/>
+			<xs:element minOccurs="0" name="MeasurementLocation"
+				type="AirHandlerStaticPressureMeasurementLocation"/>
 			<xs:element minOccurs="0" name="LocationDescription" type="HPXMLString"/>
 			<xs:element minOccurs="0" name="StaticPressureSource" type="StaticPressureSource"/>
 			<xs:element minOccurs="0" ref="extension"/>
@@ -6026,8 +6568,10 @@
 			<xs:sequence>
 				<xs:group ref="SystemInfo"/>
 				<xs:element name="IsConnected" type="HPXMLBoolean"/>
-				<xs:element maxOccurs="unbounded" minOccurs="0" name="CommunicatesWith" type="LocalReference"/>
-				<xs:element minOccurs="0" name="CommunicationProtocol" type="ConnectedDeviceCommunicationProtocol" maxOccurs="unbounded"/>
+				<xs:element maxOccurs="unbounded" minOccurs="0" name="CommunicatesWith"
+					type="LocalReference"/>
+				<xs:element minOccurs="0" name="CommunicationProtocol"
+					type="ConnectedDeviceCommunicationProtocol" maxOccurs="unbounded"/>
 				<xs:element minOccurs="0" name="DemandResponseCapability" type="HPXMLBoolean"/>
 				<xs:element minOccurs="0" name="OccupancySensor" type="HPXMLBoolean"/>
 				<xs:element minOccurs="0" ref="extension"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -972,7 +972,7 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element name="RadiantBarrier" type="HPXMLBoolean" minOccurs="0"/>
-									<xs:element name="RadiantBarrierLocation" type="RadiantBarrierLocation_roof" minOccurs="0"/>
+									<xs:element name="RadiantBarrierLocation" type="RadiantBarrierLocation" minOccurs="0"/>
 									<xs:element name="RadiantBarrierGrade" type="InsulationGrade" minOccurs="0"/>
 									<xs:element minOccurs="0" name="Insulation" type="InsulationInfo"/>
 									<xs:element ref="extension" minOccurs="0"/>
@@ -1067,10 +1067,9 @@
 									<xs:element minOccurs="0" name="SolarAbsorptance" type="SolarAbsorptance"/>
 									<xs:element minOccurs="0" name="Emittance" type="Emittance"/>
 									<xs:element minOccurs="0" name="InteriorFinish" type="InteriorFinishInfo"/>
-									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"/>
 									<xs:element name="RadiantBarrier" type="HPXMLBoolean" minOccurs="0"/>
-									<xs:element name="RadiantBarrierLocation" type="RadiantBarrierLocation_wall" minOccurs="0"/>
 									<xs:element name="RadiantBarrierGrade" type="InsulationGrade" minOccurs="0"/>
+									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"/>
 									<xs:element name="AnnualEnergyUse" minOccurs="0">
 										<xs:complexType>
 											<xs:sequence>
@@ -1176,10 +1175,9 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="InteriorFinish" type="InteriorFinishInfo"/>
-									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"/>
 									<xs:element name="RadiantBarrier" type="HPXMLBoolean" minOccurs="0"/>
-									<xs:element name="RadiantBarrierLocation" type="RadiantBarrierLocation_floor" minOccurs="0"/>
 									<xs:element name="RadiantBarrierGrade" type="InsulationGrade" minOccurs="0"/>
+									<xs:element minOccurs="0" maxOccurs="1" name="Insulation" type="InsulationInfo"/>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.1">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10"
+	targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.1">
 	<xs:simpleType name="DataSource">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="user"/>
@@ -1552,7 +1553,7 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="RadiantBarrierLocation_simple">
+	<xs:simpleType name="RadiantBarrierLocation_roof_simple">
 		<xs:annotation>
 			<xs:documentation>Enumerations from http://www.fsec.ucf.edu/en/publications/pdf/FSEC-DN-7-84.pdf</xs:documentation>
 		</xs:annotation>
@@ -1564,15 +1565,35 @@
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:complexType name="RadiantBarrierLocation">
+	<xs:simpleType name="RadiantBarrierLocation_wall_simple">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="RadiantBarrierLocation_floor_simple">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:complexType name="RadiantBarrierLocation_roof">
 		<xs:simpleContent>
-			<xs:extension base="RadiantBarrierLocation_simple">
+			<xs:extension base="RadiantBarrierLocation_roof_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="RadiantBarrierLocation_wall">
+		<xs:simpleContent>
+			<xs:extension base="RadiantBarrierLocation_wall_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
 	<!--Ventilation Below-->
 	<!--Window Group Below-->
+	<xs:complexType name="RadiantBarrierLocation_floor">
+		<xs:simpleContent>
+			<xs:extension base="RadiantBarrierLocation_floor_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="HVACThirdPartyCertification_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Energy Star"/>
@@ -3882,7 +3903,8 @@
 	</xs:complexType>
 	<xs:simpleType name="GreenBuildingVerificationType_simple">
 		<xs:restriction base="xs:string">
-			<xs:enumeration value="BPI-2101-compliant Certificate of Residential Energy Efficiency Features and Performance"/>
+			<xs:enumeration
+				value="BPI-2101-compliant Certificate of Residential Energy Efficiency Features and Performance"/>
 			<xs:enumeration value="Certified Passive House"/>
 			<xs:enumeration value="ENERGY STAR Certified Homes"/>
 			<xs:enumeration value="EnerPHit"/>
@@ -5010,4 +5032,5 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+
 </xs:schema>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1552,24 +1552,20 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="RadiantBarrierLocation_roof_simple">
+	<xs:simpleType name="RadiantBarrierLocation_simple">
 		<xs:annotation>
 			<xs:documentation>Enumerations from http://www.fsec.ucf.edu/en/publications/pdf/FSEC-DN-7-84.pdf</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="top side of truss under sheathing"/>
 			<xs:enumeration value="below bottom chord of truss"/>
-			<xs:enumeration value="attic floor"/>
 			<xs:enumeration value="underside of rafters"/>
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="RadiantBarrierLocation_wall_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="RadiantBarrierLocation_roof">
+	<xs:complexType name="RadiantBarrierLocation">
 		<xs:simpleContent>
-			<xs:extension base="RadiantBarrierLocation_roof_simple">
+			<xs:extension base="RadiantBarrierLocation_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -4985,23 +4981,6 @@
 	<xs:complexType name="MoisureType">
 		<xs:simpleContent>
 			<xs:extension base="MoistureType_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:complexType name="RadiantBarrierLocation_wall">
-		<xs:simpleContent>
-			<xs:extension base="RadiantBarrierLocation_wall_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
-	<xs:simpleType name="RadiantBarrierLocation_floor_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:complexType name="RadiantBarrierLocation_floor">
-		<xs:simpleContent>
-			<xs:extension base="RadiantBarrierLocation_floor_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10"
-	targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.1">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2019/10" targetNamespace="http://hpxmlonline.com/2019/10" elementFormDefault="qualified" version="3.1">
 	<xs:simpleType name="DataSource">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="user"/>
@@ -1568,9 +1567,6 @@
 	<xs:simpleType name="RadiantBarrierLocation_wall_simple">
 		<xs:restriction base="xs:string"/>
 	</xs:simpleType>
-	<xs:simpleType name="RadiantBarrierLocation_floor_simple">
-		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
 	<xs:complexType name="RadiantBarrierLocation_roof">
 		<xs:simpleContent>
 			<xs:extension base="RadiantBarrierLocation_roof_simple">
@@ -1578,22 +1574,8 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:complexType name="RadiantBarrierLocation_wall">
-		<xs:simpleContent>
-			<xs:extension base="RadiantBarrierLocation_wall_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<!--Ventilation Below-->
 	<!--Window Group Below-->
-	<xs:complexType name="RadiantBarrierLocation_floor">
-		<xs:simpleContent>
-			<xs:extension base="RadiantBarrierLocation_floor_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<xs:simpleType name="HVACThirdPartyCertification_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Energy Star"/>
@@ -3903,8 +3885,7 @@
 	</xs:complexType>
 	<xs:simpleType name="GreenBuildingVerificationType_simple">
 		<xs:restriction base="xs:string">
-			<xs:enumeration
-				value="BPI-2101-compliant Certificate of Residential Energy Efficiency Features and Performance"/>
+			<xs:enumeration value="BPI-2101-compliant Certificate of Residential Energy Efficiency Features and Performance"/>
 			<xs:enumeration value="Certified Passive House"/>
 			<xs:enumeration value="ENERGY STAR Certified Homes"/>
 			<xs:enumeration value="EnerPHit"/>
@@ -5032,5 +5013,21 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-
+	<xs:complexType name="RadiantBarrierLocation_wall">
+		<xs:simpleContent>
+			<xs:extension base="RadiantBarrierLocation_wall_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="RadiantBarrierLocation_floor_simple">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:complexType name="RadiantBarrierLocation_floor">
+		<xs:simpleContent>
+			<xs:extension base="RadiantBarrierLocation_floor_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 </xs:schema>


### PR DESCRIPTION
Adds `RadiantBarrier` and `RadiantBarrierGrade` for HPXML Wall/Floor elements, which can be used for attic gable walls and attic floors. Removes "attic floor" as a choice from `Roof/RadiantBarrierLocation`.