### PR TITLE
Require units/value with parent element

### DIFF
--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -2517,8 +2517,8 @@
 									<xs:element minOccurs="0" name="FuelEconomyCombined">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="Units" type="FuelEconomyUnits"/>
-												<xs:element minOccurs="0" name="Value" type="HPXMLDoubleGreaterThanZero"/>
+												<xs:element minOccurs="1" name="Units" type="FuelEconomyUnits"/>
+												<xs:element minOccurs="1" name="Value" type="HPXMLDoubleGreaterThanZero"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -2526,8 +2526,8 @@
 									<xs:element minOccurs="0" name="FuelEconomyCity">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="Units" type="FuelEconomyUnits"/>
-												<xs:element minOccurs="0" name="Value" type="HPXMLDoubleGreaterThanZero"/>
+												<xs:element minOccurs="1" name="Units" type="FuelEconomyUnits"/>
+												<xs:element minOccurs="1" name="Value" type="HPXMLDoubleGreaterThanZero"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -2535,8 +2535,8 @@
 									<xs:element minOccurs="0" name="FuelEconomyHighway">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="Units" type="FuelEconomyUnits"/>
-												<xs:element minOccurs="0" name="Value" type="HPXMLDoubleGreaterThanZero"/>
+												<xs:element minOccurs="1" name="Units" type="FuelEconomyUnits"/>
+												<xs:element minOccurs="1" name="Value" type="HPXMLDoubleGreaterThanZero"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -5264,12 +5264,12 @@
 			<xs:element minOccurs="0" name="DuctLeakage">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="Units" type="DuctLeakageTestUnitofMeasure" minOccurs="0">
+						<xs:element name="Units" type="DuctLeakageTestUnitofMeasure" minOccurs="1">
 							<xs:annotation>
 								<xs:documentation>For Percent enter values as a fractional number, i.e. 30% = 0.3</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="Value" type="MeasuredDuctLeakage" minOccurs="0"/>
+						<xs:element name="Value" type="MeasuredDuctLeakage" minOccurs="1"/>
 						<xs:element minOccurs="0" name="TotalOrToOutside" type="DuctLeakageTotalOrToOutside"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -6006,8 +6006,8 @@
 			<xs:element minOccurs="0" name="BuildingAirLeakage">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="UnitofMeasure" type="BuildingAirLeakageUnit" minOccurs="0"/>
-						<xs:element name="AirLeakage" type="BuildingAirLeakage" minOccurs="0"/>
+						<xs:element name="UnitofMeasure" type="BuildingAirLeakageUnit" minOccurs="1"/>
+						<xs:element name="AirLeakage" type="BuildingAirLeakage" minOccurs="1"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -6798,8 +6798,8 @@
 	</xs:complexType>
 	<xs:complexType name="VentilationType">
 		<xs:sequence>
-			<xs:element name="UnitofMeasure" type="VentilationUnit" minOccurs="0"/>
-			<xs:element name="Value" type="BuildingAirLeakage" minOccurs="0"/>
+			<xs:element name="UnitofMeasure" type="VentilationUnit" minOccurs="1"/>
+			<xs:element name="Value" type="BuildingAirLeakage" minOccurs="1"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -2503,8 +2503,8 @@
 									<xs:element minOccurs="0" name="FuelEconomyCombined">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="Units" type="FuelEconomyUnits"/>
-												<xs:element minOccurs="0" name="Value" type="HPXMLDoubleGreaterThanZero"/>
+												<xs:element minOccurs="1" name="Units" type="FuelEconomyUnits"/>
+												<xs:element minOccurs="1" name="Value" type="HPXMLDoubleGreaterThanZero"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -2512,8 +2512,8 @@
 									<xs:element minOccurs="0" name="FuelEconomyCity">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="Units" type="FuelEconomyUnits"/>
-												<xs:element minOccurs="0" name="Value" type="HPXMLDoubleGreaterThanZero"/>
+												<xs:element minOccurs="1" name="Units" type="FuelEconomyUnits"/>
+												<xs:element minOccurs="1" name="Value" type="HPXMLDoubleGreaterThanZero"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -2521,8 +2521,8 @@
 									<xs:element minOccurs="0" name="FuelEconomyHighway">
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element minOccurs="0" name="Units" type="FuelEconomyUnits"/>
-												<xs:element minOccurs="0" name="Value" type="HPXMLDoubleGreaterThanZero"/>
+												<xs:element minOccurs="1" name="Units" type="FuelEconomyUnits"/>
+												<xs:element minOccurs="1" name="Value" type="HPXMLDoubleGreaterThanZero"/>
 											</xs:sequence>
 											<xs:attribute name="dataSource" type="DataSource"/>
 										</xs:complexType>
@@ -5250,12 +5250,12 @@
 			<xs:element minOccurs="0" name="DuctLeakage">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="Units" type="DuctLeakageTestUnitofMeasure" minOccurs="0">
+						<xs:element name="Units" type="DuctLeakageTestUnitofMeasure" minOccurs="1">
 							<xs:annotation>
 								<xs:documentation>For Percent enter values as a fractional number, i.e. 30% = 0.3</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="Value" type="MeasuredDuctLeakage" minOccurs="0"/>
+						<xs:element name="Value" type="MeasuredDuctLeakage" minOccurs="1"/>
 						<xs:element minOccurs="0" name="TotalOrToOutside" type="DuctLeakageTotalOrToOutside"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
@@ -5992,8 +5992,8 @@
 			<xs:element minOccurs="0" name="BuildingAirLeakage">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="UnitofMeasure" type="BuildingAirLeakageUnit" minOccurs="0"/>
-						<xs:element name="AirLeakage" type="BuildingAirLeakage" minOccurs="0"/>
+						<xs:element name="UnitofMeasure" type="BuildingAirLeakageUnit" minOccurs="1"/>
+						<xs:element name="AirLeakage" type="BuildingAirLeakage" minOccurs="1"/>
 					</xs:sequence>
 					<xs:attribute name="dataSource" type="DataSource"/>
 				</xs:complexType>
@@ -6784,8 +6784,8 @@
 	</xs:complexType>
 	<xs:complexType name="VentilationType">
 		<xs:sequence>
-			<xs:element name="UnitofMeasure" type="VentilationUnit" minOccurs="0"/>
-			<xs:element name="Value" type="BuildingAirLeakage" minOccurs="0"/>
+			<xs:element name="UnitofMeasure" type="VentilationUnit" minOccurs="1"/>
+			<xs:element name="Value" type="BuildingAirLeakage" minOccurs="1"/>
 		</xs:sequence>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>


### PR DESCRIPTION
Require units/value elements when the parent element is specified. We already do this many places (e.g., `AnnualCoolingEfficiency/Units`, `AnnualHeatingEfficiency/Units`, `Load/Units`, etc.), but not everywhere.

Affects:
- `AirInfiltrationMeasurement/BuildingAirLeakage`
- `DuctLeakageMeasurement/DuctLeakage`
- `Attic/VentilationRate`
- `Foundation/VentilationRate`
- `Vehicle/FuelEconomyCombined`
- `Vehicle/FuelEconomyCity`
- `Vehicle/FuelEconomyHighway`

This is technically a breaking change, but probably wouldn't affect any end users?