### PR TITLE
Add none/other/unknown choices for building components

### DIFF
--- a/schemas/HPXML.xsd
+++ b/schemas/HPXML.xsd
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    xmlns="http://hpxmlonline.com/2023/09" targetNamespace="http://hpxmlonline.com/2023/09" elementFormDefault="qualified" version="4.1">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://hpxmlonline.com/2023/09" targetNamespace="http://hpxmlonline.com/2023/09" elementFormDefault="qualified" version="4.1">
     <xs:include schemaLocation="HPXMLBaseElements.xsd"/>
     <xs:element name="HPXML">
         <xs:complexType>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -556,6 +556,7 @@
 		<xs:complexContent>
 			<xs:extension base="ApplianceTypeSummaryInfo">
 				<xs:sequence>
+					<xs:element minOccurs="0" name="Type" type="FreezerType"/>
 					<xs:element minOccurs="0" name="Location" type="RefrigeratorLocation"/>
 					<xs:element name="RatedAnnualkWh" type="RatedAnnualkWh" minOccurs="0"/>
 					<xs:element name="Configuration" type="FreezerStyle" minOccurs="0"/>
@@ -661,6 +662,7 @@
 		<xs:complexContent>
 			<xs:extension base="ApplianceTypeSummaryInfo">
 				<xs:sequence>
+					<xs:element minOccurs="0" name="Type" type="CookingRangeType"/>
 					<xs:element minOccurs="0" name="Location" type="RefrigeratorLocation"/>
 					<xs:element name="FuelType" type="FuelType" minOccurs="0"/>
 					<xs:element minOccurs="0" name="IsInduction" type="HPXMLBoolean"/>
@@ -673,6 +675,7 @@
 		<xs:complexContent>
 			<xs:extension base="ApplianceTypeSummaryInfo">
 				<xs:sequence>
+					<xs:element minOccurs="0" name="Type" type="OvenType"/>
 					<xs:element minOccurs="0" name="Location" type="RefrigeratorLocation"/>
 					<xs:element name="FuelType" type="FuelType" minOccurs="0"/>
 					<xs:element minOccurs="0" name="IsConvection" type="HPXMLBoolean"/>
@@ -1322,7 +1325,7 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="WindowInfo"/>
-									<xs:element minOccurs="0" name="SolarTube" type="HPXMLBoolean"/>
+									<xs:element name="SkylightType" minOccurs="0" type="SkylightType"/>
 									<xs:element minOccurs="0" name="Pitch" type="Pitch">
 										<xs:annotation>
 											<xs:documentation>Pitch of skylight ?/12</xs:documentation>
@@ -2097,6 +2100,7 @@
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
 									<xs:element minOccurs="0" ref="ConnectedDevice"/>
+									<xs:element minOccurs="0" name="SystemType" type="PVSystemType"/>
 									<xs:element minOccurs="0" name="IsSharedSystem" type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>Does the system serve multiple building/dwelling units?</xs:documentation>
@@ -2424,6 +2428,7 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
+									<xs:element minOccurs="0" name="Type" type="EVChargerType"/>
 									<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanOrEqualToZero"/>
 									<xs:element minOccurs="0" name="Manufacturer" type="Manufacturer"/>
 									<xs:element maxOccurs="1" minOccurs="0" name="ModelNumber" type="Model"/>
@@ -2469,6 +2474,7 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
+									<xs:element minOccurs="0" name="Type" type="WindTurbineType"/>
 									<xs:element minOccurs="0" name="Model" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="YearInstalled" type="Year"/>
 									<xs:element minOccurs="0" name="ThirdPartyCertification" maxOccurs="unbounded" type="WindThirdPartyCertification"/>
@@ -2636,6 +2642,7 @@
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
 						<xs:element minOccurs="0" ref="ConnectedDevice"/>
+						<xs:element minOccurs="0" name="Type" type="CeilingFanType"/>
 						<xs:element maxOccurs="3" minOccurs="0" name="Airflow">
 							<xs:annotation>
 								<xs:documentation/>
@@ -3846,6 +3853,8 @@
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
 			</xs:element>
+			<xs:element name="Unknown"/>
+			<xs:element name="None"/>
 		</xs:choice>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
@@ -4674,6 +4683,7 @@
 							<xs:complexType>
 								<xs:sequence>
 									<xs:group ref="SystemInfo"/>
+									<xs:element minOccurs="0" name="Type" type="PortableElectricSpaType"/>
 									<xs:element minOccurs="0" name="Manufacturer" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="Model" type="HPXMLString"/>
 									<xs:element minOccurs="0" name="Capacity" type="IntegerGreaterThanZero">
@@ -5418,6 +5428,7 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
+						<xs:element minOccurs="0" name="Type" type="WindowFilmType"/>
 						<xs:element minOccurs="0" name="ShadingCoefficient" type="Fraction">
 							<xs:annotation>
 								<xs:documentation>Shading coefficients are defined as a multiplier on transmittance: 1 is transparent, 0 is opaque. </xs:documentation>
@@ -5509,6 +5520,7 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
+						<xs:element minOccurs="0" name="Type" type="ScreenType"/>
 						<xs:element minOccurs="0" name="Location" type="StormLocation"/>
 						<xs:element minOccurs="0" name="ScreenMaterial" type="ScreenMaterial"/>
 						<xs:element minOccurs="0" name="SummerFractionCovered" type="Fraction">
@@ -5543,6 +5555,7 @@
 				<xs:complexType>
 					<xs:sequence>
 						<xs:group ref="SystemInfo"/>
+						<xs:element name="Type" minOccurs="0" type="StormType"/>
 						<xs:element minOccurs="0" name="GlazingMaterial" type="GlazingMaterial"/>
 						<xs:element minOccurs="0" name="GlassType" type="GlassType"/>
 						<xs:element minOccurs="0" name="FrameType" type="WindowFrameType"/>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -1280,6 +1280,9 @@
 			<xs:enumeration value="interior"/>
 			<xs:enumeration value="exterior"/>
 			<xs:enumeration value="storm"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="DoorType">
@@ -1651,11 +1654,31 @@
 			<xs:enumeration value="door glazing"/>
 			<xs:enumeration value="sliding glass door"/>
 			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="WindowType">
 		<xs:simpleContent>
 			<xs:extension base="WindowType_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="SkylightType_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="fixed"/>
+			<xs:enumeration value="venting"/>
+			<xs:enumeration value="tubular"/>
+			<xs:enumeration value="dome"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="SkylightType">
+		<xs:simpleContent>
+			<xs:extension base="SkylightType_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -1715,6 +1738,7 @@
 			<xs:enumeration value="medium curtains"/>
 			<xs:enumeration value="dark curtains"/>
 			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
 			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
@@ -1735,12 +1759,30 @@
 			<xs:enumeration value="evergreen tree"/>
 			<xs:enumeration value="building"/>
 			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
 			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="ExteriorShading">
 		<xs:simpleContent>
 			<xs:extension base="ExteriorShading_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="WindowFilmType_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="solar control"/>
+			<xs:enumeration value="privacy"/>
+			<xs:enumeration value="decorative"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="WindowFilmType">
+		<xs:simpleContent>
+			<xs:extension base="WindowFilmType_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -1829,6 +1871,8 @@
 			<xs:enumeration value="cooling tower"/>
 			<xs:enumeration value="packaged terminal air conditioner"/>
 			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="CoolingSystemType">
@@ -1934,6 +1978,8 @@
 			<xs:enumeration value="closed"/>
 			<xs:enumeration value="direct expansion"/>
 			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="LoopType">
@@ -1984,6 +2030,9 @@
 			<xs:enumeration value="variable refrigerant flow"/>
 			<xs:enumeration value="packaged terminal heat pump"/>
 			<xs:enumeration value="room air conditioner with reverse cycle"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="HeatPumpType">
@@ -2457,6 +2506,9 @@
 			<xs:enumeration value="counter-top"/>
 			<xs:enumeration value="single tank"/>
 			<xs:enumeration value="conveyor"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="DishwasherType">
@@ -3019,6 +3071,9 @@
 			<xs:enumeration value="front loader"/>
 			<xs:enumeration value="all-in-one combination washer/dryer"/>
 			<xs:enumeration value="unitized/stacked washer-dryer pair"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="ClothesWasherType">
@@ -3033,6 +3088,9 @@
 			<xs:enumeration value="dryer"/>
 			<xs:enumeration value="all-in-one combination washer/dryer"/>
 			<xs:enumeration value="unitized/stacked washer-dryer pair"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="ClothesDryerType">
@@ -3089,6 +3147,38 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+	<xs:simpleType name="WindTurbineType_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="horizontal axis"/>
+			<xs:enumeration value="vertical axis"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="WindTurbineType">
+		<xs:simpleContent>
+			<xs:extension base="WindTurbineType_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="FreezerType_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="upright"/>
+			<xs:enumeration value="chest"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="FreezerType">
+		<xs:simpleContent>
+			<xs:extension base="FreezerType_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="FreezerStyle_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="uncategorized"/>
@@ -3118,7 +3208,9 @@
 			<xs:enumeration value="walk-in"/>
 			<xs:enumeration value="open case"/>
 			<xs:enumeration value="closed case"/>
-			<xs:enumeration value="uncategorized"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="RefrigeratorStyle">
@@ -3169,6 +3261,9 @@
 			<xs:enumeration value="split heat pump water heater"/>
 			<xs:enumeration value="space-heating boiler with storage tank"/>
 			<xs:enumeration value="space-heating boiler with tankless coil"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="WaterHeaterType">
@@ -3184,6 +3279,9 @@
 			<xs:enumeration value="hot water and space heating"/>
 			<xs:enumeration value="space heating"/>
 			<xs:enumeration value="hybrid system"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="SolarThermalSystemType">
@@ -3689,6 +3787,22 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+	<xs:simpleType name="PVSystemType_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="grid tied"/>
+			<xs:enumeration value="off-grid"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="PVSystemType">
+		<xs:simpleContent>
+			<xs:extension base="PVSystemType_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="PVSystemLocation_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="roof"/>
@@ -3719,6 +3833,22 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+	<xs:simpleType name="EVChargerType_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="hardwired"/>
+			<xs:enumeration value="plug-in"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="EVChargerType">
+		<xs:simpleContent>
+			<xs:extension base="EVChargerType_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="EVChargingLevel_simple">
 		<xs:restriction base="xs:integer">
 			<xs:minInclusive value="1"/>
@@ -3738,6 +3868,8 @@
 			<xs:enumeration value="CHAdeMO"/>
 			<xs:enumeration value="Tesla"/>
 			<xs:enumeration value="Combined Charging System"/>
+			<xs:enumeration value="NEMA 14-50"/>
+			<xs:enumeration value="NEMA 6-50"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="EVChargingConnector">
@@ -4018,6 +4150,9 @@
 			<xs:enumeration value="energy recovery ventilator"/>
 			<xs:enumeration value="balanced"/>
 			<xs:enumeration value="central fan integrated supply"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="VentilationFanType">
@@ -4618,6 +4753,8 @@
 			<xs:enumeration value="Ni-Cd"/>
 			<xs:enumeration value="salt water"/>
 			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="BatteryType">
@@ -4932,15 +5069,85 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+	<xs:simpleType name="CookingRangeType_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="freestanding"/>
+			<xs:enumeration value="slide-in"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="CookingRangeType">
+		<xs:simpleContent>
+			<xs:extension base="CookingRangeType_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="OvenType_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="range oven"/>
+			<xs:enumeration value="wall oven"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="OvenType">
+		<xs:simpleContent>
+			<xs:extension base="OvenType_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="DehumidifierType_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="portable"/>
 			<xs:enumeration value="whole-home"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="DehumidifierType">
 		<xs:simpleContent>
 			<xs:extension base="DehumidifierType_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="CeilingFanType_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="standard"/>
+			<xs:enumeration value="low-profile"/>
+			<xs:enumeration value="dual motor"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="CeilingFanType">
+		<xs:simpleContent>
+			<xs:extension base="CeilingFanType_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="PortableElectricSpaType_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="standard spa"/>
+			<xs:enumeration value="exercise spa"/>
+			<xs:enumeration value="combination spa"/>
+			<xs:enumeration value="inflatable spa"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="PortableElectricSpaType">
+		<xs:simpleContent>
+			<xs:extension base="PortableElectricSpaType_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -4967,6 +5174,23 @@
 	<xs:complexType name="DayOfMonth">
 		<xs:simpleContent>
 			<xs:extension base="DayOfMonth_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="StormType_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="fixed"/>
+			<xs:enumeration value="two track"/>
+			<xs:enumeration value="three track"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="StormType">
+		<xs:simpleContent>
+			<xs:extension base="StormType_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -5145,6 +5369,8 @@
 			<xs:enumeration value="multi-string inverter"/>
 			<xs:enumeration value="micro inverter"/>
 			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="InverterType">
@@ -5327,6 +5553,23 @@
 	<xs:complexType name="ServiceFeederLoadType">
 		<xs:simpleContent>
 			<xs:extension base="ServiceFeederLoadType_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ScreenType_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="fixed"/>
+			<xs:enumeration value="retractable"/>
+			<xs:enumeration value="swinging"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="ScreenType">
+		<xs:simpleContent>
+			<xs:extension base="ScreenType_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>


### PR DESCRIPTION
Closes #450. Allows specifying that a building component doesn't exist (or is unknown).

For building components with existing `Type` elements, added new choice values for:
- `Window/WindowType`: "unknown", "none"
- `Window/InteriorShading/Type`: "unknown"
- `Window/ExteriorShading/Type`: "unknown"
- `Door/DoorType`: "other", "unknown", "none"
- `HeatingSystem/HeatingSystemType`: `Unknown`, `None` (**note**: these are elements, not enumerations)
- `CoolingSystem/CoolingSystemType`: "unknown", "none"
- `HeatPump/HeatPumpType`: "other", "unknown", "none"
- `GeothermalLoop/LoopType`: "unknown", "none"
- `WaterHeatingSystem/WaterHeaterType`: "other", "unknown", "none"
- `SolarThermalSystem/SystemType`: "other", "unknown", "none"
- `VentilationFan/FanType`: "other", "unknown", "none"
- `Dishwasher/Type`: "other", "unknown", "none"
- `ClothesWasher/Type`: "other", "unknown", "none"
- `ClothesDryer/Type`: "other", "unknown", "none"
- `Refrigerator/Type`: "other", "unknown", "none" (**breaking change**: replaces "uncategorized")
- `Dehumidifier/Type`: "other", "unknown", "none"
- `Battery/BatteryType`: "unknown", "none"
- `Inverter/InverterType`: "unknown", "none"

For building components without existing `Type` elements, added new elements to accommodate this information:
- `Freezer/Type`: "upright", "chest", "other", "unknown", "none"
- `CookingRange/Type`: "freestanding", "slide-in", "other", "unknown", "none"
- `Oven/Type`: "range oven", "wall oven", "other", "unknown", "none"
- `Window/WindowFilm/Type`: "solar control", "privacy", "decorative", "other", "unknown", "none"
- `Window/InsectScreen/Type`: "fixed", "retractable", "swinging", "other", "unknown", "none"
- `Window/StormWindow/Type`: "fixed", "two track", "three track", "other", "unknown", "none"
- `Skylight/Type`: "fixed", "venting", "tubular", "dome", "other", "unknown", "none" (**breaking change**: replaces `SolarTube`)
- `PVSystem/SystemType`: "grid tied", "off-grid", "other", "unknown", "none"
- `ElectricVehicleCharger/Type`: "hardwired", "plug-in", "other", "unknown", "none"
- `WindTurbine/Type`: "horizontal axis", "vertical axis", "other", "unknown", "none"
- `CeilingFan/Type`: "standard", "low-profile", "dual motor", "other", "unknown", "none"
- `PortableElectricSpa/Type`: "standard spa", "exercise spa", "combination spa", "inflatable spa", "other", "unknown", "none"

Also sneaks in a couple more `EVChargingConnector` choices: "NEMA 14-50" and "NEMA 6-50"