### PR TITLE
Portable Electric Spa Fixes

### DIFF
--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -4463,7 +4463,7 @@
 											<xs:documentation>[W] Maximum standby power allowed for this size spa under ANSI/APSP/ICC-14</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="TotalAnnualPowerConsumptionInStandbyMode" minOccurs="0" type="EnergyAndWaterUseTypeDescription">
+									<xs:element name="TotalAnnualPowerConsumptionInStandbyMode" minOccurs="0" type="RatedAnnualkWh">
 										<xs:annotation>
 											<xs:documentation>[kWh] Total annual power consumption in standby mode, based on test procedure in ANSI/APSP/ICC-14. Typically standby power * 8760. </xs:documentation>
 										</xs:annotation>
@@ -4479,11 +4479,6 @@
 									<xs:element minOccurs="0" name="MonthsPerYearofOperation" type="MonthsPerYear">
 										<xs:annotation>
 											<xs:documentation>Months per year portable spa is in operation.</xs:documentation>
-										</xs:annotation>
-									</xs:element>
-									<xs:element minOccurs="0" name="FilterType" type="PoolFilterType">
-										<xs:annotation>
-											<xs:documentation>Type of filter used, if any.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -4449,7 +4449,7 @@
 											<xs:documentation>[W] Maximum standby power allowed for this size spa under ANSI/APSP/ICC-14</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="TotalAnnualPowerConsumptionInStandbyMode" minOccurs="0" type="EnergyAndWaterUseTypeDescription">
+									<xs:element name="TotalAnnualPowerConsumptionInStandbyMode" minOccurs="0" type="RatedAnnualkWh">
 										<xs:annotation>
 											<xs:documentation>[kWh] Total annual power consumption in standby mode, based on test procedure in ANSI/APSP/ICC-14. Typically standby power * 8760. </xs:documentation>
 										</xs:annotation>
@@ -4465,11 +4465,6 @@
 									<xs:element minOccurs="0" name="MonthsPerYearofOperation" type="MonthsPerYear">
 										<xs:annotation>
 											<xs:documentation>Months per year portable spa is in operation.</xs:documentation>
-										</xs:annotation>
-									</xs:element>
-									<xs:element minOccurs="0" name="FilterType" type="PoolFilterType">
-										<xs:annotation>
-											<xs:documentation>Type of filter used, if any.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>


### PR DESCRIPTION
Related to #229.

Based on feedback from Jennifer Hatfield with PHTA:

- Changes the datatype for `TotalAnnualPowerConsumptionInStandbyMode` to be `RatedAnnualkWh`, which is accurately just a single number. The previous data type selection was an error.
- Removes `FilterType` from `PortableElectricSpa` because they all use cartridge filters, so there is no good reason to ask for something that will likely lead to an erroneous input. 

![HPXMLBaseElements_PortableElectricSpa](https://github.com/hpxmlwg/hpxml/assets/5325034/83007faa-2e86-4bff-a523-59cb6b645f52)

