### PR TITLE
Allow zero bathrooms

### DIFF
--- a/merged_schema/HPXMLMerged.xsd
+++ b/merged_schema/HPXMLMerged.xsd
@@ -4682,8 +4682,8 @@
 									</xs:element>
 									<xs:element minOccurs="0" name="NumberofRooms" type="IntegerGreaterThanZero"/>
 									<xs:element name="NumberofBedrooms" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
-									<xs:element name="NumberofBathrooms" type="IntegerGreaterThanZero" minOccurs="0"/>
-									<xs:element minOccurs="0" name="NumberofCompleteBathrooms" type="IntegerGreaterThanZero">
+									<xs:element name="NumberofBathrooms" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+									<xs:element minOccurs="0" name="NumberofCompleteBathrooms" type="IntegerGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>Number of bathrooms with a tub or shower</xs:documentation>
 										</xs:annotation>

--- a/schemas/HPXMLBaseElements.xsd
+++ b/schemas/HPXMLBaseElements.xsd
@@ -4668,8 +4668,8 @@
 									</xs:element>
 									<xs:element minOccurs="0" name="NumberofRooms" type="IntegerGreaterThanZero"/>
 									<xs:element name="NumberofBedrooms" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
-									<xs:element name="NumberofBathrooms" type="IntegerGreaterThanZero" minOccurs="0"/>
-									<xs:element minOccurs="0" name="NumberofCompleteBathrooms" type="IntegerGreaterThanZero">
+									<xs:element name="NumberofBathrooms" type="IntegerGreaterThanOrEqualToZero" minOccurs="0"/>
+									<xs:element minOccurs="0" name="NumberofCompleteBathrooms" type="IntegerGreaterThanOrEqualToZero">
 										<xs:annotation>
 											<xs:documentation>Number of bathrooms with a tub or shower</xs:documentation>
 										</xs:annotation>


### PR DESCRIPTION
Allow zero for `NumberofBathrooms` and `NumberofCompleteBathrooms`. Currently they need to be an integer greater than zero.

Here are some examples of (old) homes without bathrooms:
- https://www.facebook.com/groups/1706748102970911/posts/4680287338950291/
- https://www.reddit.com/r/FirstTimeHomeBuyer/comments/1enj0lj/house_without_bathroom/
- https://www.facebook.com/groups/1706748102970911/posts/3660771020901933/