### PR TITLE
Adds a `Slab/ExteriorHorizontalInsulation` element

### DIFF
--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -371,7 +371,7 @@
 							<xs:documentation>[ft] Width from stem wall outward of horizontal insulation</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="InsulationDepthBelowGrade" type="HPXMLDoubleGreaterThanZero"/>
+					<xs:element minOccurs="0" name="InsulationDepthBelowGrade" type="LengthMeasurement"/>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>

--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -278,11 +278,11 @@
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
-	<xs:complexType name="SlabWingInsulationInfo">
+	<xs:complexType name="SlabExteriorHorizontalInsulationInfo">
 		<xs:complexContent>
 			<xs:extension base="InsulationInfoBase">
 				<xs:sequence>
-					<xs:element maxOccurs="unbounded" minOccurs="0" name="Layer" type="SlabWingInsulationLayerInfo"> </xs:element>
+					<xs:element maxOccurs="unbounded" minOccurs="0" name="Layer" type="SlabExteriorHorizontalInsulationLayerInfo"> </xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -362,7 +362,7 @@
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
-	<xs:complexType name="SlabWingInsulationLayerInfo">
+	<xs:complexType name="SlabExteriorHorizontalInsulationLayerInfo">
 		<xs:complexContent>
 			<xs:extension base="InsulationLayerInfoBase">
 				<xs:sequence>
@@ -371,6 +371,7 @@
 							<xs:documentation>[ft] Width from stem wall outward of horizontal insulation</xs:documentation>
 						</xs:annotation>
 					</xs:element>
+					<xs:element minOccurs="0" name="InsulationDepthBelowGrade" type="HPXMLDoubleGreaterThanZero"/>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -1273,14 +1274,14 @@
 											<xs:documentation>Vertical slab perimeter insulation along stem wall</xs:documentation>
 										</xs:annotation>
 									</xs:element>
+									<xs:element minOccurs="0" name="ExteriorHorizontalInsulation" type="SlabExteriorHorizontalInsulationInfo">
+										<xs:annotation>
+											<xs:documentation>Horizontal insulation extending outward from stem wall</xs:documentation>
+										</xs:annotation>
+									</xs:element>
 									<xs:element minOccurs="0" name="UnderSlabInsulation" type="UnderSlabInsulationInfo">
 										<xs:annotation>
 											<xs:documentation>Horizontal insulation under slab</xs:documentation>
-										</xs:annotation>
-									</xs:element>
-									<xs:element minOccurs="0" name="WingInsulation" type="SlabWingInsulationInfo">
-										<xs:annotation>
-											<xs:documentation>Horizontal insulation extending outward from stem wall</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>

--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -278,6 +278,16 @@
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
+	<xs:complexType name="SlabWingInsulationInfo">
+		<xs:complexContent>
+			<xs:extension base="InsulationInfoBase">
+				<xs:sequence>
+					<xs:element maxOccurs="unbounded" minOccurs="0" name="Layer" type="SlabWingInsulationLayerInfo"> </xs:element>
+					<xs:element ref="extension" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
 	<xs:complexType name="InsulationLayerInfoBase">
 		<xs:sequence>
 			<xs:element name="InstallationType" type="InstallationType" minOccurs="0"/>
@@ -345,6 +355,20 @@
 					<xs:element name="InsulationSpansEntireSlab" type="HPXMLBoolean" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation/>
+						</xs:annotation>
+					</xs:element>
+					<xs:element ref="extension" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="SlabWingInsulationLayerInfo">
+		<xs:complexContent>
+			<xs:extension base="InsulationLayerInfoBase">
+				<xs:sequence>
+					<xs:element name="InsulationWidth" type="LengthMeasurement" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>[ft] Width from stem wall outward of horizontal insulation</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
@@ -1244,8 +1268,21 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="FloorCovering" type="FloorCovering"/>
-									<xs:element maxOccurs="1" minOccurs="0" name="PerimeterInsulation" type="SlabPerimeterInsulationInfo"/>
-									<xs:element minOccurs="0" name="UnderSlabInsulation" type="UnderSlabInsulationInfo"/>
+									<xs:element maxOccurs="1" minOccurs="0" name="PerimeterInsulation" type="SlabPerimeterInsulationInfo">
+										<xs:annotation>
+											<xs:documentation>Vertical slab perimeter insulation along stem wall</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="UnderSlabInsulation" type="UnderSlabInsulationInfo">
+										<xs:annotation>
+											<xs:documentation>Horizontal insulation under slab</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="WingInsulation" type="SlabWingInsulationInfo">
+										<xs:annotation>
+											<xs:documentation>Horizontal insulation extending outward from stem wall</xs:documentation>
+										</xs:annotation>
+									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -264,6 +264,16 @@
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
+	<xs:complexType name="SlabWingInsulationInfo">
+		<xs:complexContent>
+			<xs:extension base="InsulationInfoBase">
+				<xs:sequence>
+					<xs:element maxOccurs="unbounded" minOccurs="0" name="Layer" type="SlabWingInsulationLayerInfo"> </xs:element>
+					<xs:element ref="extension" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
 	<xs:complexType name="InsulationLayerInfoBase">
 		<xs:sequence>
 			<xs:element name="InstallationType" type="InstallationType" minOccurs="0"/>
@@ -331,6 +341,20 @@
 					<xs:element name="InsulationSpansEntireSlab" type="HPXMLBoolean" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation/>
+						</xs:annotation>
+					</xs:element>
+					<xs:element ref="extension" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="SlabWingInsulationLayerInfo">
+		<xs:complexContent>
+			<xs:extension base="InsulationLayerInfoBase">
+				<xs:sequence>
+					<xs:element name="InsulationWidth" type="LengthMeasurement" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>[ft] Width from stem wall outward of horizontal insulation</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
@@ -1230,8 +1254,21 @@
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" name="FloorCovering" type="FloorCovering"/>
-									<xs:element maxOccurs="1" minOccurs="0" name="PerimeterInsulation" type="SlabPerimeterInsulationInfo"/>
-									<xs:element minOccurs="0" name="UnderSlabInsulation" type="UnderSlabInsulationInfo"/>
+									<xs:element maxOccurs="1" minOccurs="0" name="PerimeterInsulation" type="SlabPerimeterInsulationInfo">
+										<xs:annotation>
+											<xs:documentation>Vertical slab perimeter insulation along stem wall</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="UnderSlabInsulation" type="UnderSlabInsulationInfo">
+										<xs:annotation>
+											<xs:documentation>Horizontal insulation under slab</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element minOccurs="0" name="WingInsulation" type="SlabWingInsulationInfo">
+										<xs:annotation>
+											<xs:documentation>Horizontal insulation extending outward from stem wall</xs:documentation>
+										</xs:annotation>
+									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>
 								</xs:sequence>
 								<xs:attribute name="dataSource" type="DataSource"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -264,11 +264,11 @@
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
-	<xs:complexType name="SlabWingInsulationInfo">
+	<xs:complexType name="SlabExteriorHorizontalInsulationInfo">
 		<xs:complexContent>
 			<xs:extension base="InsulationInfoBase">
 				<xs:sequence>
-					<xs:element maxOccurs="unbounded" minOccurs="0" name="Layer" type="SlabWingInsulationLayerInfo"> </xs:element>
+					<xs:element maxOccurs="unbounded" minOccurs="0" name="Layer" type="SlabExteriorHorizontalInsulationLayerInfo"> </xs:element>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -348,7 +348,7 @@
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
-	<xs:complexType name="SlabWingInsulationLayerInfo">
+	<xs:complexType name="SlabExteriorHorizontalInsulationLayerInfo">
 		<xs:complexContent>
 			<xs:extension base="InsulationLayerInfoBase">
 				<xs:sequence>
@@ -357,6 +357,7 @@
 							<xs:documentation>[ft] Width from stem wall outward of horizontal insulation</xs:documentation>
 						</xs:annotation>
 					</xs:element>
+					<xs:element minOccurs="0" name="InsulationDepthBelowGrade" type="HPXMLDoubleGreaterThanZero"/>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
@@ -1259,14 +1260,14 @@
 											<xs:documentation>Vertical slab perimeter insulation along stem wall</xs:documentation>
 										</xs:annotation>
 									</xs:element>
+									<xs:element minOccurs="0" name="ExteriorHorizontalInsulation" type="SlabExteriorHorizontalInsulationInfo">
+										<xs:annotation>
+											<xs:documentation>Horizontal insulation extending outward from stem wall</xs:documentation>
+										</xs:annotation>
+									</xs:element>
 									<xs:element minOccurs="0" name="UnderSlabInsulation" type="UnderSlabInsulationInfo">
 										<xs:annotation>
 											<xs:documentation>Horizontal insulation under slab</xs:documentation>
-										</xs:annotation>
-									</xs:element>
-									<xs:element minOccurs="0" name="WingInsulation" type="SlabWingInsulationInfo">
-										<xs:annotation>
-											<xs:documentation>Horizontal insulation extending outward from stem wall</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element minOccurs="0" ref="extension"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -357,7 +357,7 @@
 							<xs:documentation>[ft] Width from stem wall outward of horizontal insulation</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element minOccurs="0" name="InsulationDepthBelowGrade" type="HPXMLDoubleGreaterThanZero"/>
+					<xs:element minOccurs="0" name="InsulationDepthBelowGrade" type="LengthMeasurement"/>
 					<xs:element ref="extension" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>


### PR DESCRIPTION
See [here](https://framebuildingnews.com/below-grade-insulation-part-1/) and [here](https://www.renovation-headquarters.com/foundations-29.html) for examples. Sometimes also referred to as "wing" or "skirt" insulation.

Very similar to the existing `PerimeterInsulation` and `UnderSlabInsulation` elements.

![image](https://github.com/hpxmlwg/hpxml/assets/5861765/2e04769c-7b3b-4c5b-9b0b-c8483401e5ab)
