### PR TITLE
Clarify `sameas` attribute

### DIFF
--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -90,7 +90,7 @@
 		</xs:attribute>
 		<xs:attribute name="sameas" type="xs:IDREF">
 			<xs:annotation>
-				<xs:documentation>Use to reference the id of the same object on the base building where the object has not been replaced.</xs:documentation>
+				<xs:documentation>A reference to the id of the identical object on another Building element. For example, this could be used to indicate a building component like a water heater has not changed between the base Building and the post-upgrade Building, or that a building component like a central boiler is shared between two Buildings (dwelling units) in a multifamily building. Note that when a building component does change as part of an upgrade, the sameas attribute should be omitted and a Measure should be used to reference the relationship between components.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:attribute name="dataSource" type="DataSource"/>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -76,7 +76,7 @@
 		</xs:attribute>
 		<xs:attribute name="sameas" type="xs:IDREF">
 			<xs:annotation>
-				<xs:documentation>Use to reference the id of the same object on the base building where the object has not been replaced.</xs:documentation>
+				<xs:documentation>A reference to the id of the identical object on another Building element. For example, this could be used to indicate a building component like a water heater has not changed between the base Building and the post-upgrade Building, or that a building component like a central boiler is shared between two Buildings (dwelling units) in a multifamily building. Note that when a building component does change as part of an upgrade, the sameas attribute should be omitted and a Measure should be used to reference the relationship between components.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:attribute name="dataSource" type="DataSource"/>


### PR DESCRIPTION
Replaces #399.

Updates the documentation for the `sameas` attribute in a couple ways:
1. In an upgrade use case, makes it clear that the `sameas` attribute should only be used *when the building component has not changed*. This is consistent with the HPXML Implementation Guide as described [here](https://hpxml-guide.readthedocs.io/en/latest/software_developer/references.html#sameas) and [here](https://hpxml-guide.readthedocs.io/en/latest/software_developer/usecases/auditupgrade.html#post-upgrade).
2. In an upgrade use case where the building component *has* changed, makes it clear that a `Measure` should be used to link the components instead. (Indeed, this is the only way to handle an AC/furnace -> HP retrofit.)
3. Expands the description to allow the `sameas` attribute to be used for e.g. shared HVAC systems or walls, in which the building component can be referenced from multiple MF dwelling unit `Buildings`.

Proposed description: "A reference to the id of the identical object on another Building element. For example, this could be used to indicate a building component like a water heater has not changed between the base Building and the post-upgrade Building, or that a building component like a central boiler is shared between two Buildings (dwelling units) in a multifamily building. Note that when a building component does change as part of an upgrade, the sameas attribute should be omitted and a Measure should be used to reference the relationship between components."

Note: Some existing software tools are misusing the `sameas` attribute to link e.g. a post-upgrade insulated wall with a pre-upgrade uninsulated wall.

