### PR TITLE
`WaterFixture/Location` element

### DIFF
--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -2073,6 +2073,7 @@
 										<xs:element name="AttachedToHotWaterDistribution" type="LocalReference"/>
 									</xs:choice>
 									<xs:element minOccurs="1" name="WaterFixtureType" type="WaterFixtureType"/>
+									<xs:element minOccurs="0" name="Location" type="WaterFixtureLocation"/>
 									<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Number of similar water fixtures.</xs:documentation>
@@ -11609,6 +11610,24 @@
 	<xs:complexType name="WaterFixtureType">
 		<xs:simpleContent>
 			<xs:extension base="WaterFixtureType_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="WaterFixtureLocation_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="bathroom"/>
+			<xs:enumeration value="kitchen"/>
+			<xs:enumeration value="garage"/>
+			<xs:enumeration value="basement"/>
+			<xs:enumeration value="laundry room"/>
+			<xs:enumeration value="outside"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="WaterFixtureLocation">
+		<xs:simpleContent>
+			<xs:extension base="WaterFixtureLocation_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -2059,6 +2059,7 @@
 										<xs:element name="AttachedToHotWaterDistribution" type="LocalReference"/>
 									</xs:choice>
 									<xs:element minOccurs="1" name="WaterFixtureType" type="WaterFixtureType"/>
+									<xs:element minOccurs="0" name="Location" type="WaterFixtureLocation"/>
 									<xs:element minOccurs="0" name="Count" type="IntegerGreaterThanZero">
 										<xs:annotation>
 											<xs:documentation>Number of similar water fixtures.</xs:documentation>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -4549,6 +4549,24 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
+	<xs:simpleType name="WaterFixtureLocation_simple">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="bathroom"/>
+			<xs:enumeration value="kitchen"/>
+			<xs:enumeration value="garage"/>
+			<xs:enumeration value="basement"/>
+			<xs:enumeration value="laundry room"/>
+			<xs:enumeration value="outside"/>
+			<xs:enumeration value="other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="WaterFixtureLocation">
+		<xs:simpleContent>
+			<xs:extension base="WaterFixtureLocation_simple">
+				<xs:attribute name="dataSource" type="DataSource"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:simpleType name="WaterFixtureThirdPartyCertification_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Energy Star"/>


### PR DESCRIPTION
Closes #443. Allows differentiating, for example, a bathroom faucet from a kitchen faucet.

Choices are:
- bathroom
- kitchen
- garage
- basement
- laundry room
- outside
- other

<img width="323" height="297" alt="image" src="https://github.com/user-attachments/assets/e5030066-9b71-4413-9171-491d2d69f39c" />
