### PR TITLE
Add new `RoofType` element

### DIFF
--- a/examples/audit.xml
+++ b/examples/audit.xml
@@ -116,7 +116,7 @@
         <Roofs>
           <Roof>
             <SystemIdentifier id="roof1"/>
-            <RoofType>shingles</RoofType>
+            <RoofMaterial>shingles</RoofMaterial>
             <Insulation>
               <SystemIdentifier id="attic2ins"/>
               <Layer>
@@ -373,7 +373,7 @@
         <Roofs>
           <Roof>
             <SystemIdentifier id="roof1p" sameas="roof1"/>
-            <RoofType>shingles</RoofType>
+            <RoofMaterial>shingles</RoofMaterial>
             <Insulation>
               <SystemIdentifier id="attic2insp" sameas="attic2ins"/>
               <Layer>

--- a/examples/bpi2101.xml
+++ b/examples/bpi2101.xml
@@ -60,7 +60,7 @@
         <Roofs>
           <Roof>
             <SystemIdentifier id="roof1"/>
-            <RoofType>shingles</RoofType>
+            <RoofMaterial>shingles</RoofMaterial>
             <RadiantBarrier>false</RadiantBarrier>
             <Insulation>
               <SystemIdentifier id="attic1roofins"/>
@@ -250,7 +250,7 @@
         <Roofs>
           <Roof>
             <SystemIdentifier id="roof1proposed" sameas="roof1"/>
-            <RoofType>shingles</RoofType>
+            <RoofMaterial>shingles</RoofMaterial>
             <RadiantBarrier>false</RadiantBarrier>
             <Insulation>
               <SystemIdentifier id="attic1roofinsproposed" sameas="attic1roofins"/>
@@ -449,7 +449,7 @@
         <Roofs>
           <Roof>
             <SystemIdentifier id="roof1completion" sameas="roof1"/>
-            <RoofType>shingles</RoofType>
+            <RoofMaterial>shingles</RoofMaterial>
             <RadiantBarrier>false</RadiantBarrier>
             <Insulation>
               <SystemIdentifier id="attic1roofinscompletion" sameas="attic1roofins"/>

--- a/examples/invalid.xml
+++ b/examples/invalid.xml
@@ -116,7 +116,7 @@
         <Roofs>
           <Roof>
             <SystemIdentifier id="roof1"/>
-            <RoofType>shingles</RoofType>
+            <RoofMaterial>shingles</RoofMaterial>
             <Insulation>
               <SystemIdentifier id="attic2ins"/>
               <Layer>
@@ -373,7 +373,7 @@
         <Roofs>
           <Roof>
             <SystemIdentifier id="roof1p" sameas="roof1"/>
-            <RoofType>shingles</RoofType>
+            <RoofMaterial>shingles</RoofMaterial>
             <Insulation>
               <SystemIdentifier id="attic2insp" sameas="attic2ins"/>
               <Layer>

--- a/examples/upgrade.xml
+++ b/examples/upgrade.xml
@@ -111,7 +111,7 @@
         <Roofs>
           <Roof>
             <SystemIdentifier id="roof1"/>
-            <RoofType>shingles</RoofType>
+            <RoofMaterial>shingles</RoofMaterial>
             <Insulation>
               <SystemIdentifier id="insul2"/>
               <Layer>
@@ -352,7 +352,7 @@
         <Roofs>
           <Roof>
             <SystemIdentifier id="roof1c"/>
-            <RoofType>shingles</RoofType>
+            <RoofMaterial>shingles</RoofMaterial>
             <Insulation>
               <SystemIdentifier id="insul2c" sameas="insul2"/>
               <MisalignedInsulation>false</MisalignedInsulation>

--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -1034,7 +1034,8 @@
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RoofType" type="RoofType"/>
+									<xs:element minOccurs="0" name="RoofType" type="FloorOrRoofType"/>
+									<xs:element minOccurs="0" name="RoofMaterial" type="RoofMaterial"/>
 									<xs:element minOccurs="0" name="CoolRoof" type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>A cool roof has a material or coating that lowers the roof surface temperature, by having a low solar absorptance and/or high thermal emittance. Products may be designated by an efficiency program or similar.</xs:documentation>
@@ -1253,7 +1254,7 @@
 											<xs:documentation>From the perspective of the living/conditioned space.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FloorType" type="FloorType"/>
+									<xs:element minOccurs="0" name="FloorType" type="FloorOrRoofType"/>
 									<xs:element minOccurs="0" name="FloorJoists" type="StudProperties"/>
 									<xs:element minOccurs="0" name="FloorTrusses" type="StudProperties"/>
 									<xs:element minOccurs="0" name="FloorCovering" type="FloorCovering">
@@ -6288,7 +6289,7 @@
 		</xs:choice>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
-	<xs:complexType name="FloorType">
+	<xs:complexType name="FloorOrRoofType">
 		<xs:choice>
 			<xs:element name="WoodFrame">
 				<xs:complexType>
@@ -10717,7 +10718,7 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="RoofType_simple">
+	<xs:simpleType name="RoofMaterial_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="shingles"/>
 			<xs:enumeration value="slate or tile shingles"/>
@@ -10726,15 +10727,15 @@
 			<xs:enumeration value="metal surfacing"/>
 			<xs:enumeration value="expanded polystyrene sheathing"/>
 			<xs:enumeration value="plastic/rubber/synthetic sheeting"/>
-			<xs:enumeration value="concrete"/>
+			<xs:enumeration value="concrete tiles"/>
 			<xs:enumeration value="green roof"/>
 			<xs:enumeration value="no one major type"/>
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:complexType name="RoofType">
+	<xs:complexType name="RoofMaterial">
 		<xs:simpleContent>
-			<xs:extension base="RoofType_simple">
+			<xs:extension base="RoofMaterial_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -1020,7 +1020,8 @@
 											<xs:documentation>[deg]</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="RoofType" type="RoofType"/>
+									<xs:element minOccurs="0" name="RoofType" type="FloorOrRoofType"/>
+									<xs:element minOccurs="0" name="RoofMaterial" type="RoofMaterial"/>
 									<xs:element minOccurs="0" name="CoolRoof" type="HPXMLBoolean">
 										<xs:annotation>
 											<xs:documentation>A cool roof has a material or coating that lowers the roof surface temperature, by having a low solar absorptance and/or high thermal emittance. Products may be designated by an efficiency program or similar.</xs:documentation>
@@ -1239,7 +1240,7 @@
 											<xs:documentation>From the perspective of the living/conditioned space.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element minOccurs="0" name="FloorType" type="FloorType"/>
+									<xs:element minOccurs="0" name="FloorType" type="FloorOrRoofType"/>
 									<xs:element minOccurs="0" name="FloorJoists" type="StudProperties"/>
 									<xs:element minOccurs="0" name="FloorTrusses" type="StudProperties"/>
 									<xs:element minOccurs="0" name="FloorCovering" type="FloorCovering">
@@ -6274,7 +6275,7 @@
 		</xs:choice>
 		<xs:attribute name="dataSource" type="DataSource"/>
 	</xs:complexType>
-	<xs:complexType name="FloorType">
+	<xs:complexType name="FloorOrRoofType">
 		<xs:choice>
 			<xs:element name="WoodFrame">
 				<xs:complexType>

--- a/schemas/HPXMLDataTypes.xsd
+++ b/schemas/HPXMLDataTypes.xsd
@@ -3647,7 +3647,7 @@
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
-	<xs:simpleType name="RoofType_simple">
+	<xs:simpleType name="RoofMaterial_simple">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="shingles"/>
 			<xs:enumeration value="slate or tile shingles"/>
@@ -3656,15 +3656,15 @@
 			<xs:enumeration value="metal surfacing"/>
 			<xs:enumeration value="expanded polystyrene sheathing"/>
 			<xs:enumeration value="plastic/rubber/synthetic sheeting"/>
-			<xs:enumeration value="concrete"/>
+			<xs:enumeration value="concrete tiles"/>
 			<xs:enumeration value="green roof"/>
 			<xs:enumeration value="no one major type"/>
 			<xs:enumeration value="other"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:complexType name="RoofType">
+	<xs:complexType name="RoofMaterial">
 		<xs:simpleContent>
-			<xs:extension base="RoofType_simple">
+			<xs:extension base="RoofMaterial_simple">
 				<xs:attribute name="dataSource" type="DataSource"/>
 			</xs:extension>
 		</xs:simpleContent>


### PR DESCRIPTION
Closes #476.
1. Adds a new `RoofType` element with the same child elements as used for [FloorType](https://hpxml.nlr.gov/datadictionary/4.2.0/Building/BuildingDetails/Enclosure/Floors/Floor/FloorType).
2. Renames existing `RoofType` element to `RoofMaterial`. Renames "concrete" choice to "concrete tiles".

<img width="466" height="423" alt="image" src="https://github.com/user-attachments/assets/288dab4c-04ce-4d00-96bd-b113ecc0b20b" />
