### PR TITLE
Fix HPWH enumerations

### DIFF
--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -12497,11 +12497,11 @@
 	</xs:complexType>
 	<xs:simpleType name="HPWHOperatingModeType_simple">
 		<xs:restriction base="xs:string">
-			<xs:pattern value="hybrid/auto"/>
-			<xs:pattern value="heat pump only"/>
-			<xs:pattern value="electric heater only"/>
-			<xs:pattern value="high demand/recovery"/>
-			<xs:pattern value="other"/>
+			<xs:enumeration value="hybrid/auto"/>
+			<xs:enumeration value="heat pump only"/>
+			<xs:enumeration value="electric heater only"/>
+			<xs:enumeration value="high demand/recovery"/>
+			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="HPWHOperatingMode">
@@ -12513,11 +12513,11 @@
 	</xs:complexType>
 	<xs:simpleType name="HPWHVoltage_simple">
 		<xs:restriction base="xs:string">
-			<xs:pattern value="240V"/>
-			<xs:pattern value="120V"/>
-			<xs:pattern value="120V dedicated circuit"/>
-			<xs:pattern value="120V shared circuit"/>
-			<xs:pattern value="other"/>
+			<xs:enumeration value="240V"/>
+			<xs:enumeration value="120V"/>
+			<xs:enumeration value="120V dedicated circuit"/>
+			<xs:enumeration value="120V shared circuit"/>
+			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="HPWHVoltage">

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -5433,11 +5433,11 @@
 	</xs:complexType>
 	<xs:simpleType name="HPWHOperatingModeType_simple">
 		<xs:restriction base="xs:string">
-			<xs:pattern value="hybrid/auto"/>
-			<xs:pattern value="heat pump only"/>
-			<xs:pattern value="electric heater only"/>
-			<xs:pattern value="high demand/recovery"/>
-			<xs:pattern value="other"/>
+			<xs:enumeration value="hybrid/auto"/>
+			<xs:enumeration value="heat pump only"/>
+			<xs:enumeration value="electric heater only"/>
+			<xs:enumeration value="high demand/recovery"/>
+			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="HPWHOperatingMode">
@@ -5449,11 +5449,11 @@
 	</xs:complexType>
 	<xs:simpleType name="HPWHVoltage_simple">
 		<xs:restriction base="xs:string">
-			<xs:pattern value="240V"/>
-			<xs:pattern value="120V"/>
-			<xs:pattern value="120V dedicated circuit"/>
-			<xs:pattern value="120V shared circuit"/>
-			<xs:pattern value="other"/>
+			<xs:enumeration value="240V"/>
+			<xs:enumeration value="120V"/>
+			<xs:enumeration value="120V dedicated circuit"/>
+			<xs:enumeration value="120V shared circuit"/>
+			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="HPWHVoltage">


### PR DESCRIPTION
Enumerations for two HPWH elements were accidentally specified as regular expression patterns.