### PR TITLE
Additional `CeilingFan` elements

### DIFF
--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -2463,6 +2463,26 @@
 								<xs:documentation>Number of similar ceiling fans.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
+						<xs:element minOccurs="0" name="LabelEnergyUse" type="HPXMLDoubleGreaterThanZero">
+							<xs:annotation>
+								<xs:documentation>[W] Energy use per the EnergyGuide label</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="LabelAnnualCost" type="HPXMLDoubleGreaterThanZero">
+							<xs:annotation>
+								<xs:documentation>[$] Estimated yearly energy cost per the EnergyGuide label</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="LabelElectricRate" type="HPXMLDoubleGreaterThanZero">
+							<xs:annotation>
+								<xs:documentation>[$/kWh] Electric rate per the EnergyGuide label</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="LabelUsage" type="HPXMLDoubleGreaterThanZero">
+							<xs:annotation>
+								<xs:documentation>[hrs/day] Hours use per day per the EnergyGuide label</xs:documentation>
+							</xs:annotation>
+						</xs:element>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -2449,6 +2449,26 @@
 								<xs:documentation>Number of similar ceiling fans.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
+						<xs:element minOccurs="0" name="LabelEnergyUse" type="HPXMLDoubleGreaterThanZero">
+							<xs:annotation>
+								<xs:documentation>[W] Energy use per the EnergyGuide label</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="LabelAnnualCost" type="HPXMLDoubleGreaterThanZero">
+							<xs:annotation>
+								<xs:documentation>[$] Estimated yearly energy cost per the EnergyGuide label</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="LabelElectricRate" type="HPXMLDoubleGreaterThanZero">
+							<xs:annotation>
+								<xs:documentation>[$/kWh] Electric rate per the EnergyGuide label</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element minOccurs="0" name="LabelUsage" type="HPXMLDoubleGreaterThanZero">
+							<xs:annotation>
+								<xs:documentation>[hrs/day] Hours use per day per the EnergyGuide label</xs:documentation>
+							</xs:annotation>
+						</xs:element>
 						<xs:element ref="extension" minOccurs="0"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>


### PR DESCRIPTION
Adds four `CeilingFan/LabelFoo` elements for the current EnergyGuide label. Here's an [example](https://hubbellcdn.com/EnergyGuide/PROG_FTC-label-P2501_energyguide.pdf).

![image](https://github.com/hpxmlwg/hpxml/assets/5861765/f994e69f-9bc1-406a-8804-8c529118d099)
