### PR TITLE
Various additional value constraints

### DIFF
--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -3640,7 +3640,7 @@
 							<xs:documentation>[deg F] Temperature below which the compressor is disabled, often to prevent damage or occupant comfort issues. The default is the manufacturer's minimum operating temperature, but the value may be set higher. For a duel-fuel heat pump, use the BackupHeatingSwitchoverTemperature element.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="CoolingSensibleHeatFraction" type="Fraction"/>
+					<xs:element minOccurs="0" name="CoolingSensibleHeatFraction" type="SensibleHeatFraction"/>
 					<xs:element minOccurs="0" name="BackupType" type="HeatPumpBackupType">
 						<xs:annotation>
 							<xs:documentation>Whether the heat pump backup is integrated into the unit (describe in BackupSystemFuel, BackupAnnualHeatingEfficiency, BackupHeatingCapacity), or a
@@ -3722,7 +3722,7 @@
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="AnnualCoolingEfficiency" type="CoolingEfficiencyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element minOccurs="0" name="SensibleHeatFraction" type="Fraction"/>
+					<xs:element minOccurs="0" name="SensibleHeatFraction" type="SensibleHeatFraction"/>
 					<xs:element minOccurs="0" name="CoolingDetailedPerformanceData">
 						<xs:complexType>
 							<xs:sequence>
@@ -3748,7 +3748,7 @@
 			<xs:group ref="SystemInfo"/>
 			<xs:element minOccurs="0" name="LoopType" type="LoopType"/>
 			<xs:element minOccurs="0" name="LoopConfiguration" type="LoopConfiguration"/>
-			<xs:element minOccurs="0" name="LoopFlow" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="LoopFlow" type="HPXMLDoubleGreaterThanZero">
 				<xs:annotation>
 					<xs:documentation>[gpm] Water flow rate through the geothermal loop</xs:documentation>
 				</xs:annotation>
@@ -3757,17 +3757,17 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero"/>
-						<xs:element minOccurs="0" name="Length" type="HPXMLDouble">
+						<xs:element minOccurs="0" name="Length" type="HPXMLDoubleGreaterThanZero">
 							<xs:annotation>
 								<xs:documentation>[ft] Length of each borehole (vertical) or trench (horizontal)</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="Spacing" type="HPXMLDouble">
+						<xs:element minOccurs="0" name="Spacing" type="HPXMLDoubleGreaterThanZero">
 							<xs:annotation>
 								<xs:documentation>[ft] Distance between bores/trenches</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="Diameter" type="HPXMLDouble">
+						<xs:element minOccurs="0" name="Diameter" type="HPXMLDoubleGreaterThanZero">
 							<xs:annotation>
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
@@ -3784,7 +3784,7 @@
 								<xs:documentation/>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="Conductivity" type="HPXMLDouble">
+						<xs:element minOccurs="0" name="Conductivity" type="HPXMLDoubleGreaterThanZero">
 							<xs:annotation>
 								<xs:documentation>[Btu/hr-ft-F]</xs:documentation>
 							</xs:annotation>
@@ -3797,17 +3797,17 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element minOccurs="0" name="Type" type="GroutOrPipeType"/>
-						<xs:element minOccurs="0" name="Conductivity" type="HPXMLDouble">
+						<xs:element minOccurs="0" name="Conductivity" type="HPXMLDoubleGreaterThanZero">
 							<xs:annotation>
 								<xs:documentation>[Btu/hr-ft-F]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="Diameter" type="HPXMLDouble">
+						<xs:element minOccurs="0" name="Diameter" type="HPXMLDoubleGreaterThanZero">
 							<xs:annotation>
 								<xs:documentation>[in]</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element minOccurs="0" name="ShankSpacing" type="HPXMLDouble">
+						<xs:element minOccurs="0" name="ShankSpacing" type="HPXMLDoubleGreaterThanZero">
 							<xs:annotation>
 								<xs:documentation>[in] Measured as center-to-center (not edge-to-edge) distance between two branches of a vertical U-tube</xs:documentation>
 							</xs:annotation>
@@ -4064,7 +4064,7 @@
 											<xs:sequence>
 												<xs:element minOccurs="0" name="SoilType" type="SoilType"/>
 												<xs:element minOccurs="0" name="MoistureType" type="MoisureType"/>
-												<xs:element minOccurs="0" name="Conductivity" type="HPXMLDouble">
+												<xs:element minOccurs="0" name="Conductivity" type="HPXMLDoubleGreaterThanZero">
 													<xs:annotation>
 														<xs:documentation>[Btu/hr-ft-F]</xs:documentation>
 													</xs:annotation>
@@ -4716,7 +4716,7 @@
 								<xs:documentation>For Percent enter values as a fractional number, i.e. 30% = 0.3</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="Value" type="MeasuredDuctLeakage" minOccurs="0"/>
+						<xs:element name="Value" type="HPXMLDoubleGreaterThanZero" minOccurs="0"/>
 						<xs:element minOccurs="0" name="TotalOrToOutside" type="DuctLeakageTotalOrToOutside"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -5340,19 +5340,19 @@
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element minOccurs="0" name="EffectiveLeakageArea" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="EffectiveLeakageArea" type="HPXMLDoubleGreaterThanZero">
 				<xs:annotation>
 					<xs:documentation>[sq.in.] The Effective Leakage Area is defined as the area of a special nozzle-shaped hole (similar to the inlet of a blower door fan) that would leak the same
 						amount of air as the building does at a pressure of 4 Pascals.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="InfiltrationVolume" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="InfiltrationVolume" type="HPXMLDoubleGreaterThanZero">
 				<xs:annotation>
 					<xs:documentation>[sq. ft.] The volume of the building that is applicable to the air infiltration measurement test. The volume can be defined as the conditioned building volume
 						plus the volume of crawlspaces, attics, and/or basements that are connected to the building's conditioned space via open doors or hatches.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element minOccurs="0" name="InfiltrationHeight" type="HPXMLDouble">
+			<xs:element minOccurs="0" name="InfiltrationHeight" type="HPXMLDoubleGreaterThanZero">
 				<xs:annotation>
 					<xs:documentation>[ft] Vertical distance between lowest and highest above-grade points within the pressure boundary, per ASHRAE 62.2.</xs:documentation>
 				</xs:annotation>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -4716,7 +4716,7 @@
 								<xs:documentation>For Percent enter values as a fractional number, i.e. 30% = 0.3</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="Value" type="HPXMLDoubleGreaterThanZero" minOccurs="0"/>
+						<xs:element name="Value" type="MeasuredDuctLeakage" minOccurs="0"/>
 						<xs:element minOccurs="0" name="TotalOrToOutside" type="DuctLeakageTotalOrToOutside"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -2142,16 +2142,6 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="MeasuredDuctLeakage_simple">
-		<xs:restriction base="xs:double"/>
-	</xs:simpleType>
-	<xs:complexType name="MeasuredDuctLeakage">
-		<xs:simpleContent>
-			<xs:extension base="MeasuredDuctLeakage_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 	<!--HVAC System Below-->
 	<xs:simpleType name="AirHandlerStaticPressureMeasurementLocation_simple">
 		<xs:restriction base="xs:string">
@@ -3372,6 +3362,19 @@
 	<xs:complexType name="JobRole">
 		<xs:simpleContent>
 			<xs:extension base="JobRole_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="SensibleHeatFraction_simple">
+		<xs:restriction base="xs:double">
+			<xs:minExclusive value="0.5"/>
+			<xs:maxInclusive value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="SensibleHeatFraction">
+		<xs:simpleContent>
+			<xs:extension base="SensibleHeatFraction_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -2142,6 +2142,18 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+  <xs:simpleType name="MeasuredDuctLeakage_simple">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="MeasuredDuctLeakage">
+		<xs:simpleContent>
+			<xs:extension base="MeasuredDuctLeakage_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<!--HVAC System Below-->
 	<xs:simpleType name="AirHandlerStaticPressureMeasurementLocation_simple">
 		<xs:restriction base="xs:string">


### PR DESCRIPTION
New constraints:
- `AirInfiltrationMeasurement/EffectiveLeakageArea` > 0 (Note: `BuildingAirLeakage` is already > 0)
- `AirInfiltrationMeasurement/InfiltrationVolume` > 0
- `AirInfiltrationMeasurement/InfiltrationHeight` > 0
- `DuctLeakage/Value` >= 0
- `GeothermalLoop/LoopFlow` > 0
- `GeothermalLoop/BoreholesOrTrenches/Length` > 0
- `GeothermalLoop/BoreholesOrTrenches/Spacing` > 0
- `GeothermalLoop/BoreholesOrTrenches/Diameter` > 0
- `GeothermalLoop/Grout/Conductivity` > 0
- `GeothermalLoop/Pipe/Conductivity` > 0
- `GeothermalLoop/Pipe/Diameter` > 0
- `GeothermalLoop/Pipe/ShankSpacing` > 0
- `Soil/Conductivity` > 0
- `CoolingSystem /SensibleHeatFraction` > 0.5
- `HeatPump/CoolingSensibleHeatFraction` > 0.5
