### PR TITLE
Allow `UnitHeightAboveGrade` to be negative

### DIFF
--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -4217,7 +4217,7 @@
 											<xs:documentation>[ft] height of building</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="UnitHeightAboveGrade" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="UnitHeightAboveGrade" type="HPXMLDouble">
 										<xs:annotation>
 											<xs:documentation>[ft] Height of the unit's lowest conditioned floor above grade. Useful to characterize the height of apartment units above ground level or homes on pier and beam foundations. Can be negative for, e.g., a garden-level apartment unit.</xs:documentation>
 										</xs:annotation>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -4203,7 +4203,7 @@
 											<xs:documentation>[ft] height of building</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="UnitHeightAboveGrade" type="LengthMeasurement">
+									<xs:element minOccurs="0" name="UnitHeightAboveGrade" type="HPXMLDouble">
 										<xs:annotation>
 											<xs:documentation>[ft] Height of the unit's lowest conditioned floor above grade. Useful to characterize the height of apartment units above ground level or homes on pier and beam foundations. Can be negative for, e.g., a garden-level apartment unit.</xs:documentation>
 										</xs:annotation>


### PR DESCRIPTION
Bugfix for https://github.com/hpxmlwg/hpxml/pull/406. The description was previously updated to allow negative values, but I forgot to update the datatype.