### PR TITLE
Allow multiple `FractionChargedLocation` for an EV

### DIFF
--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -2303,9 +2303,9 @@
 													<xs:complexType>
 														<xs:sequence>
 															<xs:element minOccurs="0" name="Battery" type="VehicleBattery"/>
-															<xs:element minOccurs="0" name="FractionChargedLocation">
+															<xs:element minOccurs="0" name="FractionChargedLocation" maxOccurs="unbounded">
 																<xs:annotation>
-																	<xs:documentation>The percentage of charging energy provided at a certain location.</xs:documentation>
+																	<xs:documentation>The percentage of charging energy provided at different locations.</xs:documentation>
 																</xs:annotation>
 																<xs:complexType>
 																	<xs:sequence>
@@ -2328,9 +2328,9 @@
 													<xs:complexType>
 														<xs:sequence>
 															<xs:element minOccurs="0" name="Battery" type="VehicleBattery"/>
-															<xs:element minOccurs="0" name="FractionChargedLocation">
+															<xs:element minOccurs="0" name="FractionChargedLocation" maxOccurs="unbounded">
 																<xs:annotation>
-																	<xs:documentation>The percentage of charging energy provided at a certain location.</xs:documentation>
+																	<xs:documentation>The percentage of charging energy provided at different locations.</xs:documentation>
 																</xs:annotation>
 																<xs:complexType>
 																	<xs:sequence>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -2289,9 +2289,9 @@
 													<xs:complexType>
 														<xs:sequence>
 															<xs:element minOccurs="0" name="Battery" type="VehicleBattery"/>
-															<xs:element minOccurs="0" name="FractionChargedLocation">
+															<xs:element minOccurs="0" name="FractionChargedLocation" maxOccurs="unbounded">
 																<xs:annotation>
-																	<xs:documentation>The percentage of charging energy provided at a certain location.</xs:documentation>
+																	<xs:documentation>The percentage of charging energy provided at different locations.</xs:documentation>
 																</xs:annotation>
 																<xs:complexType>
 																	<xs:sequence>
@@ -2314,9 +2314,9 @@
 													<xs:complexType>
 														<xs:sequence>
 															<xs:element minOccurs="0" name="Battery" type="VehicleBattery"/>
-															<xs:element minOccurs="0" name="FractionChargedLocation">
+															<xs:element minOccurs="0" name="FractionChargedLocation" maxOccurs="unbounded">
 																<xs:annotation>
-																	<xs:documentation>The percentage of charging energy provided at a certain location.</xs:documentation>
+																	<xs:documentation>The percentage of charging energy provided at different locations.</xs:documentation>
 																</xs:annotation>
 																<xs:complexType>
 																	<xs:sequence>


### PR DESCRIPTION
Previously only allowed one location, most likely inadvertently. Now you can specify e.g. home=50%, work=25%, public=25%.