### PR TITLE
Allow negative Elevation values

### DIFF
--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -5856,7 +5856,7 @@
 						<xs:element maxOccurs="unbounded" minOccurs="0" ref="ExternalResource"/>
 						<xs:element name="Address" type="AddressInformation" minOccurs="0"/>
 						<xs:element minOccurs="0" name="GeoLocation" type="GeoLocationInformation"/>
-						<xs:element minOccurs="0" name="Elevation" type="ElevationType">
+						<xs:element minOccurs="0" name="Elevation" type="HPXMLDouble">
 							<xs:annotation>
 								<xs:documentation>[ft]</xs:documentation>
 							</xs:annotation>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -5053,16 +5053,4 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="ElevationType_simple">
-		<xs:restriction base="xs:double">
-			<xs:minInclusive value="0"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="ElevationType">
-		<xs:simpleContent>
-			<xs:extension base="ElevationType_simple">
-				<xs:attribute name="dataSource" type="DataSource"/>
-			</xs:extension>
-		</xs:simpleContent>
-	</xs:complexType>
 </xs:schema>


### PR DESCRIPTION
Fixes #412. Allows `Elevation` field to be negative for locations that are below sea level. The initial implementation incorrectly only allowed values >= 0.